### PR TITLE
8266860: [macos] Incorrect duration reported for HLS live streams

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,10 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 
 - (double) duration {
     if (self.player.currentItem.status == AVPlayerItemStatusReadyToPlay) {
-        return CMTimeGetSeconds(self.player.currentItem.duration);
+        CMTime dur = self.player.currentItem.duration;
+        if (!CMTIME_IS_INDEFINITE(dur)) {
+            return CMTimeGetSeconds(self.player.currentItem.duration);
+        }
     }
     return -1.0;
 }


### PR DESCRIPTION
This is clean backport.
Tested the patch in a [branch](https://github.com/arapte/jfx11u/tree/cherry-pick).
Backports tested in above branch are : 
[JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737), [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860), [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819), [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219), [JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558),
[JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718), [JDK-8265400](https://bugs.openjdk.java.net/browse/JDK-8265400), [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121), [JDK-8267858](https://bugs.openjdk.java.net/browse/JDK-8267858), [JDK-8267892](https://bugs.openjdk.java.net/browse/JDK-8267892)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860): [macos] Incorrect duration reported for HLS live streams


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/39.diff">https://git.openjdk.java.net/jfx11u/pull/39.diff</a>

</details>
