### PR TITLE
8240539: Upgrade gradle to version 6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1767,7 +1767,10 @@ allprojects {
         repositories {
             ivy {
                 url JFX_DEPS_URL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact]-[revision](-[classifier]).[ext]"
                     artifact "[artifact].[ext]"
                 }
@@ -1780,7 +1783,10 @@ allprojects {
             mavenCentral()
             ivy {
                 url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -1791,13 +1797,19 @@ allprojects {
         repositories {
             ivy {
                 url libAVRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
             ivy {
                 url FFmpegRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -4334,6 +4334,7 @@ allprojects {
         project.jar.enabled = false
 
         // and redirect the resources into the module
+        project.sourceSets.main.output.resourcesDir = project.moduleDir
         project.processResources.destinationDir = project.moduleDir
     }
 
@@ -4367,6 +4368,7 @@ allprojects {
         project.sourceSets.shims.resources.srcDirs += project.sourceSets.main.resources.srcDirs
 
         // and redirect the resources into the module
+        project.sourceSets.shims.output.resourcesDir = project.moduleShimsDir
         project.processShimsResources.destinationDir = project.moduleShimsDir
 
        compileTestJava.dependsOn(copyGeneratedShimsTask)

--- a/build.properties
+++ b/build.properties
@@ -85,7 +85,7 @@ jfx.build.jdk.buildnum.min=46
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
 jfx.gradle.version=5.3
-jfx.gradle.version.min=4.8
+jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.2.0-OL6.4+1.0

--- a/build.properties
+++ b/build.properties
@@ -84,7 +84,7 @@ jfx.build.jdk.buildnum.min=46
 # gradle/legal/gradle.md.
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
-jfx.gradle.version=6.0
+jfx.gradle.version=6.3
 jfx.gradle.version.min=5.3
 
 # Toolchains

--- a/build.properties
+++ b/build.properties
@@ -84,7 +84,7 @@ jfx.build.jdk.buildnum.min=46
 # gradle/legal/gradle.md.
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
-jfx.gradle.version=5.3
+jfx.gradle.version=6.0
 jfx.gradle.version.min=5.3
 
 # Toolchains

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,10 @@ repositories {
     if (buildClosed) {
         ivy {
             url jfxRepositoryURL
-            layout "pattern", {
+            metadataSources {
+                artifact()
+            }
+            patternLayout {
                 artifact "[artifact]-[revision].[ext]"
                 artifact "[artifact].[ext]"
             }

--- a/gradle/legal/gradle.md
+++ b/gradle/legal/gradle.md
@@ -1,4 +1,4 @@
-## Gradle v5.3
+## Gradle v6.0
 
 ### Apache 2.0 License
 <pre>

--- a/gradle/legal/gradle.md
+++ b/gradle/legal/gradle.md
@@ -1,4 +1,4 @@
-## Gradle v6.0
+## Gradle v6.3
 
 ### Apache 2.0 License
 <pre>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,10 +37,6 @@ project(":web").projectDir = file("modules/javafx.web")
 project(":media").projectDir = file("modules/javafx.media")
 project(":systemTests").projectDir = file("tests/system")
 
-// Stable publishing behavior is the default in gradle 5.x.
-// This setting enables it in gradle 4.8 to help with the transition.
-enableFeaturePreview('STABLE_PUBLISHING')
-
 def closedDir = file("../rt-closed")
 def buildClosed = closedDir.isDirectory()
 


### PR DESCRIPTION
jfx11u uses gradle 5.3 for build, it needs to be upgraded to gradle 6.3 same as jfx mainline.
This PR backports three fixes:

1. [JDK-8240539](https://bugs.openjdk.java.net/browse/JDK-8240539): Upgrade gradle to version 6.3
2. [JDK-8232063](https://bugs.openjdk.java.net/browse/JDK-8232063): Upgrade gradle to version 6.0 and
3. [JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754): FX build fails using gradle 5.6+ or 6

All the changes backport cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8240539](https://bugs.openjdk.java.net/browse/JDK-8240539): Upgrade gradle to version 6.3
 * [JDK-8232063](https://bugs.openjdk.java.net/browse/JDK-8232063): Upgrade gradle to version 6.0
 * [JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754): FX build fails using gradle 5.6+ or 6


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/7.diff">https://git.openjdk.java.net/jfx11u/pull/7.diff</a>

</details>
