### PR TITLE
8267121: Illegal access to private "size" field of ArrayList from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -701,7 +701,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
         }
 
         //fetch all the missing packages
-        if (fetchedPackages.size > 0) {
+        if (fetchedPackages.size() > 0) {
             destdir.mkdirs()
 
             logger.quiet "fetching missing packages $fetchedPackages"
@@ -760,7 +760,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                 errors.add(pkgname)
             }
         }
-        if (errors.size > 0) {
+        if (errors.size() > 0) {
             throw new GradleException("Error: missing tool packages: $errors")
         } else {
             logger.quiet "all tool packages are present $packages"


### PR DESCRIPTION
This is clean backport.
Tested the patch in a [branch](https://github.com/arapte/jfx11u/tree/cherry-pick).
Backports tested in above branch are : 
[JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737), [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860), [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819), [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219), [JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558),
[JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718), [JDK-8265400](https://bugs.openjdk.java.net/browse/JDK-8265400), [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121), [JDK-8267858](https://bugs.openjdk.java.net/browse/JDK-8267858), [JDK-8267892](https://bugs.openjdk.java.net/browse/JDK-8267892)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121): Illegal access to private "size" field of ArrayList from build.gradle


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/45.diff">https://git.openjdk.java.net/jfx11u/pull/45.diff</a>

</details>
