### PR TITLE
8264737: JavaFX media stream stops playing after reconnecting via Remote Desktop

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef GSTREAMER_LITE
+
+#include "gstdirectsoundnotify.h"
+
+void* InitNotificator(GSTDSNotfierCallback pCallback, void *pData) {
+  GSTDirectSoundNotify *pNotify = new GSTDirectSoundNotify();
+  if (pNotify != NULL) {
+    if (pNotify->Init(pCallback, pData)) {
+      return (void*)pNotify;
+    } else {
+      pNotify->Release();
+    }
+  }
+
+  return NULL;
+}
+
+void ReleaseNotificator(void *pObject) {
+  GSTDirectSoundNotify *pNotify = (GSTDirectSoundNotify*)pObject;
+  if (pNotify) {
+    pNotify->Dispose();
+    pNotify->Release();
+  }
+}
+
+bool GSTDirectSoundNotify::Init(GSTDSNotfierCallback pCallback, void *pData) {
+  m_pCallback = pCallback;
+  m_pData = pData;
+
+  HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator),
+                                NULL,
+                                CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&m_pEnumerator));
+  if (SUCCEEDED(hr)) {
+    hr = m_pEnumerator->RegisterEndpointNotificationCallback(this);
+    if (SUCCEEDED(hr)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void GSTDirectSoundNotify::Dispose() {
+  if (m_pEnumerator) {
+    m_pEnumerator->UnregisterEndpointNotificationCallback(this);
+    m_pEnumerator->Release();
+  }
+}
+
+GSTDirectSoundNotify::GSTDirectSoundNotify() {
+  m_cRef = 1;
+  m_pEnumerator = NULL;
+  m_pCallback = NULL;
+  m_pData = NULL;
+  m_hrCoInit = CoInitialize(NULL);
+}
+
+GSTDirectSoundNotify::~GSTDirectSoundNotify() {
+  if (SUCCEEDED(m_hrCoInit)) {
+    CoUninitialize();
+  }
+}
+
+HRESULT GSTDirectSoundNotify::OnDefaultDeviceChanged(EDataFlow flow,
+                                                     ERole role,
+                                                     LPCWSTR pwstrDefaultDeviceId) {
+  if (flow == eRender && pwstrDefaultDeviceId != NULL) {
+    if (m_pCallback && m_pData) {
+      m_pCallback(m_pData);
+    }
+  }
+
+  // return value of this callback is ignored
+  return S_OK;
+}
+
+//  IUnknown methods
+HRESULT GSTDirectSoundNotify::QueryInterface(REFIID iid, void** ppUnk) {
+  if ((iid == __uuidof(IUnknown)) ||
+      (iid == __uuidof(IMMNotificationClient))) {
+    *ppUnk = static_cast<IMMNotificationClient*>(this);
+  } else {
+    *ppUnk = NULL;
+    return E_NOINTERFACE;
+  }
+
+  AddRef();
+
+ return S_OK;
+}
+
+ULONG GSTDirectSoundNotify::AddRef() {
+  return InterlockedIncrement(&m_cRef);
+}
+
+ULONG GSTDirectSoundNotify::Release() {
+  long lRef = InterlockedDecrement(&m_cRef);
+  if (lRef == 0) {
+    delete this;
+  }
+  return lRef;
+}
+
+#endif // GSTREAMER_LITE

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef GSTREAMER_LITE
+
+#ifndef GSTDIRECTSOUNDNOTIFY_H
+#define GSTDIRECTSOUNDNOTIFY_H
+
+#include <mmdeviceapi.h>
+
+typedef void (*GSTDSNotfierCallback)(void*);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void* InitNotificator(GSTDSNotfierCallback pCallback, void *pData);
+  void ReleaseNotificator(void *pObject);
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+class GSTDirectSoundNotify : IMMNotificationClient
+{
+public:
+  GSTDirectSoundNotify();
+  ~GSTDirectSoundNotify();
+
+  bool Init(GSTDSNotfierCallback pCallback, void *pData);
+  void Dispose();
+
+  // IUnknown
+  IFACEMETHODIMP_(ULONG) AddRef();
+  IFACEMETHODIMP_(ULONG) Release();
+
+private:
+  // IMMNotificationClient
+  IFACEMETHODIMP OnDeviceStateChanged(LPCWSTR pwstrDeviceId, DWORD dwNewState) { return S_OK; }
+  IFACEMETHODIMP OnDeviceAdded(LPCWSTR pwstrDeviceId) { return S_OK; }
+  IFACEMETHODIMP OnDeviceRemoved(LPCWSTR pwstrDeviceId) { return S_OK; }
+  IFACEMETHODIMP OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDeviceId);
+  IFACEMETHODIMP OnPropertyValueChanged(LPCWSTR pwstrDeviceId, const PROPERTYKEY key) { return S_OK; }
+
+  long m_cRef;
+  IMMDeviceEnumerator* m_pEnumerator;
+  GSTDSNotfierCallback m_pCallback;
+  void *m_pData;
+  HRESULT m_hrCoInit;
+
+  // IUnknown
+  IFACEMETHODIMP QueryInterface(const IID& iid, void** ppUnk);
+};
+#endif // __cplusplus
+
+#endif // GSTDIRECTSOUNDNOTIFY_H
+#endif // GSTREAMER_LITE

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundsink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundsink.c
@@ -54,6 +54,9 @@
 
 #include <gst/base/gstbasesink.h>
 #include "gstdirectsoundsink.h"
+#ifdef GSTREAMER_LITE
+#include "gstdirectsoundnotify.h"
+#endif // GSTREAMER_LITE
 #include <gst/audio/gstaudioiec61937.h>
 
 #include <math.h>
@@ -66,6 +69,11 @@
 #endif
 
 #define DEFAULT_MUTE FALSE
+
+#ifdef GSTREAMER_LITE
+#define DS_RELOAD_TIMEOUT 60000 // 60 seconds
+#define DS_RELOAD_INTERVAL 3000 // 3 seconds
+#endif // GSTREAMER_LITE
 
 GST_DEBUG_CATEGORY_STATIC (directsoundsink_debug);
 #define GST_CAT_DEFAULT directsoundsink_debug
@@ -181,6 +189,10 @@ gst_directsound_sink_finalize (GObject * object)
 {
   GstDirectSoundSink *dsoundsink = GST_DIRECTSOUND_SINK (object);
 
+#ifdef GSTREAMER_LITE
+  ReleaseNotificator(dsoundsink->gst_ds_notifier);
+#endif // GSTREAMER_LITE
+
   g_free (dsoundsink->device_id);
   dsoundsink->device_id = NULL;
 
@@ -263,6 +275,17 @@ gst_directsound_sink_class_init (GstDirectSoundSinkClass * klass)
       &directsoundsink_sink_factory);
 }
 
+#ifdef GSTREAMER_LITE
+static void
+gst_directsound_device_callback (GstDirectSoundSink * dsoundsink)
+{
+  if (dsoundsink->need_reload) {
+    dsoundsink->reload = TRUE;
+    dsoundsink->need_reload = TRUE;
+  }
+}
+#endif // GSTREAMER_LITE
+
 static void
 gst_directsound_sink_init (GstDirectSoundSink * dsoundsink)
 {
@@ -280,6 +303,12 @@ gst_directsound_sink_init (GstDirectSoundSink * dsoundsink)
   dsoundsink->first_buffer_after_reset = FALSE;
 #ifdef GSTREAMER_LITE
   dsoundsink->panorama = 0.0;
+  memset(&dsoundsink->descSecondary, 0, sizeof(DSBUFFERDESC));
+  memset(&dsoundsink->wfx, 0, sizeof(WAVEFORMATEX));
+  dsoundsink->gst_ds_notifier = InitNotificator(&gst_directsound_device_callback,
+                                                dsoundsink);
+  dsoundsink->reload = FALSE;
+  dsoundsink->need_reload = FALSE;
 #endif // GSTREAMER_LITE
 }
 
@@ -662,6 +691,13 @@ gst_directsound_sink_prepare (GstAudioSink * asink,
     return FALSE;
   }
 
+#ifdef GSTREAMER_LITE
+  // Store DSBUFFERDESC and WAVEFORMATEX in case we need to reload DirectSound
+  memcpy(&dsoundsink->descSecondary, &descSecondary, sizeof(DSBUFFERDESC));
+  memcpy(&dsoundsink->wfx, &wfx, sizeof(WAVEFORMATEX));
+  dsoundsink->descSecondary.lpwfxFormat = (WAVEFORMATEX*)&dsoundsink->wfx;
+#endif // GSTREAMER_LITE
+
   gst_directsound_sink_set_volume (dsoundsink,
       gst_directsound_sink_get_volume (dsoundsink), FALSE);
   gst_directsound_sink_set_mute (dsoundsink, dsoundsink->mute);
@@ -709,6 +745,83 @@ gst_directsound_sink_close (GstAudioSink * asink)
   return TRUE;
 }
 
+#ifdef GSTREAMER_LITE
+static void
+gst_directsound_sink_prereload(GstAudioSink* asink)
+{
+  GstDirectSoundSink* dsoundsink;
+  dsoundsink = GST_DIRECTSOUND_SINK(asink);
+
+  if (dsoundsink->pDSBSecondary) {
+    IDirectSoundBuffer_Release(dsoundsink->pDSBSecondary);
+    dsoundsink->pDSBSecondary = NULL;
+  }
+
+  if (dsoundsink->pDS) {
+    IDirectSound_Release(dsoundsink->pDS);
+    dsoundsink->pDS = NULL;
+  }
+}
+
+static gboolean
+gst_directsound_sink_reload(GstAudioSink* asink)
+{
+  GstDirectSoundSink* dsoundsink;
+  HRESULT hRes = S_OK;
+  gint timeout = DS_RELOAD_TIMEOUT;
+
+  dsoundsink = GST_DIRECTSOUND_SINK(asink);
+
+  // To avoid memory leaks in case it gets called again
+  gst_directsound_sink_prereload(asink);
+
+  do {
+    hRes = DirectSoundCreate(NULL, &dsoundsink->pDS, NULL);
+    if (FAILED(hRes)) {
+      Sleep(DS_RELOAD_INTERVAL);
+      timeout -= DS_RELOAD_INTERVAL;
+    }
+  } while (FAILED(hRes) && timeout > 0);
+
+  if (FAILED(hRes)) {
+    return FALSE;
+  }
+
+  hRes = IDirectSound_SetCooperativeLevel(dsoundsink->pDS,
+                                          GetDesktopWindow(), DSSCL_PRIORITY);
+  if (FAILED(hRes)) {
+    IDirectSound_Release(dsoundsink->pDS);
+    dsoundsink->pDS = NULL;
+    return FALSE;
+  }
+
+  hRes = IDirectSound_CreateSoundBuffer(dsoundsink->pDS, &dsoundsink->descSecondary,
+                                        &dsoundsink->pDSBSecondary, NULL);
+  if (FAILED(hRes)) {
+    IDirectSound_Release(dsoundsink->pDS);
+    dsoundsink->pDS = NULL;
+    return FALSE;
+  }
+
+  gst_directsound_sink_set_volume(dsoundsink,
+                            gst_directsound_sink_get_volume(dsoundsink), FALSE);
+  gst_directsound_sink_set_mute(dsoundsink, dsoundsink->mute);
+  gst_directsound_sink_set_pan(dsoundsink);
+
+  hRes = IDirectSoundBuffer_Play(dsoundsink->pDSBSecondary, 0, 0,
+                                 DSBPLAY_LOOPING);
+  if (FAILED(hRes)) {
+    IDirectSound_Release(dsoundsink->pDS);
+    dsoundsink->pDS = NULL;
+    IDirectSoundBuffer_Release(dsoundsink->pDSBSecondary);
+    dsoundsink->pDSBSecondary = NULL;
+    return FALSE;
+  }
+
+  return TRUE;
+}
+#endif // GSTREAMER_LITE
+
 static gint
 gst_directsound_sink_write (GstAudioSink * asink, gpointer data, guint length)
 {
@@ -726,8 +839,16 @@ gst_directsound_sink_write (GstAudioSink * asink, gpointer data, guint length)
   dsoundsink = GST_DIRECTSOUND_SINK (asink);
 
 #ifdef GSTREAMER_LITE
-  if (dsoundsink->pDS == NULL)
-  {
+  if (dsoundsink->reload) {
+    dsoundsink->reload = FALSE;
+    if (!gst_directsound_sink_reload(asink)) {
+      GST_ELEMENT_ERROR (dsoundsink, RESOURCE, OPEN_WRITE,
+                        ("Failed to load audio render device"), (NULL));
+      return -1;
+    }
+  }
+  if (dsoundsink->pDS == NULL) {
+no_device_write:
     GST_DSOUND_LOCK (dsoundsink);
     samples = length/dsoundsink->bytes_per_sample;
     duration = (1000*samples)/dsoundsink->rate;
@@ -818,6 +939,16 @@ gst_directsound_sink_write (GstAudioSink * asink, gpointer data, guint length)
           &dwCurrentPlayCursor, NULL);
       hRes2 =
           IDirectSoundBuffer_GetStatus (dsoundsink->pDSBSecondary, &dwStatus);
+#ifdef GSTREAMER_LITE
+      if (hRes == DSERR_BUFFERLOST || hRes2 == DSERR_BUFFERLOST) {
+        // Audio device gone. Call prereload to free current device and wait for
+        // new device on callback.
+        gst_directsound_sink_prereload(asink);
+        dsoundsink->need_reload = TRUE;
+        GST_DSOUND_UNLOCK (dsoundsink);
+        goto no_device_write;
+      }
+#endif // GSTREAMER_LITE
       if (SUCCEEDED (hRes) && SUCCEEDED (hRes2)
           && (dwStatus & DSBSTATUS_PLAYING))
         goto calculate_freesize;

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundsink.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundsink.h
@@ -92,6 +92,11 @@ struct _GstDirectSoundSink
 #ifdef GSTREAMER_LITE
   gfloat panorama;
   guint rate;
+  DSBUFFERDESC descSecondary;
+  WAVEFORMATEX wfx;
+  void *gst_ds_notifier;
+  gboolean reload;
+  gboolean need_reload;
 #endif // GSTREAMER_LITE
 };
 

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/gstreamer-lite/Makefile.gstplugins
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/gstreamer-lite/Makefile.gstplugins
@@ -52,6 +52,8 @@ C_SOURCES = gst-plugins-bad/gst/aiff/aiff.c \
             gstreamer/plugins/elements/gsttypefindelement.c \
             projects/plugins/gstplugins-lite.c
 
+CPP_SOURCES = gst-plugins-good/sys/directsound/gstdirectsoundnotify.cpp
+
 COMPILER_FLAGS = -nologo -W3 -WX- -EHsc -GS -fp:precise -Gm- \
                  -Zc:wchar_t -Zc:forScope -Gd -analyze- -errorReport:queue \
                  -wd"4018" -wd"4244" -wd"4005" -wd"4018" -wd"4101" -wd"4146" -wd"4244" -wd"4996"
@@ -102,7 +104,7 @@ else
     LIBFLAGS += -MACHINE:x64
 endif
 
-OBJECTS = $(patsubst %.c,$(OBJBASE_DIR)/%.obj,$(C_SOURCES))
+OBJECTS = $(patsubst %.cpp,$(OBJBASE_DIR)/%.obj,$(CPP_SOURCES)) $(patsubst %.c,$(OBJBASE_DIR)/%.obj,$(C_SOURCES))
 
 .PHONY: default
 
@@ -115,6 +117,9 @@ $(OBJECTS): | $(DEP_DIRS)
 
 $(DEP_DIRS):
 	@mkdir -p $(DEP_DIRS)
+
+$(OBJBASE_DIR)/%.obj: $(SRCBASE_DIR)/%.cpp
+	$(CC) $(CFLAGS) -TP -c -Fo$(shell cygpath -ma $@) $<
 
 $(OBJBASE_DIR)/%.obj: $(SRCBASE_DIR)/%.c
 	$(CC) $(CFLAGS) -TC -c -Fo$(shell cygpath -ma $@) $<


### PR DESCRIPTION
This is clean backport.
Tested the patch in a [branch](https://github.com/arapte/jfx11u/tree/cherry-pick).
Backports tested in above branch are : [JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737), [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860), [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819), [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219), [JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558), [JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718), [JDK-8265400](https://bugs.openjdk.java.net/browse/JDK-8265400), [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121), [JDK-8267858](https://bugs.openjdk.java.net/browse/JDK-8267858), [JDK-8267892](https://bugs.openjdk.java.net/browse/JDK-8267892)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737): JavaFX media stream stops playing after reconnecting via Remote Desktop


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/38.diff">https://git.openjdk.java.net/jfx11u/pull/38.diff</a>

</details>
