### PR TITLE
8268718: [macos] Video stops, but audio continues to play when stopTime is reached

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -333,6 +333,9 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 - (void) setCurrentTime:(double)time
 {
     [self.player seekToTime:CMTimeMakeWithSeconds(time, 1)];
+    if (previousPlayerState == kPlayerState_FINISHED) {
+        [self play];
+    }
 }
 
 - (BOOL) mute {
@@ -402,6 +405,8 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 }
 
 - (void) finish {
+    [self.player pause];
+    [self setPlayerState:kPlayerState_FINISHED];
 }
 
 - (void) dispose {


### PR DESCRIPTION
This is clean backport.
Tested the patch in a [branch](https://github.com/arapte/jfx11u/tree/cherry-pick).
Backports tested in above branch are : 
[JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737), [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860), [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819), [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219), [JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558),
[JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718), [JDK-8265400](https://bugs.openjdk.java.net/browse/JDK-8265400), [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121), [JDK-8267858](https://bugs.openjdk.java.net/browse/JDK-8267858), [JDK-8267892](https://bugs.openjdk.java.net/browse/JDK-8267892)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718): [macos] Video stops, but audio continues to play when stopTime is reached


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/43.diff">https://git.openjdk.java.net/jfx11u/pull/43.diff</a>

</details>
