### PR TITLE
8270479: WebKit 612.1 build fails with Visual Studio 2017

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2695,6 +2695,15 @@ static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
     return false;
 }
 
+#if PLATFORM(JAVA)
+// VS 2017 has buggy support for compile-time inline constants, so they
+// are defined here as runtime constants
+const PartialOrdering PartialOrdering::less(Type::Less);
+const PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
+const PartialOrdering PartialOrdering::greater(Type::Greater);
+const PartialOrdering PartialOrdering::unordered(Type::Unordered);
+#endif
+
 template<TreeType treeType> PartialOrdering treeOrder(const Node& a, const Node& b)
 {
     if (&a == &b)

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
@@ -941,10 +941,15 @@ inline void Node::addInclusiveAncestorState(AncestorState state)
     }
 }
 
+#if PLATFORM(JAVA)
+// VS 2017 has buggy support for compile-time inline constants, so the
+// definitions are moved to Node.cpp
+#else
 inline constexpr PartialOrdering PartialOrdering::less(Type::Less);
 inline constexpr PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
 inline constexpr PartialOrdering PartialOrdering::greater(Type::Greater);
 inline constexpr PartialOrdering PartialOrdering::unordered(Type::Unordered);
+#endif
 
 constexpr bool is_eq(PartialOrdering ordering)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1195,8 +1195,15 @@ void InspectorOverlay::drawLayoutLabel(GraphicsContext& context, String label, F
     FontCascade font(WTFMove(fontDescription), 0, 0);
     font.update(nullptr);
 
+#if PLATFORM(JAVA)
+    // VS2017 complains if these are not defined as float constants (which they
+    // really should be anyway)
+    constexpr auto padding = 4.0f;
+    constexpr auto arrowSize = 4.0f;
+#else
     constexpr auto padding = 4;
     constexpr auto arrowSize = 4;
+#endif
     float textHeight = font.fontMetrics().floatHeight();
     float textDescent = font.fontMetrics().floatDescent();
 


### PR DESCRIPTION
Clean backport of the fix to allow WebKit to continue to build with VS 2017, as a follow-on to the WebKit 612.1 update, so it is based off that branch. Once PR #34 is integrated, I will rebase this branch on top of `master` (to pick up that fix), and take this out of Draft state.

As an FYI, I tested this patch in my [test-kcr-11.0.13](https://github.com/kevinrushforth/jfx11u/tree/test-kcr-11.0.13) branch, which has the aggregate set of patches for the following bugs: [JDK-8211308](https://bugs.openjdk.java.net/browse/JDK-8211308), [JDK-8268915](https://bugs.openjdk.java.net/browse/JDK-8268915), [JDK-8269147](https://bugs.openjdk.java.net/browse/JDK-8269147), [JDK-8269131](https://bugs.openjdk.java.net/browse/JDK-8269131), [JDK-8268849](https://bugs.openjdk.java.net/browse/JDK-8268849), [JDK-8270479](https://bugs.openjdk.java.net/browse/JDK-8270479), [JDK-8272329](https://bugs.openjdk.java.net/browse/JDK-8272329).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270479](https://bugs.openjdk.java.net/browse/JDK-8270479): WebKit 612.1 build fails with Visual Studio 2017


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/35.diff">https://git.openjdk.java.net/jfx11u/pull/35.diff</a>

</details>
