### PR TITLE
8266554: Change default macOS min version for aarch64 to 11.0

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,9 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
-defineProperty("MACOSX_MIN_VERSION", "10.10");
+def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
+def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
+defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 // Create $buildDir/mac_tools.properties file and load props from it
 setupTools("mac_tools",


### PR DESCRIPTION
Require at least MacOSX 11.0 to build on mac-AArch64.
Don't increase minimum SDK version when building on x86-64 (contrary to JDK-8265031)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266554](https://bugs.openjdk.java.net/browse/JDK-8266554): Change default macOS min version for aarch64 to 11.0


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/21.diff">https://git.openjdk.java.net/jfx11u/pull/21.diff</a>

</details>
