### PR TITLE
8239589: JavaFX UI will not repaint after reconnecting via Remote Desktop

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/EffectUtil.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/EffectUtil.java
@@ -128,7 +128,7 @@ class EffectUtil {
     static void renderRectInnerShadow(Graphics g, InnerShadow shadow, float alpha,
                                       float rx, float ry, float rw, float rh)
     {
-        if (itex == null) {
+        if (itex == null || itex.isSurfaceLost()) {
             byte[] sdata = new byte[TEX_SIZE * TEX_SIZE];
             fillGaussian(sdata, TEX_SIZE, TEX_SIZE/2, shadow.getChoke(), true);
             Image img = Image.fromByteAlphaData(sdata, TEX_SIZE, TEX_SIZE);
@@ -242,7 +242,7 @@ class EffectUtil {
     static void renderRectDropShadow(Graphics g, DropShadow shadow, float alpha,
                                      float rx, float ry, float rw, float rh)
     {
-        if (dtex == null) {
+        if (dtex == null || dtex.isSurfaceLost()) {
             byte[] sdata = new byte[TEX_SIZE * TEX_SIZE];
             fillGaussian(sdata, TEX_SIZE, TEX_SIZE / 2, shadow.getSpread(), false);
             //fillTestPattern(sdata, imgsize);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGExternalNode.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGExternalNode.java
@@ -107,7 +107,7 @@ public class NGExternalNode extends NGNode {
 
     private Texture createTexture(Graphics g, RenderData rd) {
         ResourceFactory factory = g.getResourceFactory();
-        if (!factory.isDeviceReady()) {
+        if (factory.isDisposed()) {
             return null;
         }
         Texture txt = factory.createTexture(PixelFormat.INT_ARGB_PRE,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
@@ -55,11 +55,30 @@ public class NGPhongMaterial {
     private TextureMap selfIllumMap = new TextureMap(PhongMaterial.MapType.SELF_ILLUM);
 
     Material createMaterial(ResourceFactory f) {
+
+        // Check whether the material is valid; dispose and recreate if needed
+        if (material != null && !material.isValid()) {
+            disposeMaterial();
+        }
+
         if (material == null) {
             material = f.createPhongMaterial();
         }
         validate(f);
         return material;
+    }
+
+    private void disposeMaterial() {
+        diffuseColorDirty = true;
+        specularColorDirty = true;
+        specularPowerDirty = true;
+        diffuseMap.setDirty(true);
+        specularMap.setDirty(true);
+        bumpMap.setDirty(true);
+        selfIllumMap.setDirty(true);
+
+        material.dispose();
+        material = null;
     }
 
     private void validate(ResourceFactory f) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
@@ -75,6 +75,15 @@ public abstract class NGShape3D extends NGNode {
         g.setup3DRendering();
 
         ResourceFactory rf = g.getResourceFactory();
+        if (rf == null || rf.isDisposed()) {
+            return;
+        }
+
+        // Check whether the meshView is valid; dispose and recreate if needed
+        if (meshView != null && !meshView.isValid()) {
+            meshView.dispose();
+            meshView = null;
+        }
 
         if (meshView == null && mesh != null) {
             meshView = rf.createMeshView(mesh.createMesh(rf));

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGTriangleMesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGTriangleMesh.java
@@ -59,6 +59,13 @@ public class NGTriangleMesh {
     private int[] faceSmoothingGroupsFromAndLengthIndices = new int[2];
 
     Mesh createMesh(ResourceFactory rf) {
+
+        // Check whether the mesh is valid; dispose and recreate if needed
+        if (mesh != null && !mesh.isValid()) {
+            mesh.dispose();
+            mesh = null;
+        }
+
         if (mesh == null) {
             mesh = rf.createMesh();
             meshDirty = true;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
@@ -70,6 +70,7 @@ final class PresentingPainter extends ViewPainter {
             }
             if (factory == null || !factory.isDeviceReady()) {
                 sceneState.getScene().entireSceneNeedsRepaint();
+                factory = null;
                 return;
             }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1359,8 +1359,17 @@ public final class QuantumToolkit extends Toolkit {
         public double getHeight() { return image.getHeight(); }
         @Override
         public void factoryReset() { dispose(); }
+
         @Override
-        public void factoryReleased() { dispose(); }
+        public void factoryReleased() {
+            dispose();
+
+            // ResourceFactory is being disposed; clear reference to avoid leak
+            if (rf != null) {
+                rf.removeFactoryListener(this);
+                rf = null;
+            }
+        }
     }
 
     @Override public ImageLoader loadPlatformImage(Object platformImage) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/UploadingPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/UploadingPainter.java
@@ -90,6 +90,7 @@ final class UploadingPainter extends ViewPainter implements Runnable {
                 factory = GraphicsPipeline.getDefaultResourceFactory();
             }
             if (factory == null || !factory.isDeviceReady()) {
+                factory = null;
                 return;
             }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/Material.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/Material.java
@@ -30,5 +30,6 @@ package com.sun.prism;
  * This class represents base material for retained mode rendering
  */
 
-public interface Material {
+public interface Material extends GraphicsResource {
+    public boolean isValid();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/Mesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/Mesh.java
@@ -40,4 +40,6 @@ public interface Mesh extends GraphicsResource {
             int faceSmoothingGroups[], int[] faceSmoothingGroupsFromAndLengthIndices);
 
     public int getCount();
+
+    public boolean isValid();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/ResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/ResourceFactory.java
@@ -32,15 +32,29 @@ import com.sun.prism.shape.ShapeRep;
 public interface ResourceFactory extends GraphicsResource {
 
     /**
-     * Returns status of this graphics device.
+     * Returns whether this resource factory has been disposed.
+     * If this resource factory has been disposed, it is no longer valid and
+     * will need to be recreated before any new resources can be created.
+     * Any attempt to create a resource will be ignored and will return null.
+     *
+     * @return true if this resource factory has been disposed.
+     */
+    public boolean isDisposed();
+
+    /**
+     * Returns status of this graphics device, possibly reinitializing it.
      * If the device is not ready the createRTTexture and
      * present operations will fail.
-     * Creation of shaders and regular textures will succeed and
-     * return valid resources.
+     * As long as the device has not been disposed, creation of shaders and
+     * regular textures will succeed and return valid resources.
      * All hardware resources (RenderTargets and SwapChains) have to be recreated
      * after a device-lost event notification.
-     **/
-
+     *
+     * NOTE: since this method can reinitialize the graphics device if it has
+     * been released, it should only be called at the start of a rendering pass.
+     *
+     * @return true if this graphics device is ready for use.
+     */
     public boolean isDeviceReady();
 
     public TextureResourcePool getTextureResourcePool();
@@ -251,8 +265,6 @@ public interface ResourceFactory extends GraphicsResource {
     public void setGlyphTexture(Texture texture);
     public Texture getGlyphTexture();
     public boolean isSuperShaderAllowed();
-
-    public void dispose();
 
     /*
      * 3D stuff

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -45,6 +45,7 @@ import com.sun.prism.ps.Shader;
 
 class D3DContext extends BaseShaderContext {
 
+    public static final int D3DERR_DEVICEREMOVED    = 0x88760870;
     public static final int D3DERR_DEVICENOTRESET   = 0x88760869;
     public static final int D3DERR_DEVICELOST       = 0x88760868;
     public static final int E_FAIL                  = 0x80004005;
@@ -129,8 +130,8 @@ class D3DContext extends BaseShaderContext {
      */
     static void validate(int res) {
         if (PrismSettings.verbose && FAILED(res)) {
-            System.out.println("D3D hresult failed :" + hResultToString(res));
-            new Exception("Stack trace").printStackTrace(System.out);
+            System.err.println("D3D hresult failed :" + hResultToString(res));
+            new Exception("Stack trace").printStackTrace(System.err);
         }
     }
 
@@ -144,9 +145,38 @@ class D3DContext extends BaseShaderContext {
     /**
      * Validates the device, sets the context lost
      * status if necessary, and tries to restore the context if needed.
+     * If the device has been removed, then it reinitializes the device, which
+     * disposes the existing factories and contexts.
      */
     boolean testLostStateAndReset() {
+        if (isDisposed()) {
+            return false;
+        }
+
         int hr = D3DResourceFactory.nTestCooperativeLevel(pContext);
+
+        if (PrismSettings.verbose && FAILED(hr)) {
+            System.err.print("D3DContext::testLostStateAndReset : ");
+            switch (hr) {
+                case D3D_OK:
+                    System.err.println("D3D_OK");
+                    break;
+                case D3DERR_DEVICELOST:
+                    System.err.println("D3DERR_DEVICELOST");
+                    break;
+                case D3DERR_DEVICEREMOVED:
+                    System.err.println("D3DERR_DEVICEREMOVED");
+                    break;
+                case D3DERR_DEVICENOTRESET:
+                    System.err.println("D3DERR_DEVICENOTRESET");
+                    break;
+                case E_FAIL:
+                    System.err.println("E_FAIL");
+                    break;
+                default:
+                    System.err.println(String.format("Unknown D3D error 0x%x", hr));
+            }
+        }
 
         if (hr == D3DERR_DEVICELOST) {
             setLost();
@@ -169,6 +199,14 @@ class D3DContext extends BaseShaderContext {
             }
         }
 
+        if (hr == D3DERR_DEVICEREMOVED) {
+            setLost();
+
+            // Reinitialize the D3DPipeline. This will dispose and recreate
+            // the resource factory and context for each adapter.
+            D3DPipeline.getInstance().reinitialize();
+        }
+
         return !FAILED(hr);
     }
 
@@ -184,6 +222,14 @@ class D3DContext extends BaseShaderContext {
         }
 
         return !FAILED(res);
+    }
+
+    @Override
+    public void dispose() {
+        disposeLCDBuffer();
+        state = null;
+
+        super.dispose();
     }
 
     /**
@@ -203,6 +249,8 @@ class D3DContext extends BaseShaderContext {
     @Override
     protected State updateRenderTarget(RenderTarget target, NGCamera camera,
                                        boolean depthTest)  {
+        if (checkDisposed()) return null;
+
         long resourceHandle = ((D3DRenderTarget)target).getResourceHandle();
         int res = nSetRenderTarget(pContext, resourceHandle, depthTest, target.isMSAA());
         validate(res);
@@ -445,6 +493,8 @@ class D3DContext extends BaseShaderContext {
     private static native boolean nIsRTTVolatile(long contextHandle);
 
     public boolean isRTTVolatile() {
+        if (checkDisposed()) return false;
+
         return nIsRTTVolatile(pContext);
     }
 
@@ -456,6 +506,8 @@ class D3DContext extends BaseShaderContext {
                 return "D3DERR_DEVICELOST";
             case (int)D3DERR_OUTOFVIDEOMEMORY:
                 return "D3DERR_OUTOFVIDEOMEMORY";
+            case (int)D3DERR_DEVICEREMOVED:
+                return "D3DERR_DEVICEREMOVED";
             case (int)D3D_OK:
                 return "D3D_OK";
             default:
@@ -465,15 +517,21 @@ class D3DContext extends BaseShaderContext {
 
     @Override
     public void setDeviceParametersFor2D() {
+        if (checkDisposed()) return;
+
         nSetDeviceParametersFor2D(pContext);
     }
 
     @Override
     protected void setDeviceParametersFor3D() {
+        if (checkDisposed()) return;
+
         nSetDeviceParametersFor3D(pContext);
     }
 
     long createD3DMesh() {
+        if (checkDisposed()) return 0;
+
         return nCreateD3DMesh(pContext);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMesh.java
@@ -54,6 +54,11 @@ class D3DMesh extends BaseMesh {
     }
 
     @Override
+    public boolean isValid() {
+        return !context.isDisposed();
+    }
+
+    @Override
     public void dispose() {
         disposerRecord.dispose();
         count--;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
@@ -36,6 +36,7 @@ import com.sun.prism.impl.Disposer;
 class D3DMeshView extends BaseMeshView {
 
     static int count = 0;
+
     private final D3DContext context;
     private final long nativeHandle;
 
@@ -93,6 +94,11 @@ class D3DMeshView extends BaseMeshView {
         material.lockTextureMaps();
         context.renderMeshView(nativeHandle, g);
         material.unlockTextureMaps();
+    }
+
+    @Override
+    public boolean isValid() {
+        return !context.isDisposed();
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
@@ -29,14 +29,14 @@ import com.sun.prism.Image;
 import com.sun.prism.PhongMaterial;
 import com.sun.prism.Texture;
 import com.sun.prism.TextureMap;
-import com.sun.prism.impl.BaseGraphicsResource;
+import com.sun.prism.impl.BasePhongMaterial;
 import com.sun.prism.impl.Disposer;
 import com.sun.javafx.logging.PlatformLogger;
 
 /**
  * TODO: 3D - Need documentation
  */
-class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
+class D3DPhongMaterial extends BasePhongMaterial implements PhongMaterial {
 
     static int count = 0;
 
@@ -113,6 +113,11 @@ class D3DPhongMaterial extends BaseGraphicsResource implements PhongMaterial {
                 texture.unlock();
             }
         }
+    }
+
+    @Override
+    public boolean isValid() {
+        return !context.isDisposed();
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -39,6 +39,11 @@ public final class D3DPipeline extends GraphicsPipeline {
 
     private static final boolean d3dEnabled;
 
+    private static final Thread creator;
+    private static D3DPipeline theInstance;
+    private static D3DResourceFactory factories[];
+    private static boolean d3dInitialized;
+
     static {
 
         d3dEnabled = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
@@ -49,7 +54,7 @@ public final class D3DPipeline extends GraphicsPipeline {
             if (PrismSettings.verbose) {
                 System.out.println("\tsucceeded.");
             }
-            return Boolean.valueOf(nInit(PrismSettings.class));
+            return Boolean.valueOf(nInit(PrismSettings.class, true));
         });
 
         if (PrismSettings.verbose) {
@@ -67,14 +72,11 @@ public final class D3DPipeline extends GraphicsPipeline {
         creator = Thread.currentThread();
 
         if (d3dEnabled) {
+            d3dInitialized = true;
             theInstance = new D3DPipeline();
             factories = new D3DResourceFactory[nGetAdapterCount()];
         }
     }
-
-    private static Thread creator;
-    private static D3DPipeline theInstance;
-    private static D3DResourceFactory factories[];
 
     public static D3DPipeline getInstance() {
         return theInstance;
@@ -138,9 +140,9 @@ public final class D3DPipeline extends GraphicsPipeline {
         return d3dEnabled;
     }
 
-    private static native boolean nInit(Class psClass);
+    private static native boolean nInit(Class psClass, boolean load);
     private static native String nGetErrorMessage();
-    private static native void nDispose();
+    private static native void nDispose(boolean unload);
 
     private static native int nGetAdapterOrdinal(long hMonitor);
     private static native int nGetAdapterCount();
@@ -153,18 +155,53 @@ public final class D3DPipeline extends GraphicsPipeline {
 
     private static native int nGetMaxSampleSupport(int adapterOrdinal);
 
-    @Override
-    public void dispose() {
+    // Called by dispose and reinitialize methods to reset the pipeline
+    // and free all resources
+    private void reset(boolean unload) {
+        if (!d3dInitialized) {
+            return;
+        }
+
         if (creator != Thread.currentThread()) {
             throw new IllegalStateException(
                     "This operation is not permitted on the current thread ["
                     + Thread.currentThread().getName() + "]");
         }
-        notifyAllResourcesReleased();
-        nDispose();
-        for (int i=0; i!=factories.length; ++i) {
+        for (int i = 0; i != factories.length; ++i) {
+            if (factories[i] != null) {
+                factories[i].dispose();
+            }
             factories[i] = null;
         }
+        factories = null;
+        _default = null;
+        d3dInitialized = false;
+        nDispose(unload);
+    }
+
+    // Reinitialize pipeline
+    void reinitialize() {
+        if (PrismSettings.verbose) {
+            System.err.println("D3DPipeline: reinitialize after device was removed");
+        }
+
+        // Device was removed, reset and reinitialize
+        reset(false);
+
+        boolean success = nInit(PrismSettings.class, false);
+        if (!success) {
+            nDispose(false);
+            return;
+        }
+
+        d3dInitialized = true;
+        factories = new D3DResourceFactory[nGetAdapterCount()];
+    }
+
+    @Override
+    public void dispose() {
+        reset(true);
+        theInstance = null;
         super.dispose();
     }
 
@@ -180,12 +217,6 @@ public final class D3DPipeline extends GraphicsPipeline {
             factories[adapterOrdinal] = factory;
         }
         return factory;
-    }
-
-    private static void notifyAllResourcesReleased() {
-        for (D3DResourceFactory rf : factories) {
-            if (rf != null) rf.notifyReleased();
-        }
     }
 
     /*
@@ -206,6 +237,17 @@ public final class D3DPipeline extends GraphicsPipeline {
     }
 
     private static D3DResourceFactory findDefaultResourceFactory(List<Screen> screens) {
+        if (!d3dInitialized) {
+            // If initialization failed, try again
+            D3DPipeline.getInstance().reinitialize();
+
+            // If reinitialization failed, return a null resource factory; we will
+            // try again the next time this method is called.
+            if (!d3dInitialized) {
+                return null;
+            }
+        }
+
         for (int adapter = 0, n = nGetAdapterCount(); adapter != n; ++adapter) {
             D3DResourceFactory rf =
                     getD3DResourceFactory(adapter, getScreenForAdapter(screens, adapter));

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
@@ -91,7 +91,11 @@ class D3DRTTexture extends D3DTexture
     }
 
     public boolean readPixels(Buffer pixels) {
-        getContext().flushVertexBuffer();
+        final D3DContext context = getContext();
+        if (context.isDisposed()) {
+            return false;
+        }
+        context.flushVertexBuffer();
         long ctx = getContext().getContextHandle();
         int res = D3DContext.D3D_OK;
         if (pixels instanceof ByteBuffer) {
@@ -113,7 +117,7 @@ class D3DRTTexture extends D3DTexture
             throw new IllegalArgumentException("Buffer of this type is " +
                                                "not supported: "+pixels);
         }
-        return getContext().validatePresent(res);
+        return context.validatePresent(res);
     }
 
     public Screen getAssociatedScreen() {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -112,6 +112,9 @@ class D3DResourceFactory extends BaseShaderFactory {
 
     @Override
     public boolean isDeviceReady() {
+        if (isDisposed()) {
+            return false;
+        }
         displayPrismStatistics();
         return context.testLostStateAndReset();
     }
@@ -141,6 +144,9 @@ class D3DResourceFactory extends BaseShaderFactory {
     @Override
     public D3DTexture createTexture(PixelFormat format, Usage usagehint,
             WrapMode wrapMode, int w, int h, boolean useMipmap) {
+
+        if (checkDisposed()) return null;
+
         if (!isFormatSupported(format)) {
             throw new UnsupportedOperationException(
                 "Pixel format " + format +
@@ -181,6 +187,8 @@ class D3DResourceFactory extends BaseShaderFactory {
 
     @Override
     public Texture createTexture(MediaFrame frame) {
+        if (checkDisposed()) return null;
+
         frame.holdFrame();
 
         int width = frame.getWidth();
@@ -272,6 +280,8 @@ class D3DResourceFactory extends BaseShaderFactory {
 
     @Override
     public D3DRTTexture createRTTexture(int width, int height, WrapMode wrapMode, boolean msaa) {
+        if (checkDisposed()) return null;
+
         if (PrismSettings.verbose && context.isLost()) {
             System.err.println("RT Texture allocation while the device is lost");
         }
@@ -318,6 +328,8 @@ class D3DResourceFactory extends BaseShaderFactory {
     }
 
     public Presentable createPresentable(PresentableState pState) {
+        if (checkDisposed()) return null;
+
         if (PrismSettings.verbose && context.isLost()) {
             System.err.println("SwapChain allocation while the device is lost");
         }
@@ -386,6 +398,8 @@ class D3DResourceFactory extends BaseShaderFactory {
                                boolean isPixcoordUsed,
                                boolean isPerVertexColorUsed)
     {
+        if (checkDisposed()) return null;
+
         long shaderHandle = D3DShader.init(
                 context.getContextHandle(), getBuffer(pixelShaderCode),
                 maxTexCoordIndex, isPixcoordUsed, isPerVertexColorUsed);
@@ -410,11 +424,6 @@ class D3DResourceFactory extends BaseShaderFactory {
             e.printStackTrace();
             throw new InternalError("Error loading stock shader " + name);
         }
-    }
-
-    @Override
-    public void dispose() {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
@@ -453,13 +462,16 @@ class D3DResourceFactory extends BaseShaderFactory {
     }
 
     @Override
-    protected void notifyReleased() {
+    public void dispose() {
+        context.dispose();
+
         for (ListIterator<D3DRecord> it = records.listIterator(); it.hasNext();) {
             D3DRecord r = it.next();
             r.markDisposed();
         }
         records.clear();
-        super.notifyReleased();
+
+        super.dispose();
     }
 
     void addRecord(D3DRecord record) {
@@ -471,15 +483,18 @@ class D3DResourceFactory extends BaseShaderFactory {
     }
 
     public PhongMaterial createPhongMaterial() {
+        if (checkDisposed()) return null;
         return D3DPhongMaterial.create(context);
     }
 
     public MeshView createMeshView(Mesh mesh) {
+        if (checkDisposed()) return null;
         return D3DMeshView.create(context, (D3DMesh) mesh);
 
     }
 
     public Mesh createMesh() {
+        if (checkDisposed()) return null;
         return D3DMesh.create(context);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -80,6 +80,9 @@ class D3DSwapChain
 
     public boolean present() {
         D3DContext context = getContext();
+        if (context.isDisposed()) {
+            return false;
+        }
         int res = nPresent(context.getContextHandle(), d3dResRecord.getResource());
         return context.validatePresent(res);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongMaterial.java
@@ -30,7 +30,7 @@ import com.sun.prism.Image;
 import com.sun.prism.PhongMaterial;
 import com.sun.prism.Texture;
 import com.sun.prism.TextureMap;
-import com.sun.prism.impl.BaseGraphicsResource;
+import com.sun.prism.impl.BasePhongMaterial;
 import com.sun.prism.impl.Disposer;
 import com.sun.prism.paint.Color;
 import com.sun.javafx.logging.PlatformLogger;
@@ -38,7 +38,7 @@ import com.sun.javafx.logging.PlatformLogger;
 /**
  * TODO: 3D - Need documentation
  */
-class ES2PhongMaterial extends BaseGraphicsResource implements PhongMaterial {
+class ES2PhongMaterial extends BasePhongMaterial implements PhongMaterial {
 
     static int count = 0;
     private final ES2Context context;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseContext.java
@@ -54,6 +54,8 @@ public abstract class BaseContext {
     private final ResourceFactory factory;
     private final VertexBuffer vertexBuffer;
 
+    private boolean disposed = false;
+
     private static final int MIN_MASK_DIM = 1024;
     private Texture maskTex;
     private ByteBuffer maskBuffer;
@@ -73,7 +75,6 @@ public abstract class BaseContext {
 
     private final GeneralTransform3D perspectiveTransform = new GeneralTransform3D();
 
-    // TODO: need to dispose these when the context is disposed... (RT-27421)
     private final Map<FontStrike, GlyphCache>
         greyGlyphCaches = new HashMap<FontStrike, GlyphCache>();
     private final Map<FontStrike, GlyphCache>
@@ -101,6 +102,8 @@ public abstract class BaseContext {
     }
 
     public void flushVertexBuffer() {
+        if (checkDisposed()) return;
+
         vertexBuffer.flush();
     }
 
@@ -199,6 +202,9 @@ public abstract class BaseContext {
 
     private GlyphCache getGlyphCache(FontStrike strike,
                                      Map<FontStrike, GlyphCache> glyphCaches) {
+
+        if (checkDisposed()) return null;
+
         GlyphCache glyphCache = glyphCaches.get(strike);
         if (glyphCache == null) {
             glyphCache = new GlyphCache(this, strike);
@@ -208,6 +214,8 @@ public abstract class BaseContext {
     }
 
     public Texture validateMaskTexture(MaskData maskData, boolean canScale) {
+        if (checkDisposed()) return null;
+
         int pad = canScale ? 1 : 0;
         int needW = maskData.getWidth() + pad + pad;
         int needH = maskData.getHeight() + pad + pad;
@@ -252,6 +260,8 @@ public abstract class BaseContext {
     }
 
     public void updateMaskTexture(MaskData maskData, RectBounds maskBounds, boolean canScale) {
+        if (checkDisposed()) return;
+
         // assert maskTex bound as texture 1...
         maskTex.assertLocked();
         int maskW = maskData.getWidth();
@@ -303,6 +313,8 @@ public abstract class BaseContext {
     }
 
     public int getRectTextureMaxSize() {
+        if (checkDisposed()) return 0;
+
         if (rectTex == null) {
             createRectTexture();
         }
@@ -310,6 +322,8 @@ public abstract class BaseContext {
     }
 
     public Texture getRectTexture() {
+        if (checkDisposed()) return null;
+
         if (rectTex == null) {
             createRectTexture();
         }
@@ -323,6 +337,8 @@ public abstract class BaseContext {
     }
 
     private void createRectTexture() {
+        if (checkDisposed()) return;
+
         int texMax = PrismSettings.primTextureSize;
         if (texMax < 0) texMax = getResourceFactory().getMaximumTextureSize();
         int texDim = 3;
@@ -367,6 +383,8 @@ public abstract class BaseContext {
     }
 
     public Texture getWrapRectTexture() {
+        if (checkDisposed()) return null;
+
         if (wrapRectTex == null) {
             Texture tex =
                 getResourceFactory().createMaskTexture(2, 2, WrapMode.CLAMP_TO_EDGE);
@@ -406,6 +424,8 @@ public abstract class BaseContext {
     }
 
     public Texture getOvalTexture() {
+        if (checkDisposed()) return null;
+
         if (ovalTex == null) {
             int cellMax = getRectTextureMaxSize();
             int texDim = (cellMax * (cellMax + 1)) / 2;
@@ -499,6 +519,8 @@ public abstract class BaseContext {
                                       MaskData maskData,
                                       float bx, float by, float bw, float bh)
     {
+        if (checkDisposed()) return null;
+
         int sizeInPixels = paintW * paintH;
         int sizeInBytes = sizeInPixels * 4;
         if (paintBuffer == null || paintBuffer.capacity() < sizeInBytes) {
@@ -576,4 +598,61 @@ public abstract class BaseContext {
 
         return paintTex;
     }
+
+    /**
+     * Dispose of this context. Subclass implementations can override this
+     * if needed. They must call super.dispose().
+     */
+    public void dispose() {
+        clearGlyphCaches();
+        GlyphCache.disposeForContext(this);
+
+        if (maskTex != null) {
+            maskTex.dispose();
+            maskTex = null;
+        }
+        if (paintTex != null) {
+            paintTex.dispose();
+            paintTex = null;
+        }
+        if (rectTex != null) {
+            rectTex.dispose();
+            rectTex = null;
+        }
+        if (wrapRectTex != null) {
+            wrapRectTex.dispose();
+            wrapRectTex = null;
+        }
+        if (ovalTex != null) {
+            ovalTex.dispose();
+            ovalTex = null;
+        }
+        disposed = true;
+    }
+
+    /**
+     * Returns a flag indicating whether this context has been disposed. A graphics
+     * context is disposed by the associated ResourceFactory when it is disposed.
+     * If a context has been disposed, it must be recreated, by a new ResourceFactory.
+     * All draw calls will be ignored. An attempt to create a resource will be
+     * ignored and will return null.
+     *
+     * @return true if this context has been disposed.
+     */
+    public final boolean isDisposed() {
+        return disposed;
+    }
+
+    protected boolean checkDisposed() {
+        if (PrismSettings.verbose && isDisposed()) {
+            try {
+                throw new IllegalStateException("attempt to use resource after context is disposed");
+            } catch (RuntimeException ex) {
+                ex.printStackTrace();
+            }
+        }
+
+        return isDisposed();
+    }
+
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseMesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseMesh.java
@@ -817,6 +817,11 @@ public abstract class BaseMesh extends BaseGraphicsResource implements Mesh {
         return face;
     }
 
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
     // Package scope method for testing
     boolean test_isVertexBufferNull() {
         return vertexBuffer == null;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseMeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseMeshView.java
@@ -36,4 +36,9 @@ public abstract class BaseMeshView extends BaseGraphicsResource implements MeshV
         super(disposerRecord);
     }
 
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BasePhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BasePhongMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,34 +23,19 @@
  * questions.
  */
 
-package com.sun.prism;
+package com.sun.prism.impl;
 
-import javafx.scene.shape.CullFace;
+import com.sun.prism.PhongMaterial;
 
-/**
- * TODO: 3D - Need documentation
- * This class represents new retained mode rendering object
- * it has a { mesh, material, position, lights and other common rendering properties
- */
-public interface MeshView extends GraphicsResource {
+public abstract class BasePhongMaterial extends BaseGraphicsResource implements PhongMaterial {
 
-    public final static int CULL_NONE = CullFace.NONE.ordinal();
-    public final static int CULL_BACK = CullFace.BACK.ordinal();
-    public final static int CULL_FRONT = CullFace.FRONT.ordinal();
+    protected BasePhongMaterial(Disposer.Record disposerRecord) {
+        super(disposerRecord);
+    }
 
-    public void setCullingMode(int mode);
+    @Override
+    public boolean isValid() {
+        return true;
+    }
 
-    public void setMaterial(Material material);
-
-    public void setWireframe(boolean wireframe);
-
-    public void setAmbientLight(float r, float g, float b);
-
-    public void setPointLight(int index,
-            float x, float y, float z,
-            float r, float g, float b, float w);
-
-    public void render(Graphics g);
-
-    public boolean isValid();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseResourcePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseResourcePool.java
@@ -460,7 +460,16 @@ public abstract class BaseResourcePool<T> implements ResourcePool<T> {
                 cur = cur.next;
             }
         }
-        throw new IllegalStateException("unmanaged resource freed from pool "+this);
+
+        // If we get here, the resource is not currently being managed. This
+        // can happen when the Disposer processes its queue of disposed records
+        // and encounters a record that was previously reclaimed via
+        // cleanup() or freeDisposalRequestedAndCheckResources(), when the
+        // device is lost or removed. We can safely ignore it.
+        if (PrismSettings.poolDebug) {
+            System.err.println("Warning: unmanaged resource " + freed +
+                    " freed from pool: " + this);
+        }
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -397,4 +397,19 @@ public class GlyphCache {
             return rect;
         }
     }
+
+    private static void disposePackerForContext(BaseContext ctx,
+            WeakHashMap<BaseContext, RectanglePacker> packerMap) {
+
+        RectanglePacker packer = packerMap.remove(ctx);
+        if (packer != null) {
+            packer.dispose();
+        }
+    }
+
+    public static void disposeForContext(BaseContext ctx) {
+        disposePackerForContext(ctx, greyPackerMap);
+        disposePackerForContext(ctx, lcdPackerMap);
+    }
+
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/PaintHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/PaintHelper.java
@@ -53,6 +53,7 @@ import com.sun.prism.paint.RadialGradient;
 import com.sun.prism.paint.Stop;
 import com.sun.prism.ps.Shader;
 import com.sun.prism.ps.ShaderGraphics;
+import java.util.WeakHashMap;
 
 class PaintHelper {
 
@@ -105,6 +106,16 @@ class PaintHelper {
     private static Texture gradientCacheTexture = null;
     private static Texture gtexCacheTexture = null;
 
+    /**
+     * The keySet of this map is used to track the gradients that have
+     * a valid entry (offset) in the gradient cache. We need this so that we can
+     * invalidate all entries when a device is lost (at which time we recreate
+     * the gradient cache textures). This prevents using a stale offset that is
+     * no longer valid.
+     * The values in this map are unused.
+     */
+    private static final WeakHashMap<Gradient, Void> gradientMap = new WeakHashMap<>();
+
     private static final Affine2D scratchXform2D = new Affine2D();
     private static final Affine3D scratchXform3D = new Affine3D();
 
@@ -115,6 +126,11 @@ class PaintHelper {
     }
 
     static void initGradientTextures(ShaderGraphics g) {
+        // We must clear cached gradient texture and offsets when the
+        // device is removed and recreated
+        cacheOffset = -1;
+        gradientMap.clear();
+
         gradientCacheTexture = g.getResourceFactory().createTexture(
                 PixelFormat.BYTE_BGRA_PRE, Usage.DEFAULT, WrapMode.CLAMP_TO_EDGE,
                 MULTI_TEXTURE_SIZE, MULTI_CACHE_SIZE);
@@ -137,27 +153,27 @@ class PaintHelper {
     }
 
     static Texture getGradientTexture(ShaderGraphics g, Gradient paint) {
-        if (gradientCacheTexture == null) {
+        if (gradientCacheTexture == null || gradientCacheTexture.isSurfaceLost()) {
             initGradientTextures(g);
         }
 
-        // gradientCacheTexture is left permanent and locked so it never
-        // goes away or needs to be checked for isSurfaceLost(), but we
-        // add a lock here so that the caller can unlock without knowing
-        // our inner implementation details
+        // gradientCacheTexture is left permanent and locked, although we still
+        // must check for isSurfaceLost() in case the device is disposed.
+        // We add a lock here so that the caller can unlock without knowing
+        // our inner implementation details.
         gradientCacheTexture.lock();
         return gradientCacheTexture;
     }
 
     static Texture getWrapGradientTexture(ShaderGraphics g) {
-        if (gtexCacheTexture == null) {
+        if (gtexCacheTexture == null || gtexCacheTexture.isSurfaceLost()) {
             initGradientTextures(g);
         }
 
-        // gtexCacheTexture is left permanent and locked so it never
-        // goes away or needs to be checked for isSurfaceLost(), but we
-        // add a lock here so that the caller can unlock without knowing
-        // our inner implementation details
+        // gtexCacheTexture is left permanent and locked, although we still
+        // must check for isSurfaceLost() in case the device is disposed.
+        // We add a lock here so that the caller can unlock without knowing
+        // our inner implementation details.
         gtexCacheTexture.lock();
         return gtexCacheTexture;
     }
@@ -252,7 +268,7 @@ class PaintHelper {
     // the cache in the range [cacheOffset - cacheSize + 1, cacheOffset]..
     public static int initGradient(Gradient paint) {
         long offset = paint.getGradientOffset();
-        if (offset >= 0 && (offset > cacheOffset - MULTI_CACHE_SIZE)) {
+        if (gradientMap.containsKey(paint) && offset >= 0 && (offset > cacheOffset - MULTI_CACHE_SIZE)) {
             return (int) (offset % MULTI_CACHE_SIZE);
         } else {
             List<Stop> stops = paint.getStops();
@@ -267,6 +283,7 @@ class PaintHelper {
             // either or both of them here.
             gradientCacheTexture.update(colorsImg, 0, cacheIdx);
             gtexCacheTexture.update(gtexImg, 0, cacheIdx);
+            gradientMap.put(paint, null);
             return cacheIdx;
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
@@ -47,7 +47,10 @@ public abstract class Renderer {
 
     /**
      * Enumeration describing the lifecycle states of the renderer.
-     * When the renderer is created, it is in the {@code OK} state.
+     * When the renderer is created, it will either start in the {@code OK}
+     * state, or it will start in the {@code NOTREADY} state until
+     * the first time it is used during rendering, then transition
+     * to the {@code OK} state.
      *
      * It could become {@code LOST} at some point. This may happen for
      * example if the renderer is susceptible to display changes.
@@ -61,9 +64,13 @@ public abstract class Renderer {
      * will be created for the particular context.
      * <p>
      * Thus the lifecycle of a renderer is:
-     * {@code OK} [=> {@code LOST} [=> {@code DISPOSED}]]
+     * [{@code NOTREADY} =>] {@code OK} [=> {@code LOST} [=> {@code DISPOSED}]]
      */
     public static enum RendererState {
+        /**
+         * Renderer is not ready; it might be able to be used for rendering.
+         */
+        NOTREADY,
         /**
          * Renderer can be used for rendering.
          */
@@ -339,6 +346,9 @@ public abstract class Renderer {
 
         Renderer r = rendererMap.get(fctx);
         if (r != null) {
+            if (r.getRendererState() == RendererState.NOTREADY) {
+                return r;
+            }
             if (r.getRendererState() == RendererState.OK) {
                 return r;
             }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1337,7 +1337,10 @@ public class Scene implements EventTarget {
         context.platformImage = accessor.getTkImageLoader(wimg);
         setAllowPGAccess(false);
         Object tkImage = tk.renderToImage(context);
-        accessor.loadTkImage(wimg, tkImage);
+
+        if (tkImage != null) {
+            accessor.loadTkImage(wimg, tkImage);
+        }
 
         if (camera != null) {
             setAllowPGAccess(true);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -734,7 +734,9 @@ HRESULT D3DContext::InitDevice(IDirect3DDevice9 *pd3dDevice)
 HRESULT
 D3DContext::TestCooperativeLevel()
 {
-    TraceLn(NWT_TRACE_INFO, "D3DContext::testCooperativeLevel");
+    TraceLn2(NWT_TRACE_INFO,
+             "D3DContext::testCooperativeLevel pd3dDevice = 0x%x, pd3dDeviceEx = 0x%x",
+             pd3dDevice, pd3dDeviceEx);
 
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
@@ -746,12 +748,13 @@ D3DContext::TestCooperativeLevel()
     switch (res) {
     case S_OK: break;
     case D3DERR_DEVICELOST:
-        TraceLn1(NWT_TRACE_VERBOSE, "  device %d is still lost",
-            adapterOrdinal);
+        TraceLn1(NWT_TRACE_INFO, "  device %d is still lost", adapterOrdinal);
         break;
     case D3DERR_DEVICENOTRESET:
-        TraceLn1(NWT_TRACE_VERBOSE, "  device %d needs to be reset",
-            adapterOrdinal);
+        TraceLn1(NWT_TRACE_INFO, "  device %d needs to be reset", adapterOrdinal);
+        break;
+    case D3DERR_DEVICEREMOVED:
+        TraceLn1(NWT_TRACE_INFO, "  device %d has been removed", adapterOrdinal);
         break;
     case S_PRESENT_OCCLUDED:
         break;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
@@ -112,10 +112,10 @@ struct ConfigJavaStaticClass : IConfig {
 /*
  * Class:     com_sun_prism_d3d_D3DPipeline
  * Method:    nInit
+ * Signature: (Ljava/lang/Class;Z)Z
  */
-
 JNIEXPORT jboolean JNICALL Java_com_sun_prism_d3d_D3DPipeline_nInit
-  (JNIEnv *env, jclass, jclass psClass)
+  (JNIEnv *env, jclass, jclass psClass, jboolean load)
 {
     if (D3DPipelineManager::GetInstance()) {
         D3DPipelineManager::SetErrorMessage("Double D3DPipelineManager initialization");
@@ -146,9 +146,10 @@ JNIEXPORT jstring JNICALL Java_com_sun_prism_d3d_D3DPipeline_nGetErrorMessage(JN
 /*
  * Class:     com_sun_prism_d3d_D3DPipeline
  * Method:    nDispose
+ * Signature: (Z)V
  */
-
-JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DPipeline_nDispose(JNIEnv *pEnv, jclass)
+JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DPipeline_nDispose
+  (JNIEnv *pEnv, jclass, jboolean unload)
 {
     TraceLn(NWT_TRACE_INFO, "D3DPipeline_nDispose");
     if (D3DPipelineManager::GetInstance()) {

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipelineManager.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipelineManager.cc
@@ -149,6 +149,10 @@ HRESULT D3DPipelineManager::InitAdapters(IConfig &cfg)
     TraceLn(NWT_TRACE_INFO, "D3DPPLM::InitAdapters()");
 
     adapterCount = pd3d9->GetAdapterCount();
+
+    if (adapterCount == 0) {
+        RlsTraceLn(NWT_TRACE_WARNING, "Zero adapters found");
+    }
     pAdapters = new D3DAdapter[adapterCount];
     if (pAdapters == NULL) {
         SetErrorMessage("InitAdapters: out of memory");

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/TestGraphics.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/TestGraphics.java
@@ -179,6 +179,7 @@ public class TestGraphics extends BaseGraphics {
 
     private static class TestResourceFactory implements ResourceFactory {
         @Override public boolean isDeviceReady() { return true; }
+        @Override public boolean isDisposed() { return false; }
 
         @Override public TextureResourcePool getTextureResourcePool() { return null; }
         @Override public Texture createTexture(Image image, Texture.Usage usageHint, WrapMode wrapMode) { return null; }

--- a/modules/javafx.media/src/main/java/com/sun/javafx/media/PrismMediaFrameHandler.java
+++ b/modules/javafx.media/src/main/java/com/sun/javafx/media/PrismMediaFrameHandler.java
@@ -24,6 +24,7 @@
  */
 package com.sun.javafx.media;
 
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -36,6 +37,7 @@ import com.sun.prism.Graphics;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.MediaFrame;
 import com.sun.prism.PixelFormat;
+import com.sun.prism.ResourceFactory;
 import com.sun.prism.ResourceFactoryListener;
 import com.sun.prism.Texture;
 
@@ -63,7 +65,8 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
         return ret;
     }
 
-    private boolean registeredWithFactory = false;
+    private WeakReference<ResourceFactory> registeredWithFactory = null;
+
     private PrismMediaFrameHandler(Object provider) {
     }
 
@@ -129,11 +132,12 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
 
         PrismFrameBuffer prismBuffer = new PrismFrameBuffer(vdb);
         if (tme.texture == null) {
-            if (!registeredWithFactory) {
+            ResourceFactory factory = GraphicsPipeline.getDefaultResourceFactory();
+            if (registeredWithFactory == null || registeredWithFactory.get() != factory) {
                 // make sure we've registered with the resource factory so we know
                 // when to purge old textures
-                GraphicsPipeline.getDefaultResourceFactory().addFactoryListener(this);
-                registeredWithFactory = true;
+                factory.addFactoryListener(this);
+                registeredWithFactory = new WeakReference<>(factory);
             }
 
             tme.texture = GraphicsPipeline.getPipeline().

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
@@ -29,11 +29,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.locks.ReentrantLock;
 import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.tk.RenderJob;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.Invoker;
 
 public final class PrismInvoker extends Invoker {
+
+    private static final PlatformLogger log =
+            PlatformLogger.getLogger(PrismInvoker.class.getName());
 
     public PrismInvoker() {
     }
@@ -87,10 +91,8 @@ public final class PrismInvoker extends Invoker {
             try {
                 // block until job is complete
                 f.get();
-            } catch (ExecutionException ex) {
-                throw new AssertionError(ex);
-            } catch (InterruptedException ex) {
-                // ignore; recovery is impossible
+            } catch (ExecutionException | InterruptedException ex) {
+                log.severe("RenderJob error", ex);
             }
         }
     }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
@@ -25,6 +25,7 @@
 
 package com.sun.javafx.webkit.prism;
 
+import com.sun.javafx.logging.PlatformLogger;
 import com.sun.prism.CompositeMode;
 import com.sun.prism.Graphics;
 import com.sun.prism.GraphicsPipeline;
@@ -37,6 +38,7 @@ import com.sun.prism.ResourceFactoryListener;
 import com.sun.prism.Texture;
 import com.sun.prism.paint.Color;
 import com.sun.prism.paint.Paint;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -47,9 +49,12 @@ import java.nio.IntBuffer;
 final class RTImage extends PrismImage implements ResourceFactoryListener {
     private RTTexture txt;
     private final int width, height;
-    private boolean listenerAdded = false;
+    private WeakReference<ResourceFactory> registeredWithFactory = null;
     private ByteBuffer pixelBuffer;
     private float pixelScale;
+
+    private final static PlatformLogger log =
+            PlatformLogger.getLogger(RTImage.class.getName());
 
     RTImage(int w, int h, float pixelScale) {
         width = w;
@@ -66,23 +71,36 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
 
     @Override
     Graphics getGraphics() {
-        Graphics g = getTexture().createGraphics();
+        RTTexture texture = getTexture();
+        if (texture == null) {
+            return null;
+        }
+        Graphics g = texture.createGraphics();
         g.transform(PrismGraphicsManager.getPixelScaleTransform());
         return g;
     }
 
     private RTTexture getTexture() {
+        if (txt != null && txt.isSurfaceLost()) {
+            log.fine("RTImage::getTexture : surface lost: " + this);
+        }
+
+        ResourceFactory f = GraphicsPipeline.getDefaultResourceFactory();
+        if (f == null || f.isDisposed()) {
+            log.fine("RTImage::getTexture : return null because device disposed or not ready");
+            return null;
+        }
+
         if (txt == null) {
-            ResourceFactory f = GraphicsPipeline.getDefaultResourceFactory();
             txt = f.createRTTexture(
                     (int) Math.ceil(width * pixelScale),
                     (int) Math.ceil(height * pixelScale),
                     Texture.WrapMode.CLAMP_NOT_NEEDED);
             txt.contentsUseful();
             txt.makePermanent();
-            if (! listenerAdded) {
+            if (registeredWithFactory == null || registeredWithFactory.get() != f) {
                 f.addFactoryListener(this);
-                listenerAdded = true;
+                registeredWithFactory = new WeakReference<>(f);
             }
         }
         return txt;
@@ -94,6 +112,10 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
             int srcx1, int srcy1, int srcx2, int srcy2)
     {
         if (txt == null && g.getCompositeMode() == CompositeMode.SRC_OVER) {
+            return;
+        }
+        if (g.getResourceFactory().isDisposed()) {
+            log.fine("RTImage::draw : skip because device has been disposed");
             return;
         }
         if (g instanceof PrinterGraphics) {
@@ -160,6 +182,11 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
         }
         if (isNew || isDirty()) {
             PrismInvoker.runOnRenderThread(() -> {
+                final ResourceFactory f = GraphicsPipeline.getDefaultResourceFactory();
+                if (f == null || f.isDisposed()) {
+                    log.fine("RTImage::getPixelBuffer : skip because device disposed or not ready");
+                    return;
+                }
                 flushRQ();
                 if (txt != null && pixelBuffer != null) {
                     PixelFormat pf = txt.getPixelFormat();
@@ -172,7 +199,6 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
                     RTTexture t = txt;
                     if (pixelScale != 1.0f) {
                         // Convert [txt] to a texture the size of the image
-                        ResourceFactory f = GraphicsPipeline.getDefaultResourceFactory();
                         t = f.createRTTexture(width, height, Texture.WrapMode.CLAMP_NOT_NEEDED);
                         Graphics g = t.createGraphics();
                         g.drawTexture(txt, 0, 0, width, height,
@@ -203,7 +229,7 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
         PrismInvoker.invokeOnRenderThread(new Runnable() {
             public void run() {
                 //[g] field can be null if it is the first paint
-                //from synthetic ImageData.
+                //from synthetic ImageData or if the resource factory is disposed
                 Graphics g = getGraphics();
                 if (g != null && pixelBuffer != null) {
                     pixelBuffer.rewind();//critical!
@@ -228,6 +254,10 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
     }
 
     @Override public void factoryReleased() {
+        if (txt != null) {
+            txt.dispose();
+            txt = null;
+        }
     }
 
     @Override

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageImpl.java
@@ -90,9 +90,15 @@ final class WCImageImpl extends PrismImage {
             int dstx1, int dsty1, int dstx2, int dsty2,
             int srcx1, int srcy1, int srcx2, int srcy2)
     {
+        ResourceFactory resourceFactory = g.getResourceFactory();
+        if (resourceFactory.isDisposed()) {
+            log.fine("WCImageImpl::draw : skip because device disposed or not ready");
+            return;
+        }
+
         if (g instanceof PrinterGraphics) {
             // We're printing. Wrap [img] into a J2DTexture and draw it.
-            Texture t = g.getResourceFactory().createTexture(
+            Texture t = resourceFactory.createTexture(
                     img, Texture.Usage.STATIC, Texture.WrapMode.CLAMP_NOT_NEEDED);
             g.drawTexture(t,
                     dstx1, dsty1, dstx2, dsty2,
@@ -108,7 +114,6 @@ final class WCImageImpl extends PrismImage {
             }
         }
         if (texture == null && compoundTexture == null) {
-            ResourceFactory resourceFactory = g.getResourceFactory();
             int maxSize = resourceFactory.getMaximumTextureSize();
             if (img.getWidth() <= maxSize && img.getHeight() <= maxSize) {
                 texture = resourceFactory.createTexture(img, Texture.Usage.DEFAULT, Texture.WrapMode.CLAMP_TO_EDGE);

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/GraphicsDecoder.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/GraphicsDecoder.java
@@ -91,9 +91,13 @@ public final class GraphicsDecoder  {
             PlatformLogger.getLogger(GraphicsDecoder.class.getName());
 
     static void decode(WCGraphicsManager gm, WCGraphicsContext gc, BufferData bdata) {
-        if (gc == null) {
+        if (gc == null || !gc.isValid()) {
+            log.fine("GraphicsDecoder::decode : GC is " +
+                    (gc == null ? "null" : " invalid"));
+
             return;
         }
+
         ByteBuffer buf = bdata.getBuffer();
         buf.order(ByteOrder.nativeOrder());
         while (buf.remaining() > 0) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCGraphicsContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCGraphicsContext.java
@@ -138,5 +138,7 @@ public abstract class WCGraphicsContext {
 
     public abstract void flush();
 
+    public abstract boolean isValid();
+
     public abstract void dispose();
 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCRenderQueue.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCRenderQueue.java
@@ -87,6 +87,11 @@ public abstract class WCRenderQueue extends Ref {
     }
 
     public synchronized void decode(WCGraphicsContext gc) {
+        if (gc == null || !gc.isValid()) {
+            log.fine("WCRenderQueue::decode : GC is " + (gc == null ? "null" : " invalid"));
+            return;
+        }
+
         for (BufferData bdata : buffers) {
             try {
                 GraphicsDecoder.decode(
@@ -99,13 +104,19 @@ public abstract class WCRenderQueue extends Ref {
     }
 
     public synchronized void decode() {
-        assert (gc != null);
+        if (gc == null || !gc.isValid()) {
+            log.fine("WCRenderQueue::decode : GC is " + (gc == null ? "null" : " invalid"));
+            return;
+        }
         decode(gc);
         gc.flush();
     }
 
     public synchronized void decode(int fontSmoothingType) {
-        assert (gc != null);
+        if (gc == null || !gc.isValid()) {
+            log.fine("WCRenderQueue::decode : GC is " + (gc == null ? "null" : " invalid"));
+            return;
+        }
         gc.setFontSmoothingType(fontSmoothingType);
         decode();
     }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCGraphicsPerfLogger.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/perf/WCGraphicsPerfLogger.java
@@ -71,6 +71,11 @@ public final class WCGraphicsPerfLogger extends WCGraphicsContext {
     }
 
     @Override
+    public boolean isValid() {
+        return gc.isValid();
+    }
+
+    @Override
     public void drawString(WCFont f, int[] glyphs,
                            float[] advanceDXY,
                            float x, float y)


### PR DESCRIPTION
This is a mostly-clean backport to jfx11u. The only merge conflicts I had to fix were in `D3DPipeline.cc` to ignore two hunks from the patch, since the static library support is not present in 11 (this is the exact same thing I had to do for the FX 8u backport).

Tested on all three platforms, along with my other in-progress backports, all of which are aggregated in my [`kevinrushforth:test-kcr-11.0.12`](https://github.com/kevinrushforth/jfx11u/commits/test-kcr-11.0.12) branch.

Additional testing: verified on a remote desktop connection that disconnecting and reconnecting now works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239589](https://bugs.openjdk.java.net/browse/JDK-8239589): JavaFX UI will not repaint after reconnecting via Remote Desktop


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/8.diff">https://git.openjdk.java.net/jfx11u/pull/8.diff</a>

</details>
