### PR TITLE
8259356: MediaPlayer's seek freezes video

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/app/gstappsink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/app/gstappsink.c
@@ -670,6 +670,7 @@ gst_app_sink_flush_unlocked (GstAppSink * appsink)
         GstEvent *event = GST_EVENT_CAST (obj);
         gst_event_parse_caps (event, &caps);
         gst_caps_replace (&priv->last_caps, caps);
+        gst_sample_set_caps(priv->sample, priv->last_caps);
       }
     }
     gst_mini_object_unref (obj);


### PR DESCRIPTION
Clean backport to jfx11u. Tested on all three platforms, along with my other in-progress backports, all of which are aggregated in my [`kevinrushforth:test-kcr-11.0.12`](https://github.com/kevinrushforth/jfx11u/commits/test-kcr-11.0.12) branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259356](https://bugs.openjdk.java.net/browse/JDK-8259356): MediaPlayer's seek freezes video


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/10.diff">https://git.openjdk.java.net/jfx11u/pull/10.diff</a>

</details>
