### PR TITLE
8268152: gstmpegaudioparse does not provides timestamps for HLS MP3 streams

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/audio/gstaudiobasesink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/audio/gstaudiobasesink.c
@@ -1883,8 +1883,14 @@ gst_audio_base_sink_render (GstBaseSink * bsink, GstBuffer * buf)
   /* Last ditch attempt to ensure that we only play silence if
    * we are in trickmode no-audio mode (or if a buffer is marked as a GAP)
    * by dropping the buffer contents and rendering as a gap event instead */
+#ifndef GSTREAMER_LITE
   if (G_UNLIKELY ((bsink->segment.flags & GST_SEGMENT_FLAG_TRICKMODE_NO_AUDIO)
           || (buf && GST_BUFFER_FLAG_IS_SET (buf, GST_BUFFER_FLAG_GAP)))) {
+#else // GSTREAMER_LITE
+  if (G_UNLIKELY ((bsink->segment.flags & GST_SEGMENT_FLAG_TRICKMODE_NO_AUDIO)
+          || (buf && GST_BUFFER_FLAG_IS_SET (buf, GST_BUFFER_FLAG_GAP)))
+          && GST_BUFFER_TIMESTAMP_IS_VALID(buf)) {
+#endif // GSTREAMER_LITE
     GstClockTime duration;
     GstEvent *event;
     GstBaseSinkClass *bclass;

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
@@ -1336,7 +1336,11 @@ gst_base_parse_sink_event_default (GstBaseParse * parse, GstEvent * event)
         /* not considered BYTE seekable if it is talking to us in TIME,
          * whatever else it might claim */
         parse->priv->upstream_seekable = FALSE;
+#ifndef GSTREAMER_LITE
         next_dts = GST_CLOCK_TIME_NONE;
+#else // GSTREAMER_LITE
+        next_dts = in_segment->start;
+#endif // GSTREAMER_LITE
         gst_event_copy_segment (event, &out_segment);
       }
 


### PR DESCRIPTION
This is a clean backport of a GStreamer audio fix for a regression caused by the recent GStreamer 1.18.3 update in [JDK-8262365](https://bugs.openjdk.java.net/browse/JDK-8262365). I tested it on all three platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268152](https://bugs.openjdk.java.net/browse/JDK-8268152): gstmpegaudioparse does not provides timestamps for HLS MP3 streams


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/22.diff">https://git.openjdk.java.net/jfx11u/pull/22.diff</a>

</details>
