### PR TITLE
8211308: Support HTTP/2 in WebView

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/ByteBufferPool.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/ByteBufferPool.java
@@ -112,6 +112,7 @@ final class ByteBufferPool {
          */
         @Override
         public void release(ByteBuffer byteBuffer) {
+            byteBuffer.clear();
             byteBuffers.add(byteBuffer);
             semaphore.release();
         }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.network;
+
+import com.sun.javafx.logging.PlatformLogger.Level;
+import com.sun.javafx.logging.PlatformLogger;
+import com.sun.javafx.tk.Toolkit;
+import com.sun.webkit.Invoker;
+import com.sun.webkit.LoadListenerClient;
+import com.sun.webkit.WebPage;
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Native;
+import java.net.ConnectException;
+import java.net.CookieHandler;
+import java.net.HttpRetryException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.ByteBuffer;
+import java.security.AccessControlException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+import javax.net.ssl.SSLHandshakeException;
+import static com.sun.webkit.network.URLs.newURL;
+import static java.net.http.HttpClient.Redirect;
+import static java.net.http.HttpClient.Version;
+import static java.net.http.HttpResponse.BodyHandlers;
+import static java.net.http.HttpResponse.BodySubscribers;
+
+final class HTTP2Loader extends URLLoaderBase {
+
+    private static final PlatformLogger logger =
+            PlatformLogger.getLogger(URLLoader.class.getName());
+
+    private final WebPage webPage;
+    private final boolean asynchronous;
+    private String url;
+    private String method;
+    private final String headers;
+    private FormDataElement[] formDataElements;
+    private final long data;
+    private volatile boolean canceled = false;
+
+    private final CompletableFuture<Void> response;
+    // Use singleton instance of HttpClient to get the maximum benefits
+    private final static HttpClient HTTP_CLIENT =
+        AccessController.doPrivileged((PrivilegedAction<HttpClient>) () -> HttpClient.newBuilder()
+                .version(Version.HTTP_2)  // this is the default
+                .followRedirects(Redirect.NEVER) // WebCore handles redirection
+                .connectTimeout(Duration.ofSeconds(30)) // FIXME: Add a property to control the timeout
+                .cookieHandler(CookieHandler.getDefault())
+                .build());
+    // Singleton instance of direct ByteBuffer to transfer downloaded bytes from
+    // Java to native
+    private static final int DEFAULT_BUFSIZE = 40 * 1024;
+    private final static ByteBuffer BUFFER;
+    static {
+       int bufSize  = AccessController.doPrivileged(
+                        (PrivilegedAction<Integer>) () ->
+                            Integer.valueOf(System.getProperty("jdk.httpclient.bufsize", Integer.toString(DEFAULT_BUFSIZE))));
+       BUFFER = ByteBuffer.allocateDirect(bufSize);
+    }
+
+    /**
+     * Creates a new {@code HTTP2Loader}.
+     */
+    static HTTP2Loader create(WebPage webPage,
+              ByteBufferPool byteBufferPool,
+              boolean asynchronous,
+              String url,
+              String method,
+              String headers,
+              FormDataElement[] formDataElements,
+              long data) {
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            return new HTTP2Loader(
+                webPage,
+                byteBufferPool,
+                asynchronous,
+                url,
+                method,
+                headers,
+                formDataElements,
+                data);
+        }
+        return null;
+    }
+
+    // following 2 methods can be generalized and keep a common
+    // implementation with URLLoader.java
+    private String[] getCustomHeaders() {
+        final var loc = Locale.getDefault();
+        String lang = "";
+        if (!loc.equals(Locale.US) && !loc.equals(Locale.ENGLISH)) {
+            lang = loc.getCountry().isEmpty() ?
+                loc.getLanguage() + ",":
+                loc.getLanguage() + "-" + loc.getCountry() + ",";
+        }
+
+        return new String[] { "Accept-Language", lang.toLowerCase() + "en-us;q=0.8,en;q=0.7",
+                              "Accept-Encoding", "gzip, inflate",
+                              "Accept-Charset", "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+        };
+    }
+
+    private String[] getRequestHeaders() {
+        return Arrays.stream(headers.split("\n"))
+                     .flatMap(s -> Stream.of(s.split(":", 2))) // split from first occurance of :
+                     .toArray(String[]::new);
+    }
+
+    private URI toURI() throws MalformedURLException {
+        URI uriObj;
+        try {
+            uriObj = new URI(this.url);
+        } catch(URISyntaxException | IllegalArgumentException e) {
+            // slow path
+            try {
+                var urlObj = newURL(this.url);
+                uriObj = new URI(
+                        urlObj.getProtocol(),
+                        urlObj.getUserInfo(),
+                        urlObj.getHost(),
+                        urlObj.getPort(),
+                        urlObj.getPath(),
+                        urlObj.getQuery(),
+                        urlObj.getRef());
+            } catch(URISyntaxException | MalformedURLException | IllegalArgumentException ex) {
+                throw new MalformedURLException(this.url);
+            }
+        }
+        return uriObj;
+    }
+
+    private HttpRequest.BodyPublisher getFormDataPublisher() {
+        if (this.formDataElements == null) {
+            return HttpRequest.BodyPublishers.noBody();
+        }
+
+        final var formDataElementsStream = new Vector<InputStream>();
+        final AtomicLong length = new AtomicLong();
+        for (final var formData : formDataElements) {
+            try {
+                formData.open();
+                length.addAndGet(formData.getSize());
+                formDataElementsStream.add(formData.getInputStream());
+            } catch(IOException ex) {
+                return null;
+            }
+        }
+
+        final var stream = new SequenceInputStream(formDataElementsStream.elements());
+        final var streamBodyPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> stream);
+        // Forwarding implementation to send didSendData notification
+        // to WebCore. Otherwise `formDataPublisher = streamBodyPublisher`
+        // can do the job.
+        final var formDataPublisher = new HttpRequest.BodyPublisher() {
+            @Override
+            public long contentLength() {
+                // streaming or fixed length
+                return length.longValue() <= Integer.MAX_VALUE ? length.longValue() : -1;
+            }
+
+            @Override
+            public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+                streamBodyPublisher.subscribe(new Flow.Subscriber<ByteBuffer>() {
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+
+                    @Override
+                    public void onError(Throwable th) {
+                        subscriber.onError(th);
+                    }
+
+                    @Override
+                    public void onNext(ByteBuffer bytes) {
+                        subscriber.onNext(bytes);
+                        didSendData(bytes.limit(), length.longValue());
+                    }
+
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {
+                        subscriber.onSubscribe(subscription);
+                    }
+                });
+            }
+        };
+        return formDataPublisher;
+    }
+
+    // InputStream based subscriber is used to handle gzip|inflate encoded body. Since InputStream based subscriber is costly interms
+    // of memory usage and thread usage, use only when response content-encoding is set to gzip|inflate.
+    // There will be 2 threads involved while reading data from InputStream provided by BodySubscriber.
+    //      1. The main worker which downloads HTTP data and writes to stream
+    //      2. Other worker which reads data from the InputStream(getBody.thenAcceptAsync)
+    // For the better efficiency, we should consider using java.util.zip.Inflater directly
+    // to deal with gzip and inflate encoded data.
+    private InputStream createZIPStream(final String type, InputStream in) throws IOException {
+        if ("gzip".equalsIgnoreCase(type))
+            return new GZIPInputStream(in);
+        else if ("deflate".equalsIgnoreCase(type))
+            return new InflaterInputStream(in);
+        return in;
+    }
+
+    private BodySubscriber<Void> createZIPEncodedBodySubscriber(final String contentEncoding) {
+        // Discard body if content type is unknown
+        if (!("gzip".equalsIgnoreCase(contentEncoding)
+                    || "inflate".equalsIgnoreCase(contentEncoding))) {
+            logger.severe(String.format("Unknown encoding type '%s' found, discarding", contentEncoding));
+            return BodySubscribers.discarding();
+        }
+
+        final BodySubscriber<InputStream> streamSubscriber = BodySubscribers.ofInputStream();
+        final CompletionStage<Void> unzipTask = streamSubscriber.getBody().thenAcceptAsync(is -> {
+            try (
+                // To AutoClose the InputStreams
+                final InputStream stream = is;
+                final InputStream in = createZIPStream(contentEncoding, stream);
+            ) {
+                while (!canceled) {
+                    // same as URLLoader.java
+                    final byte[] buf = new byte[8 * 1024];
+                    final int read = in.read(buf);
+                    if (read < 0) {
+                        didFinishLoading();
+                        break;
+                    }
+                    didReceiveData(buf, read);
+                }
+            } catch (IOException ex) {
+                didFail(ex);
+            }
+        });
+        return new BodySubscriber<Void>() {
+                @Override
+                public void onComplete() {
+                    streamSubscriber.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable th) {
+                    streamSubscriber.onError(th);
+                }
+
+                @Override
+                public void onNext(List<ByteBuffer> bytes) {
+                    streamSubscriber.onNext(bytes);
+                }
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    streamSubscriber.onSubscribe(subscription);
+                }
+
+                @Override
+                public CompletionStage<Void> getBody() {
+                    return streamSubscriber.getBody().thenCombine(unzipTask, (t, u) -> null);
+                }
+        };
+    }
+
+    // Normal plain body handler, simple, easy to use and pass data to downstream.
+    private BodySubscriber<Void> createNormalBodySubscriber() {
+        final BodySubscriber<Void> normalBodySubscriber = BodySubscribers.fromSubscriber(new Flow.Subscriber<List<ByteBuffer>>() {
+            private Flow.Subscription subscription;
+            private final AtomicBoolean subscribed = new AtomicBoolean();
+
+            @Override
+            public void onComplete() {
+                didFinishLoading();
+            }
+
+            @Override
+            public void onError(Throwable th) {}
+
+            @Override
+            public void onNext(final List<ByteBuffer> bytes) {
+                didReceiveData(bytes);
+                requestIfNotCancelled();
+            }
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                if (!subscribed.compareAndSet(false, true)) {
+                    subscription.cancel();
+                } else {
+                    this.subscription = subscription;
+                    requestIfNotCancelled();
+                }
+            }
+
+            private void requestIfNotCancelled() {
+                if (canceled) {
+                    subscription.cancel();
+                } else {
+                    subscription.request(1);
+                }
+            }
+        });
+        return normalBodySubscriber;
+    }
+
+    private BodySubscriber<Void> getBodySubscriber(final String contentEncoding) {
+        return contentEncoding.isEmpty() ?
+                  createNormalBodySubscriber() : createZIPEncodedBodySubscriber(contentEncoding);
+    }
+
+    private HTTP2Loader(WebPage webPage,
+              ByteBufferPool byteBufferPool,
+              boolean asynchronous,
+              String url,
+              String method,
+              String headers,
+              FormDataElement[] formDataElements,
+              long data)
+    {
+        this.webPage = webPage;
+        this.asynchronous = asynchronous;
+        this.url = url;
+        this.method = method;
+        this.headers = headers;
+        this.formDataElements = formDataElements;
+        this.data = data;
+
+        URI uri;
+        try {
+            uri = toURI();
+        } catch(MalformedURLException e) {
+            this.response = null;
+            didFail(e);
+            return;
+        }
+
+        final var request = HttpRequest.newBuilder()
+                               .uri(uri)
+                               .headers(getRequestHeaders()) // headers from WebCore
+                               .headers(getCustomHeaders()) // headers set by us
+                               .version(Version.HTTP_2)  // this is the default
+                               .method(method, getFormDataPublisher())
+                               .build();
+
+        final BodyHandler<Void> bodyHandler = rsp -> {
+            if(!handleRedirectionIfNeeded(rsp)) {
+                didReceiveResponse(rsp);
+            }
+            return getBodySubscriber(getContentEncoding(rsp));
+        };
+
+        // Run the HttpClient in the page's access control context
+        this.response = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
+            return HTTP_CLIENT.sendAsync(request, bodyHandler)
+                              .thenAccept($ -> {})
+                              .exceptionally(ex -> didFail(ex.getCause()));
+        }, webPage.getAccessControlContext());
+
+        if (!asynchronous) {
+            waitForRequestToComplete();
+        }
+    }
+
+    /**
+     * Cancels this loader.
+     */
+    @Override
+    public void fwkCancel() {
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format("data: [0x%016X]", data));
+        }
+        canceled = true;
+    }
+
+    private void callBackIfNotCanceled(final Runnable r) {
+        Invoker.getInvoker().invokeOnEventThread(() -> {
+            if (!canceled) {
+                r.run();
+            }
+        });
+    }
+
+    private void waitForRequestToComplete() {
+        // Wait for the response using nested event loop. Once the response
+        // arrives, nested event loop will be terminated.
+        final Object key = new Object();
+        this.response.handle((r, th) -> {
+            Invoker.getInvoker().invokeOnEventThread(() ->
+                Toolkit.getToolkit().exitNestedEventLoop(key, null));
+            return null;
+        });
+        Toolkit.getToolkit().enterNestedEventLoop(key);
+        // No need to join, nested event loop takes care of
+        // blocking the caller until response arrives.
+        // this.response.join();
+    }
+
+    private boolean handleRedirectionIfNeeded(final HttpResponse.ResponseInfo rsp) {
+        switch(rsp.statusCode()) {
+                case 301: // Moved Permanently
+                case 302: // Found
+                case 303: // See Other
+                case 307: // Temporary Redirect
+                    willSendRequest(rsp);
+                    return true;
+
+                case 304: // Not Modified
+                    didReceiveResponse(rsp);
+                    didFinishLoading();
+                    return true;
+        }
+        return false;
+    }
+
+    private static long getContentLength(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValueAsLong("content-length").orElse(-1);
+    }
+
+    private static String getContentType(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValue("content-type").orElse("application/octet-stream");
+    }
+
+    private static String getContentEncoding(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValue("content-encoding").orElse("");
+    }
+
+    private static String getHeadersAsString(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers()
+                  .map()
+                  .entrySet()
+                  .stream()
+                  .map(e -> String.format("%s:%s", e.getKey(), e.getValue().stream().collect(Collectors.joining(","))))
+                  .collect(Collectors.joining("\n")) + "\n";
+    }
+
+    private void willSendRequest(final HttpResponse.ResponseInfo rsp) {
+        callBackIfNotCanceled(() -> {
+            twkWillSendRequest(
+                    rsp.statusCode(),
+                    getContentType(rsp),
+                    "",
+                    getContentLength(rsp),
+                    getHeadersAsString(rsp),
+                    this.url,
+                    data);
+        });
+    }
+
+    private void didReceiveResponse(final HttpResponse.ResponseInfo rsp) {
+        callBackIfNotCanceled(() -> {
+            twkDidReceiveResponse(
+                    rsp.statusCode(),
+                    getContentType(rsp),
+                    "",
+                    getContentLength(rsp),
+                    getHeadersAsString(rsp),
+                    this.url,
+                    data);
+        });
+    }
+
+    private ByteBuffer getDirectBuffer(int size) {
+        ByteBuffer dbb = BUFFER;
+        // Though the chance of reaching here is rare, handle the
+        // case by allocating a tmp direct buffer.
+        if (size > dbb.capacity()) {
+            dbb = ByteBuffer.allocateDirect(size);
+        }
+        return dbb.clear();
+    }
+
+    private ByteBuffer copyToDirectBuffer(final ByteBuffer bb) {
+        return getDirectBuffer(bb.limit()).put(bb).flip();
+    }
+
+    // another variant to use from createZIPEncodedBodySubscriber
+    private void didReceiveData(final byte[] bytes, int size) {
+        callBackIfNotCanceled(() -> {
+            notifyDidReceiveData(getDirectBuffer(size).put(bytes, 0, size).flip());
+        });
+    }
+
+    private void didReceiveData(final List<ByteBuffer> bytes) {
+        callBackIfNotCanceled(() -> bytes.stream()
+                                          .map(this::copyToDirectBuffer)
+                                          .forEach(this::notifyDidReceiveData)
+        );
+    }
+
+    private void notifyDidReceiveData(ByteBuffer byteBuffer) {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "byteBuffer: [%s], "
+                    + "position: [%s], "
+                    + "remaining: [%s], "
+                    + "data: [0x%016X]",
+                    byteBuffer,
+                    byteBuffer.position(),
+                    byteBuffer.remaining(),
+                    data));
+        }
+        twkDidReceiveData(byteBuffer, byteBuffer.position(), byteBuffer.remaining(), data);
+    }
+
+    private void didFinishLoading() {
+        callBackIfNotCanceled(this::notifyDidFinishLoading);
+    }
+
+    private void notifyDidFinishLoading() {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format("data: [0x%016X]", data));
+        }
+        twkDidFinishLoading(data);
+    }
+
+
+    private Void didFail(final Throwable th) {
+        callBackIfNotCanceled(() ->  {
+            // FIXME: simply copied from URLLoader.java, it should be
+            // retwritten using if..else rather than throw.
+            int errorCode;
+            try {
+                throw th;
+            } catch (MalformedURLException ex) {
+                errorCode = LoadListenerClient.MALFORMED_URL;
+            } catch (AccessControlException ex) {
+                errorCode = LoadListenerClient.PERMISSION_DENIED;
+            } catch (UnknownHostException ex) {
+                errorCode = LoadListenerClient.UNKNOWN_HOST;
+            } catch (NoRouteToHostException ex) {
+                errorCode = LoadListenerClient.NO_ROUTE_TO_HOST;
+            } catch (ConnectException ex) {
+                errorCode = LoadListenerClient.CONNECTION_REFUSED;
+            } catch (SocketException ex) {
+                errorCode = LoadListenerClient.CONNECTION_RESET;
+            } catch (SSLHandshakeException ex) {
+                errorCode = LoadListenerClient.SSL_HANDSHAKE;
+            } catch (SocketTimeoutException | HttpTimeoutException ex) {
+                errorCode = LoadListenerClient.CONNECTION_TIMED_OUT;
+            } catch (FileNotFoundException ex) {
+                errorCode = LoadListenerClient.FILE_NOT_FOUND;
+            } catch (Throwable ex) {
+                errorCode = LoadListenerClient.UNKNOWN_ERROR;
+            }
+            notifyDidFail(errorCode, url, th.getMessage());
+        });
+        return null;
+    }
+
+    private void notifyDidFail(int errorCode, String url, String message) {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "errorCode: [%d], "
+                    + "url: [%s], "
+                    + "message: [%s], "
+                    + "data: [0x%016X]",
+                    errorCode,
+                    url,
+                    message,
+                    data));
+        }
+        twkDidFail(errorCode, url, message, data);
+    }
+
+    private void didSendData(final long totalBytesSent,
+                             final long totalBytesToBeSent)
+    {
+        callBackIfNotCanceled(() -> notifyDidSendData(totalBytesSent, totalBytesToBeSent));
+    }
+
+    private void notifyDidSendData(long totalBytesSent,
+                                   long totalBytesToBeSent)
+    {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "totalBytesSent: [%d], "
+                    + "totalBytesToBeSent: [%d], "
+                    + "data: [0x%016X]",
+                    totalBytesSent,
+                    totalBytesToBeSent,
+                    data));
+        }
+        twkDidSendData(totalBytesSent, totalBytesToBeSent, data);
+    }
+}

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoaderBase.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoaderBase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.network;
+
+import java.lang.annotation.Native;
+import java.nio.ByteBuffer;
+
+abstract class URLLoaderBase {
+    @Native public static final int ALLOW_UNASSIGNED = java.net.IDN.ALLOW_UNASSIGNED;
+
+    /**
+     * Cancels the loader.
+     */
+    protected abstract void fwkCancel();
+
+    protected static native void twkDidSendData(long totalBytesSent,
+                                              long totalBytesToBeSent,
+                                              long data);
+
+    protected static native void twkWillSendRequest(int status,
+                                                     String contentType,
+                                                     String contentEncoding,
+                                                     long contentLength,
+                                                     String headers,
+                                                     String url,
+                                                     long data);
+
+    protected static native void twkDidReceiveResponse(int status,
+                                                     String contentType,
+                                                     String contentEncoding,
+                                                     long contentLength,
+                                                     String headers,
+                                                     String url,
+                                                     long data);
+
+    protected static native void twkDidReceiveData(ByteBuffer byteBuffer,
+                                                 int position,
+                                                 int remaining,
+                                                 long data);
+
+    protected static native void twkDidFinishLoading(long data);
+
+    protected static native void twkDidFail(int errorCode,
+                                          String url,
+                                          String message,
+                                          long data);
+
+}

--- a/modules/javafx.web/src/main/java/module-info.java
+++ b/modules/javafx.web/src/main/java/module-info.java
@@ -32,9 +32,10 @@
  */
 module javafx.web {
     requires java.desktop;
+    requires java.net.http;
     requires javafx.media;
-    requires jdk.xml.dom;
     requires jdk.jsobject;
+    requires jdk.xml.dom;
 
     requires transitive java.xml;
     requires transitive javafx.base;

--- a/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
@@ -1791,9 +1791,9 @@
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidFail
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidOpen
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidReceiveData
-               _Java_com_sun_webkit_network_URLLoader_twkDidFail
-               _Java_com_sun_webkit_network_URLLoader_twkDidFinishLoading
-               _Java_com_sun_webkit_network_URLLoader_twkDidReceiveData
-               _Java_com_sun_webkit_network_URLLoader_twkDidReceiveResponse
-               _Java_com_sun_webkit_network_URLLoader_twkDidSendData
-               _Java_com_sun_webkit_network_URLLoader_twkWillSendRequest
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidFail
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveResponse
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidSendData
+               _Java_com_sun_webkit_network_URLLoaderBase_twkWillSendRequest

--- a/modules/javafx.web/src/main/native/Source/WebCore/mapfile-vers
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mapfile-vers
@@ -1983,12 +1983,12 @@ SUNWprivate_1.0 {
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidFail;
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidOpen;
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidReceiveData;
-               Java_com_sun_webkit_network_URLLoader_twkDidFail;
-               Java_com_sun_webkit_network_URLLoader_twkDidFinishLoading;
-               Java_com_sun_webkit_network_URLLoader_twkDidReceiveData;
-               Java_com_sun_webkit_network_URLLoader_twkDidReceiveResponse;
-               Java_com_sun_webkit_network_URLLoader_twkDidSendData;
-               Java_com_sun_webkit_network_URLLoader_twkWillSendRequest;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidFail;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveResponse;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidSendData;
+               Java_com_sun_webkit_network_URLLoaderBase_twkWillSendRequest;
                kJSClassDefinitionEmpty;
         local:
                 *;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/IDNJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/IDNJava.cpp
@@ -25,8 +25,8 @@
 
 #include "config.h"
 #include "IDNJava.h"
-#include "PlatformJavaClasses.h"
-#include "com_sun_webkit_network_URLLoader.h"
+#include <wtf/java/JavaEnv.h>
+#include "com_sun_webkit_network_URLLoaderBase.h"
 
 namespace IDNJavaInternal {
 
@@ -62,9 +62,8 @@ String toASCII(const String& hostname)
             idnClass,
             toASCIIMID,
             (jstring)hostname.toJavaString(env),
-            com_sun_webkit_network_URLLoader_ALLOW_UNASSIGNED));
+            com_sun_webkit_network_URLLoaderBase_ALLOW_UNASSIGNED));
     WTF::CheckAndClearException(env);
-
     return String(env, result);
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
@@ -102,6 +102,11 @@ public:
     void willSendRequest(ResourceRequest&&, ResourceResponse&&, CompletionHandler<void(ResourceRequest&&)>&&);
 #endif
 
+#if PLATFORM(JAVA)
+    void continueAfterWillSendRequest(ResourceRequest&& request);
+    void willSendRequest(const ResourceResponse& response);
+#endif
+
     void didReceiveResponse(ResourceResponse&&, CompletionHandler<void()>&&);
 
     bool shouldUseCredentialStorage();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -138,6 +138,7 @@ public:
 
 #if PLATFORM(JAVA)
     std::unique_ptr<URLLoader> m_loader;
+    int m_redirectCount { 0 };
 #endif
 
 #if PLATFORM(COCOA)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceHandleJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/ResourceHandleJava.cpp
@@ -3,10 +3,12 @@
  */
 
 #include "config.h"
+
+#include <wtf/CompletionHandler.h>
+#include "NotImplemented.h"
 #include "ResourceHandle.h"
 #include "ResourceHandleInternal.h"
-
-#include "NotImplemented.h"
+#include "com_sun_webkit_LoadListenerClient.h"
 
 namespace WebCore {
 
@@ -21,7 +23,7 @@ ResourceHandle::~ResourceHandle()
 bool ResourceHandle::start()
 {
     ASSERT(!d->m_loader);
-    d->m_loader = URLLoader::loadAsynchronously(context(), this);
+    d->m_loader = URLLoader::loadAsynchronously(context(), this, this->firstRequest());
     return d->m_loader != nullptr;
 }
 
@@ -29,7 +31,103 @@ void ResourceHandle::cancel()
 {
     if (d->m_loader) {
         d->m_loader->cancel();
+        d->m_loader.reset();
     }
+}
+
+static bool shouldRedirectAsGET(const ResourceRequest& request, const ResourceResponse& response, bool crossOrigin)
+{
+    if (request.httpMethod() == "GET" || request.httpMethod() == "HEAD")
+        return false;
+
+    if (!request.url().protocolIsInHTTPFamily())
+        return true;
+
+    if (response.isSeeOther())
+        return true;
+
+    if ((response.isMovedPermanently() || response.isFound()) && (request.httpMethod() == "POST"))
+        return true;
+
+    if (crossOrigin && (request.httpMethod() == "DELETE"))
+        return true;
+
+    return false;
+}
+
+void ResourceHandle::willSendRequest(const ResourceResponse& response)
+{
+    ASSERT(isMainThread());
+
+    ResourceRequest request = firstRequest();
+
+    static const int maxRedirects = 20;
+    if (d->m_redirectCount++ > maxRedirects) {
+        client()->didFail(this, ResourceError(
+            String(),
+            com_sun_webkit_LoadListenerClient_TOO_MANY_REDIRECTS,
+            request.url(),
+            "Illegal redirect"));
+        return;
+    }
+
+    if (response.httpStatusCode() == 307) {
+        String lastHTTPMethod = d->m_lastHTTPMethod;
+        if (!equalIgnoringASCIICase(lastHTTPMethod, request.httpMethod())) {
+            request.setHTTPMethod(lastHTTPMethod);
+
+            FormData* body = d->m_firstRequest.httpBody();
+            if (!equalLettersIgnoringASCIICase(lastHTTPMethod, "get") && body && !body->isEmpty())
+                request.setHTTPBody(body);
+
+            String originalContentType = d->m_firstRequest.httpContentType();
+            if (!originalContentType.isEmpty())
+                request.setHTTPHeaderField(HTTPHeaderName::ContentType, originalContentType);
+        }
+    }
+
+    String location = response.httpHeaderField(HTTPHeaderName::Location);
+    URL newURL = URL(response.url(), location);
+    bool crossOrigin = !protocolHostAndPortAreEqual(request.url(), newURL);
+
+    ResourceRequest newRequest = request;
+    newRequest.setURL(newURL);
+
+    if (shouldRedirectAsGET(newRequest, response, crossOrigin)) {
+        newRequest.setHTTPMethod("GET");
+        newRequest.setHTTPBody(nullptr);
+        newRequest.clearHTTPContentType();
+    }
+
+    if (crossOrigin) {
+        // If the network layer carries over authentication headers from the original request
+        // in a cross-origin redirect, we want to clear those headers here.
+        newRequest.clearHTTPAuthorization();
+        newRequest.clearHTTPOrigin();
+    }
+
+    // Should not set Referer after a redirect from a secure resource to non-secure one.
+    if (!newURL.protocolIs("https") && protocolIs(newRequest.httpReferrer(), "https") && context()->shouldClearReferrerOnHTTPSToHTTPRedirect())
+        newRequest.clearHTTPReferrer();
+
+    client()->willSendRequestAsync(this, WTFMove(newRequest), ResourceResponse(response), [this, protectedThis = makeRef(*this)] (ResourceRequest&& request) {
+        continueAfterWillSendRequest(WTFMove(request));
+    });
+}
+
+void ResourceHandle::continueAfterWillSendRequest(ResourceRequest&& request)
+{
+    ASSERT(isMainThread());
+
+    // willSendRequest might cancel the load.
+    if (!d->m_loader || !client())
+        return;
+
+    cancel();
+    if (request.isNull()) {
+        return;
+    }
+    d->m_loader = URLLoader::loadAsynchronously(context(), this, request);
 }
 
 //utatodo: merge artifact
@@ -42,7 +140,6 @@ void ResourceHandle::platformLoadResourceSynchronously(NetworkingContext* contex
 {
     URLLoader::loadSynchronously(context, request, error, response, data);
 }
-
 
 void ResourceHandle::platformSetDefersLoading(bool)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.cpp
@@ -43,7 +43,7 @@
 #include "ResourceResponse.h"
 #include "URLLoader.h"
 #include "com_sun_webkit_LoadListenerClient.h"
-#include "com_sun_webkit_network_URLLoader.h"
+#include "com_sun_webkit_network_URLLoaderBase.h"
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
@@ -77,12 +77,12 @@ static void initRefs(JNIEnv* env)
                 "(Lcom/sun/webkit/WebPage;Z"
                 "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
                 "[Lcom/sun/webkit/network/FormDataElement;J)"
-                "Lcom/sun/webkit/network/URLLoader;");
+                "Lcom/sun/webkit/network/URLLoaderBase;");
         ASSERT(loadMethod);
     }
     if (!urlLoaderClass) {
         urlLoaderClass = JLClass(env->FindClass(
-                "com/sun/webkit/network/URLLoader"));
+                "com/sun/webkit/network/URLLoaderBase"));
         ASSERT(urlLoaderClass);
 
         cancelMethod = env->GetMethodID(urlLoaderClass, "fwkCancel", "()V");
@@ -108,25 +108,6 @@ static void initRefs(JNIEnv* env)
     }
 }
 
-static bool shouldRedirectAsGET(const ResourceRequest& request, const ResourceResponse& response, bool crossOrigin)
-{
-    if (request.httpMethod() == "GET" || request.httpMethod() == "HEAD")
-        return false;
-
-    if (!request.url().protocolIsInHTTPFamily())
-        return true;
-
-    if (response.isSeeOther())
-        return true;
-
-    if ((response.isMovedPermanently() || response.isFound()) && (request.httpMethod() == "POST"))
-        return true;
-
-    if (crossOrigin && (request.httpMethod() == "DELETE"))
-        return true;
-
-    return false;
-}
 }
 
 URLLoader::URLLoader()
@@ -139,14 +120,15 @@ URLLoader::~URLLoader()
 }
 
 std::unique_ptr<URLLoader> URLLoader::loadAsynchronously(NetworkingContext* context,
-                                                    ResourceHandle* handle)
+                                                    ResourceHandle* handle,
+                                                    const ResourceRequest& request)
 {
     std::unique_ptr<URLLoader> result = std::unique_ptr<URLLoader>(new URLLoader());
     result->m_target = std::unique_ptr<AsynchronousTarget>(new AsynchronousTarget(handle));
     result->m_ref = load(
             true,
             context,
-            handle->firstRequest(),
+            request,
             result->m_target.get());
     return result;
 }
@@ -198,15 +180,10 @@ JLObject URLLoader::load(bool asynchronous,
     ASSERT(webPage);
 
     String headerString;
-    const HTTPHeaderMap& headerMap = request.httpHeaderFields();
-    for (
-        HTTPHeaderMap::const_iterator it = headerMap.begin();
-        headerMap.end() != it;
-        ++it)
-    {
-        headerString.append(it->key);
+    for (const auto& header : request.httpHeaderFields()) {
+        headerString.append(header.key);
         headerString.append(": ");
-        headerString.append(it->value);
+        headerString.append(header.value);
         headerString.append("\n");
     }
 
@@ -304,39 +281,10 @@ void URLLoader::AsynchronousTarget::didSendData(long totalBytesSent,
 }
 
 
-bool URLLoader::AsynchronousTarget::willSendRequest(
-        const String& newUrl,
-        const String& newMethod,
-        const ResourceResponse& response)
+bool URLLoader::AsynchronousTarget::willSendRequest(const ResourceResponse& response)
 {
-    using namespace URLLoaderJavaInternal;
-    ASSERT(isMainThread());
-    ResourceHandleClient* client = m_handle->client();
-    if (client) {
-        ResourceRequest request = m_handle->firstRequest();
-        String location = response.httpHeaderField(HTTPHeaderName::Location);
-        URL newURL = URL(URL(), newUrl);
-        bool crossOrigin = !protocolHostAndPortAreEqual(request.url(), newURL);
-
-        ResourceRequest newRequest = request;
-        newRequest.setURL(newURL);
-
-        if (shouldRedirectAsGET(newRequest, response, crossOrigin)) {
-            newRequest.setHTTPMethod("GET");
-            newRequest.setHTTPBody(nullptr);
-            newRequest.clearHTTPContentType();
-        } else {
-            newRequest.setHTTPMethod(newMethod);
-        }
-
-        // Should not set Referer after a redirect from a secure resource to non-secure one.
-        if (!newURL.protocolIs("https") && protocolIs(newRequest.httpReferrer(), "https") && m_handle->context()->shouldClearReferrerOnHTTPSToHTTPRedirect())
-            newRequest.clearHTTPReferrer();
-
-        client->willSendRequestAsync(m_handle, WTFMove(newRequest), ResourceResponse(response), [] (ResourceRequest&&) {
-        });
-    }
-    return true;
+    m_handle->willSendRequest(response);
+    return false;
 }
 
 void URLLoader::AsynchronousTarget::didReceiveResponse(
@@ -344,8 +292,7 @@ void URLLoader::AsynchronousTarget::didReceiveResponse(
 {
     ResourceHandleClient* client = m_handle->client();
     if (client) {
-        client->didReceiveResponseAsync(m_handle, ResourceResponse(response), [] () {
-        });
+        client->didReceiveResponseAsync(m_handle, ResourceResponse(response), [] () {});
     }
 }
 
@@ -389,15 +336,14 @@ void URLLoader::SynchronousTarget::didSendData(long, long)
 {
 }
 
-bool URLLoader::SynchronousTarget::willSendRequest(
-        const String& newUrl,
-        const String&,
-        const ResourceResponse&)
+bool URLLoader::SynchronousTarget::willSendRequest(const ResourceResponse& response)
 {
     // The following code was adapted from the Windows port
     // FIXME: This needs to be fixed to follow redirects correctly even
     // for cross-domain requests
-    if (!protocolHostAndPortAreEqual(m_request.url(), URL(URL(), newUrl))) {
+    String location = response.httpHeaderField(HTTPHeaderName::Location);
+    URL newURL = URL(response.url(), location);
+    if (!protocolHostAndPortAreEqual(m_request.url(), newURL)) {
         didFail(ResourceError(
                 String(),
                 com_sun_webkit_LoadListenerClient_INVALID_RESPONSE,
@@ -431,14 +377,7 @@ void URLLoader::SynchronousTarget::didFail(const ResourceError& error)
 
 } // namespace WebCore
 
-using namespace WebCore;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-static void setupResponse(ResourceResponse& response,
-                          JNIEnv* env,
+static WebCore::ResourceResponse setupResponse(JNIEnv* env,
                           jint status,
                           jstring contentType,
                           jstring contentEncoding,
@@ -446,6 +385,9 @@ static void setupResponse(ResourceResponse& response,
                           jstring headers,
                           jstring url)
 {
+    using namespace WebCore;
+    ResourceResponse response { };
+
     if (status > 0) {
         response.setHTTPStatusCode(status);
     }
@@ -496,29 +438,30 @@ static void setupResponse(ResourceResponse& response,
     if (/*kurl.hasPath()*/kurl.pathEnd() != kurl.pathStart() && kurl.protocol() == String("file")) {
         response.setMimeType(MIMETypeRegistry::mimeTypeForPath(kurl.path().toString()));
     }
+    return response;
 }
 
-JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidSendData
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkDidSendData
   (JNIEnv*, jclass, jlong totalBytesSent, jlong totalBytesToBeSent, jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
     target->didSendData(totalBytesSent, totalBytesToBeSent);
 }
 
-JNIEXPORT jboolean JNICALL Java_com_sun_webkit_network_URLLoader_twkWillSendRequest
-  (JNIEnv* env, jclass, jstring newUrl, jstring newMethod, jint status,
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkWillSendRequest
+  (JNIEnv* env, jclass, jint status,
    jstring contentType, jstring contentEncoding, jlong contentLength,
    jstring headers, jstring url, jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
 
-    ResourceResponse response;
-    setupResponse(
-            response,
+    ResourceResponse response = setupResponse(
             env,
             status,
             contentType,
@@ -527,24 +470,20 @@ JNIEXPORT jboolean JNICALL Java_com_sun_webkit_network_URLLoader_twkWillSendRequ
             headers,
             url);
 
-    return bool_to_jbool(target->willSendRequest(
-            String(env, newUrl),
-            String(env, newMethod),
-            response));
+    target->willSendRequest(response);
 }
 
-JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidReceiveResponse
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveResponse
   (JNIEnv* env, jclass, jint status, jstring contentType,
    jstring contentEncoding, jlong contentLength, jstring headers,
    jstring url, jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
 
-    ResourceResponse response;
-    setupResponse(
-            response,
+    ResourceResponse response = setupResponse(
             env,
             status,
             contentType,
@@ -556,10 +495,11 @@ JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidReceiveRespon
     target->didReceiveResponse(response);
 }
 
-JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidReceiveData
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData
   (JNIEnv* env, jclass, jobject byteBuffer, jint position, jint remaining,
    jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
@@ -568,19 +508,21 @@ JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidReceiveData
     target->didReceiveData(address + position, remaining);
 }
 
-JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidFinishLoading
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading
   (JNIEnv*, jclass, jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
     target->didFinishLoading();
 }
 
-JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidFail
+JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoaderBase_twkDidFail
   (JNIEnv* env, jclass, jint errorCode, jstring url, jstring message,
    jlong data)
 {
+    using namespace WebCore;
     URLLoader::Target* target =
             static_cast<URLLoader::Target*>(jlong_to_ptr(data));
     ASSERT(target);
@@ -590,7 +532,3 @@ JNIEXPORT void JNICALL Java_com_sun_webkit_network_URLLoader_twkDidFail
             URL(env, url),
             String(env, message)));
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.h
@@ -20,7 +20,8 @@ class ResourceResponse;
 class URLLoader {
 public:
     static std::unique_ptr<URLLoader> loadAsynchronously(NetworkingContext* context,
-                                                    ResourceHandle* handle);
+                                                    ResourceHandle* handle,
+                                                    const ResourceRequest& request);
     void cancel();
     static void loadSynchronously(NetworkingContext* context,
                                   const ResourceRequest& request,
@@ -33,9 +34,7 @@ public:
     public:
         virtual void didSendData(long totalBytesSent,
                                  long totalBytesToBeSent) = 0;
-        virtual bool willSendRequest(const String& newUrl,
-                                     const String& newMethod,
-                                     const ResourceResponse& response) = 0;
+        virtual bool willSendRequest(const ResourceResponse& response) = 0;
         virtual void didReceiveResponse(const ResourceResponse& response) = 0;
         virtual void didReceiveData(const char* data, int length) = 0;
         virtual void didFinishLoading() = 0;
@@ -57,9 +56,7 @@ private:
         AsynchronousTarget(ResourceHandle* handle);
 
         void didSendData(long totalBytesSent, long totalBytesToBeSent) final;
-        bool willSendRequest(const String& newUrl,
-                             const String& newMethod,
-                             const ResourceResponse& response) final;
+        bool willSendRequest(const ResourceResponse& response) final;
         void didReceiveResponse(const ResourceResponse& response) final;
         void didReceiveData(const char* data, int length) final;
         void didFinishLoading() final;
@@ -76,9 +73,7 @@ private:
                           Vector<char>& data);
 
         void didSendData(long totalBytesSent, long totalBytesToBeSent) final;
-        bool willSendRequest(const String& newUrl,
-                             const String& newMethod,
-                             const ResourceResponse& response) final;
+        bool willSendRequest(const ResourceResponse& response) final;
         void didReceiveResponse(const ResourceResponse& response) final;
         void didReceiveData(const char* data, int length) final;
         void didFinishLoading() final;


### PR DESCRIPTION
Clean backport of HTTP/2. This is enabled by default only with running with JDK 12 or later.

I have tested this with both JDK 11, where I verified that it HTTP/2 is not enabled, and JDK 15, where I verified that it HTTP/2 is enabled.

As an FYI, I tested this patch in my [test-kcr-11.0.13](https://github.com/kevinrushforth/jfx11u/tree/test-kcr-11.0.13) branch, which has the aggregate set of patches for the following bugs: [JDK-8211308](https://bugs.openjdk.java.net/browse/JDK-8211308), [JDK-8268915](https://bugs.openjdk.java.net/browse/JDK-8268915), [JDK-8269147](https://bugs.openjdk.java.net/browse/JDK-8269147), [JDK-8269131](https://bugs.openjdk.java.net/browse/JDK-8269131), [JDK-8268849](https://bugs.openjdk.java.net/browse/JDK-8268849), [JDK-8270479](https://bugs.openjdk.java.net/browse/JDK-8270479), [JDK-8272329](https://bugs.openjdk.java.net/browse/JDK-8272329).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211308](https://bugs.openjdk.java.net/browse/JDK-8211308): Support HTTP/2 in WebView


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/30.diff">https://git.openjdk.java.net/jfx11u/pull/30.diff</a>

</details>
