### PR TITLE
8257758: Allow building of JavaFX native libs for Apple Silicon

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -28,6 +28,11 @@ ext.MAC = [:]
 MAC.canBuild = IS_MAC && IS_64
 if (!MAC.canBuild) return;
 
+def TARGET_ARCH = "x86_64"
+if (hasProperty('TARGET_ARCH')) {
+    TARGET_ARCH = ext.TARGET_ARCH
+}
+
 // All desktop related packages should be built
 MAC.compileSwing = true;
 MAC.compileSWT = true;
@@ -106,7 +111,11 @@ def commonParams = [
         "-mmacosx-version-min=$MACOSX_MIN_VERSION",
         "-isysroot", "$MACOSX_SDK_PATH",
         "-iframework$MACOSX_SDK_PATH/System/Library/Frameworks",
-        "-arch", "x86_64"]
+        "-arch", "$TARGET_ARCH"]
+
+if (hasProperty('TARGET_ARCH')) {
+    commonParams = ["-target", "${TARGET_ARCH}-apple-macos-11", commonParams]
+}
 
 def ccBaseFlags = [
         commonParams,


### PR DESCRIPTION
Reviewed-by: kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257758](https://bugs.openjdk.java.net/browse/JDK-8257758): Allow building of JavaFX native libs for Apple Silicon


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/19.diff">https://git.openjdk.java.net/jfx11u/pull/19.diff</a>

</details>
