### PR TITLE
8263788: JavaFX application freezes completely after some time when using the WebView

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/MainThread.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/MainThread.java
@@ -36,9 +36,5 @@ final class MainThread {
         });
     }
 
-    private static boolean fwkIsMainThread() {
-        return Invoker.getInvoker().isEventThread();
-    }
-
     private static native void twkScheduleDispatchFunctions();
 }

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
@@ -8,10 +8,19 @@
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
 
+#if OS(UNIX)
+#include <pthread.h>
+#endif
+
 namespace WTF {
 static JGClass jMainThreadCls;
-static jmethodID fwkIsMainThread;
 static jmethodID fwkScheduleDispatchFunctions;
+
+#if OS(UNIX)
+static pthread_t mainThread;
+#elif OS(WINDOWS)
+static ThreadIdentifier mainThread { 0 };
+#endif
 
 void scheduleDispatchFunctionsOnMainThread()
 {
@@ -48,13 +57,6 @@ void initializeMainThreadPlatform()
     static JGClass jMainThreadRef(env->FindClass("com/sun/webkit/MainThread"));
     jMainThreadCls = jMainThreadRef;
 
-    fwkIsMainThread = env->GetStaticMethodID(
-            jMainThreadCls,
-            "fwkIsMainThread",
-            "()Z");
-
-    ASSERT(fwkIsMainThread);
-
     fwkScheduleDispatchFunctions = env->GetStaticMethodID(
             jMainThreadCls,
             "fwkScheduleDispatchFunctions",
@@ -62,24 +64,25 @@ void initializeMainThreadPlatform()
 
     ASSERT(fwkScheduleDispatchFunctions);
 
-#if OS(WINDOWS)
+#if OS(UNIX)
+    mainThread = pthread_self();
+#elif OS(WINDOWS)
+    mainThread = Thread::currentID();
     RunLoop::registerRunLoopMessageWindowClass();
 #endif
 }
 
-bool isMainThreadIfInitialized()
-{
-    return isMainThread();
-}
-
+#if OS(UNIX)
 bool isMainThread()
 {
-    AttachThreadAsNonDaemonToJavaEnv autoAttach;
-    JNIEnv* env = autoAttach.env();
-    jboolean isMainThread = env->CallStaticBooleanMethod(jMainThreadCls, fwkIsMainThread);
-    WTF::CheckAndClearException(env);
-    return isMainThread == JNI_TRUE;
+    return pthread_equal(pthread_self(), mainThread);
 }
+#elif OS(WINDOWS)
+bool isMainThread()
+{
+    return mainThread == Thread::currentID();
+}
+#endif
 
 extern "C" {
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -271,10 +271,8 @@ struct Thread::ThreadHolder {
         // after Windows terminates other threads. If the terminated
         // thread was holding a mutex, trying to lock the mutex causes
         // deadlock.
-#if !PLATFORM(JAVA)
         if (isMainThread())
             return;
-#endif
         if (thread) {
             thread->specificStorage().destroySlots();
             thread->didExit();


### PR DESCRIPTION
Clean backport to jfx11u. Tested on all three platforms, along with my other in-progress backports, all of which are aggregated in my [`kevinrushforth:test-kcr-11.0.12`](https://github.com/kevinrushforth/jfx11u/commits/test-kcr-11.0.12) branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263788](https://bugs.openjdk.java.net/browse/JDK-8263788): JavaFX application freezes completely after some time when using the WebView


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/12.diff">https://git.openjdk.java.net/jfx11u/pull/12.diff</a>

</details>
