### PR TITLE
8267819: CoInitialize/CoUninitialize should be called on same thread

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
@@ -46,7 +46,6 @@ class GSTDirectSoundNotify : IMMNotificationClient
 {
 public:
   GSTDirectSoundNotify();
-  ~GSTDirectSoundNotify();
 
   bool Init(GSTDSNotfierCallback pCallback, void *pData);
   void Dispose();
@@ -67,7 +66,6 @@ private:
   IMMDeviceEnumerator* m_pEnumerator;
   GSTDSNotfierCallback m_pCallback;
   void *m_pData;
-  HRESULT m_hrCoInit;
 
   // IUnknown
   IFACEMETHODIMP QueryInterface(const IID& iid, void** ppUnk);


### PR DESCRIPTION
This is clean backport.
Tested the patch in a [branch](https://github.com/arapte/jfx11u/tree/cherry-pick).
Backports tested in above branch are : 
[JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737), [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860), [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819), [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219), [JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558),
[JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718), [JDK-8265400](https://bugs.openjdk.java.net/browse/JDK-8265400), [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121), [JDK-8267858](https://bugs.openjdk.java.net/browse/JDK-8267858), [JDK-8267892](https://bugs.openjdk.java.net/browse/JDK-8267892)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819): CoInitialize/CoUninitialize should be called on same thread


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/40.diff">https://git.openjdk.java.net/jfx11u/pull/40.diff</a>

</details>
