### PR TITLE
8264990: WebEngine crashes with segfault when not loaded through system classloader

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
@@ -34,25 +34,18 @@ namespace WTF {
 
 namespace FileSystemImpl {
 
-static jclass GetFileSystemClass(JNIEnv* env)
-{
-    static JGClass clazz(env->FindClass("com/sun/webkit/FileSystem"));
-    ASSERT(clazz);
-    return clazz;
-}
-
 bool fileExists(const String& path)
 {
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkFileExists",
             "(Ljava/lang/String;)Z");
     ASSERT(mid);
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env));
     WTF::CheckAndClearException(env);
@@ -75,13 +68,13 @@ bool getFileSize(const String& path, long long& result)
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkGetFileSize",
             "(Ljava/lang/String;)J");
     ASSERT(mid);
 
     jlong size = env->CallStaticLongMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring) path.toJavaString(env));
     WTF::CheckAndClearException(env);
@@ -125,13 +118,13 @@ String pathByAppendingComponent(const String& path, const String& component)
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkPathByAppendingComponent",
             "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
     ASSERT(mid);
 
     JLString result = static_cast<jstring>(env->CallStaticObjectMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env),
             (jstring)component.toJavaString(env)));
@@ -145,13 +138,13 @@ bool makeAllDirectories(const String& path)
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkMakeAllDirectories",
             "(Ljava/lang/String;)Z");
     ASSERT(mid);
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env));
     WTF::CheckAndClearException(env);
@@ -174,7 +167,7 @@ Optional<FileMetadata> fileMetadata(const String& path)
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkGetFileMetadata",
             "(Ljava/lang/String;[J)Z");
     ASSERT(mid);
@@ -182,7 +175,7 @@ Optional<FileMetadata> fileMetadata(const String& path)
     JLocalRef<jlongArray> lArray(env->NewLongArray(3));
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env), (jlongArray)lArray);
     WTF::CheckAndClearException(env);
@@ -229,13 +222,13 @@ PlatformFileHandle openFile(const String& path, FileOpenMode mode, FileAccessPer
     }
     JNIEnv* env = WTF::GetJavaEnv();
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkOpenFile",
             "(Ljava/lang/String;Ljava/lang/String;)Ljava/io/RandomAccessFile;");
     ASSERT(mid);
 
     PlatformFileHandle result = env->CallStaticObjectMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env), (jstring)(env->NewStringUTF("r")));
 
@@ -248,13 +241,13 @@ void closeFile(PlatformFileHandle& handle)
     if (isHandleValid(handle)) {
         JNIEnv* env = WTF::GetJavaEnv();
         static jmethodID mid = env->GetStaticMethodID(
-                GetFileSystemClass(env),
+                comSunWebkitFileSystem,
                 "fwkCloseFile",
                 "(Ljava/io/RandomAccessFile;)V");
         ASSERT(mid);
 
         env->CallStaticVoidMethod(
-                GetFileSystemClass(env),
+                comSunWebkitFileSystem,
                 mid, (jobject)handle);
         WTF::CheckAndClearException(env);
         handle = invalidPlatformFileHandle;
@@ -268,13 +261,13 @@ int readFromFile(PlatformFileHandle handle, char* data, int length)
     }
     JNIEnv* env = WTF::GetJavaEnv();
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkReadFromFile",
             "(Ljava/io/RandomAccessFile;Ljava/nio/ByteBuffer;)I");
     ASSERT(mid);
 
     int result = env->CallStaticIntMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jobject)handle,
             (jobject)(env->NewDirectByteBuffer(data, length)));
@@ -304,13 +297,13 @@ String pathGetFileName(const String& path)
     JNIEnv* env = WTF::GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkPathGetFileName",
             "(Ljava/lang/String;)Ljava/lang/String;");
     ASSERT(mid);
 
     JLString result = static_cast<jstring>(env->CallStaticObjectMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring) path.toJavaString(env)));
     WTF::CheckAndClearException(env);
@@ -327,13 +320,13 @@ long long seekFile(PlatformFileHandle handle, long long offset, FileSeekOrigin)
     }
     JNIEnv* env = WTF::GetJavaEnv();
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkSeekFile",
             "(Ljava/io/RandomAccessFile;J)V");
     ASSERT(mid);
 
     env->CallStaticVoidMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jobject)handle, (jlong)offset);
     if (WTF::CheckAndClearException(env)) {

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
@@ -30,6 +30,7 @@
 JavaVM* jvm = 0;
 
 namespace WTF {
+JGClass comSunWebkitFileSystem;
 
 bool CheckAndClearException(JNIEnv* env)
 {
@@ -131,6 +132,21 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
     _CrtSetDbgFlag( tmpFlag );
 #endif
     jvm = vm;
+
+    JNIEnv* env = WTF::GetJavaEnv();
+
+    // Class com.sun.webkit.FileSystem is accessed from a newly created native
+    // thread from FileSystemJava. The class is resolved at initialization time
+    // as in the JNI_OnLoad callback the classloader used to load the native
+    // library is also used to load the target class, which is by construction
+    // the right one
+    static jclass fileSystemClass = env->FindClass("com/sun/webkit/FileSystem");
+
+    ASSERT(fileSystemClass);
+
+    static JGClass fileSystemRef(fileSystemClass);
+    WTF::comSunWebkitFileSystem = fileSystemRef;
+
     return JNI_VERSION_1_2;
 }
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.h
@@ -128,3 +128,6 @@ using AttachThreadAsNonDaemonToJavaEnv = AttachThreadToJavaEnv<false>;
 #define JINT_SZ sizeof(jint)
 #define JFLOAT_SZ sizeof(jfloat)
 
+namespace WTF {
+extern JGClass comSunWebkitFileSystem;
+}

--- a/tests/system/src/test/java/test/com/sun/webkit/LocalStorageAccessTest.java
+++ b/tests/system/src/test/java/test/com/sun/webkit/LocalStorageAccessTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.webkit;
+
+import java.io.File;
+import static java.util.Arrays.asList;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * @test
+ * @bug 8264990
+ * @summary Check if access to local storage works without causing a segfault
+ */
+public class LocalStorageAccessTest {
+    @Test (timeout = 15000)
+    public void testMainThreadDoesNotSegfault() throws Exception {
+        // This is an indirect test of the webkit file system implementation.
+        // It was observed, that accessing local storage causes a segfault
+        // in the JVM. That case is executed by this test.
+        //
+        // A new JVM is started with a custom launcher (classpath based). This
+        // launcher sets up the module layer required for OpenJFX and starts
+        // the test application. That way the OpenJFX classes are not loaded by
+        // the system class loader, but by the classloader that is associated
+        // with the new module layer.
+        //
+
+        final String appModulePath = System.getProperty("launchertest.testapp7.module.path");
+        final String workerModulePath = System.getProperty("worker.module.path");
+        final String javaLibraryPath = System.getProperty("java.library.path");
+        final String workerJavaCmd = System.getProperty("worker.java.cmd");
+
+        final List<String> cmd = asList(
+            workerJavaCmd,
+            "-cp", appModulePath + "/mymod",
+            "-Djava.library.path=" + javaLibraryPath,
+            "-Dmodule.path=" + appModulePath + "/mymod" + File.pathSeparator + workerModulePath,
+            "myapp7.LocalStorageAccessWithModuleLayerLauncher"
+        );
+
+        final ProcessBuilder builder = new ProcessBuilder(cmd);
+
+        builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        builder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        Process process = builder.start();
+        int retVal = process.waitFor();
+
+        assertEquals("Process did not exit cleanly", 0, retVal);
+    }
+}

--- a/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayer.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package myapp7;
+
+import java.lang.module.ModuleDescriptor;
+import javafx.application.Application;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Worker.State;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+public class LocalStorageAccessWithModuleLayer extends Application {
+    public static final int ERROR_OK = 0;
+    public static final int ERROR_ASSUMPTION_VIOLATED = 2;
+    public static final int ERROR_TIMEOUT = 3;
+    public static final int ERROR_TITLE_NOT_UPDATED = 4;
+    public static final int ERROR_UNEXPECTED_EXIT = 5;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        Module module = Application.class.getModule();
+
+        if (module == null) {
+            System.err.println("Failure: Module for Application not found");
+            System.exit(ERROR_ASSUMPTION_VIOLATED);
+        }
+
+        if (! module.isNamed()) {
+            System.err.println("Failure: Expected named module");
+            System.exit(ERROR_ASSUMPTION_VIOLATED);
+        }
+
+        ModuleDescriptor moduleDesc = module.getDescriptor();
+
+        if (moduleDesc.isAutomatic()) {
+            System.err.println("Failure: Automatic module found");
+            System.exit(ERROR_ASSUMPTION_VIOLATED);
+        }
+
+        if (moduleDesc.isOpen()) {
+            System.err.println("Failure: Open module found");
+            System.exit(ERROR_ASSUMPTION_VIOLATED);
+        }
+
+        BorderPane root = new BorderPane();
+        Scene scene = new Scene(root);
+
+        WebView webview = new WebView();
+        root.setCenter(webview);
+
+        // The loaded test page LocalStorageAccess will set the title to
+        // 'Executed'. This indicates, that the second script block was reached
+        webview.getEngine().getLoadWorker().stateProperty().addListener(
+            (observableValue, oldState, newState) -> {
+                if (newState == State.SUCCEEDED) {
+                    String title = webview.getEngine().getTitle();
+                    if ("Executed".equals(title)) {
+                        System.exit(ERROR_OK);
+                    } else {
+                        System.exit(ERROR_TITLE_NOT_UPDATED);
+                    }
+                }
+            });
+        webview.getEngine().load(LocalStorageAccessWithModuleLayer.class.getResource("LocalStorageAccess.html").toExternalForm());
+
+        primaryStage.setScene(scene);
+        primaryStage.setWidth(1024);
+        primaryStage.setHeight(768);
+        primaryStage.show();
+    }
+}

--- a/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package myapp7;
+
+import java.io.File;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LocalStorageAccessWithModuleLayerLauncher {
+
+    public static void main(String[] args) throws Exception {
+        // Install safeguard to ensure this application is terminated
+        new Thread() {
+            {
+                setDaemon(true);
+            }
+
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(15000);
+                } catch (InterruptedException ex) {
+                    // Ok, lets exit early
+                }
+                System.exit(LocalStorageAccessWithModuleLayer.ERROR_TIMEOUT);
+            }
+        }.start();
+
+        /*
+         * Setup a module layer for OpenJFX and the test class
+         */
+
+        // Hack to get the classes of this programm into a module layer
+        List<Path> modulePaths = new ArrayList<>();
+        for (String workerPath : System.getProperty("module.path").split(File.pathSeparator)) {
+            modulePaths.add(Paths.get(workerPath));
+        }
+        ModuleFinder finder = ModuleFinder.of(modulePaths.toArray(new Path[0]));
+
+        /*
+         * Load the application as a named module and invoke it
+         */
+        ModuleLayer parent = ModuleLayer.boot();
+        Configuration cf = parent.configuration().resolve(finder, ModuleFinder.of(), Set.of("mymod"));
+        ClassLoader scl = ClassLoader.getSystemClassLoader();
+        ModuleLayer layer = parent.defineModulesWithOneLoader(cf, scl);
+        ClassLoader moduleClassLoader = layer.findLoader("mymod");
+        Class appClass = moduleClassLoader.loadClass("javafx.application.Application");
+        Class testClass = moduleClassLoader.loadClass("myapp7.LocalStorageAccessWithModuleLayer");
+        Method launchMethod = appClass.getMethod("launch", Class.class, String[].class);
+        launchMethod.invoke(null, new Object[]{testClass, args});
+        System.exit(LocalStorageAccessWithModuleLayer.ERROR_UNEXPECTED_EXIT);
+    }
+}

--- a/tests/system/src/testapp7/resources/mymod/myapp7/LocalStorageAccess.html
+++ b/tests/system/src/testapp7/resources/mymod/myapp7/LocalStorageAccess.html
@@ -1,0 +1,41 @@
+<!--
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+-->
+<html>
+    <head>
+        <title>Armed</title>
+    </head>
+    <body>
+        <h1>Test localStorage without segfault</h1>
+        <p>
+            The test is successful if access localstorage does not cause the
+            JVM to crash with a SEGFAULT.
+        </p>
+        <script>localStorage.setItem( 'dummyKey', 'dummyValue' );</script>
+        <p style="color: darkgreen; font-weight: bold">Done</p>
+        <script>document.getElementsByTagName('title')[0].textContent='Executed'</script>
+    </body>
+</html>


### PR DESCRIPTION
Clean backport to jfx11u. Tested on all three platforms, along with my other in-progress backports, all of which are aggregated in my [`kevinrushforth:test-kcr-11.0.12`](https://github.com/kevinrushforth/jfx11u/commits/test-kcr-11.0.12) branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264990](https://bugs.openjdk.java.net/browse/JDK-8264990): WebEngine crashes with segfault when not loaded through system classloader


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/11.diff">https://git.openjdk.java.net/jfx11u/pull/11.diff</a>

</details>
