### PR TITLE
8210199: [linux / macOS] fileChooser can't handle emojis

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassCommonDialogs.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassCommonDialogs.cpp
@@ -137,10 +137,19 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_gtk_GtkCommonDialogs__1showFileC
         if (fnames_list_len > 0) {
             jFileNames = env->NewObjectArray((jsize)fnames_list_len, jStringCls, NULL);
             EXCEPTION_OCCURED(env);
+            const jmethodID bytesInit = env->GetMethodID(jStringCls, "<init>", "([B)V");
+            EXCEPTION_OCCURED(env);
             for (guint i = 0; i < fnames_list_len; i++) {
                 filename = (char*)g_slist_nth(fnames_gslist, i)->data;
                 LOG1("Add [%s] into returned filenames\n", filename)
-                jfilename = env->NewStringUTF(filename);
+                int len = strlen(filename);
+                jbyteArray bytes = env->NewByteArray(len);
+                EXCEPTION_OCCURED(env);
+                env->SetByteArrayRegion(bytes, 0, len, (jbyte *)filename);
+                EXCEPTION_OCCURED(env);
+                jfilename = (jstring) env->NewObject(jStringCls, bytesInit, bytes);
+                EXCEPTION_OCCURED(env);
+                env->DeleteLocalRef(bytes);
                 EXCEPTION_OCCURED(env);
                 env->SetObjectArrayElement(jFileNames, (jsize)i, jfilename);
                 EXCEPTION_OCCURED(env);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
@@ -187,8 +187,11 @@
 
 static jobject convertNSURLtoFile(JNIEnv *env, NSURL *url)
 {
-    LOG("   url: %s", [[url path] UTF8String]);
-    jstring path = (*env)->NewStringUTF(env, [[url path] UTF8String]);
+#ifdef VERBOSE
+    NSLog(@"   url: %@", [url path]);
+#endif // VERBOSE
+    NSData *data = [[url path] dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+    jstring path = (*env)->NewString(env, (jchar *)[data bytes], data.length/2);
 
     jobject ret = NULL;
 


### PR DESCRIPTION
Reviewed-by: pbansal, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8210199](https://bugs.openjdk.java.net/browse/JDK-8210199): [linux / macOS] fileChooser can't handle emojis


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/24.diff">https://git.openjdk.java.net/jfx11u/pull/24.diff</a>

</details>
