### PR TITLE
8264928: Update to Xcode 12.4

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -90,7 +90,7 @@ jfx.gradle.version.min=4.8
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2017-15.9.24+1.0
-jfx.build.macosx.xcode.version=Xcode11.3.1-MacOSX10.15+1.0
+jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools
 jfx.build.cmake.version=3.13.3

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -46,7 +46,7 @@ MAC.libDest = "lib"
  * In extreme cases you can provide your own properties in your home dir to
  * override these settings or pass them on the command line.
  */
-def prefSdkVersion = "10.15"
+def prefSdkVersion = "11.1"
 def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${prefSdkVersion}.sdk";
 
 // Set the minimum API version that we require (developers do not need to override this)


### PR DESCRIPTION
Almost clean backport to jfx11u (clean except for surrounding context in `build.properties`). Tested on all three platforms, along with my other in-progress backports, all of which are aggregated in my [`kevinrushforth:test-kcr-11.0.12`](https://github.com/kevinrushforth/jfx11u/commits/test-kcr-11.0.12) branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264928](https://bugs.openjdk.java.net/browse/JDK-8264928): Update to Xcode 12.4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/14.diff">https://git.openjdk.java.net/jfx11u/pull/14.diff</a>

</details>
