### PR TITLE
8220222: build.gradle does not specify clearly the project dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1937,12 +1937,24 @@ project(":base") {
 
     sourceSets {
         main
-        shims
-        test
+        shims {
+            java {
+                compileClasspath += sourceSets.main.output
+                runtimeClasspath += sourceSets.main.output
+            }
+        }
+        test {
+            java {
+                compileClasspath += sourceSets.shims.output
+                runtimeClasspath += sourceSets.shims.output
+            }
+        }
     }
 
     dependencies {
         testCompile group: "junit", name: "junit", version: "4.8.2"
+        testCompile sourceSets.main.output
+        testCompile sourceSets.shims.output
     }
 
     commonModuleSetup(project, [ 'base' ])
@@ -1999,9 +2011,19 @@ project(":graphics") {
     sourceSets {
         jslc   // JSLC gramar subset
         main
-        shims
+        shims {
+            java {
+                compileClasspath += sourceSets.main.output
+                runtimeClasspath += sourceSets.main.output
+            }
+        }
         shaders // generated shaders (prism & decora)
-        test
+        test {
+            java {
+                compileClasspath += sourceSets.shims.output
+                runtimeClasspath += sourceSets.shims.output
+            }
+        }
         stub
     }
 
@@ -2009,6 +2031,7 @@ project(":graphics") {
         stubCompile group: "junit", name: "junit", version: "4.8.2"
 
         antlr group: "org.antlr", name: "antlr4", version: "4.7.2", classifier: "complete"
+        compile project(':base')
     }
 
     project.ext.moduleSourcePath = defaultModuleSourcePath_GraphicsOne
@@ -2417,8 +2440,18 @@ project(":controls") {
 
     sourceSets {
         main
-        shims
-        test
+        shims {
+            java {
+                compileClasspath += sourceSets.main.output
+                runtimeClasspath += sourceSets.main.output
+            }
+        }
+        test {
+            java {
+                compileClasspath += sourceSets.shims.output
+                runtimeClasspath += sourceSets.shims.output
+            }
+        }
     }
 
     project.ext.moduleSourcePath = defaultModuleSourcePath
@@ -2429,6 +2462,8 @@ project(":controls") {
     dependencies {
         testCompile project(":graphics").sourceSets.test.output
         testCompile project(":base").sourceSets.test.output
+        compile project(':base')
+        compile project(':graphics')
     }
 
     test {
@@ -2507,6 +2542,8 @@ project(":swing") {
     }
 
     dependencies {
+        compile project(":base")
+        compile project(":graphics")
     }
 
     test {
@@ -2604,8 +2641,18 @@ project(":fxml") {
 
     sourceSets {
         main
-        shims
-        test
+        shims {
+            java {
+                compileClasspath += sourceSets.main.output
+                runtimeClasspath += sourceSets.main.output
+            }
+        }
+        test {
+            java {
+                compileClasspath += sourceSets.shims.output
+                runtimeClasspath += sourceSets.shims.output
+            }
+        }
     }
 
     project.ext.moduleSourcePath = defaultModuleSourcePath
@@ -2617,6 +2664,8 @@ project(":fxml") {
     dependencies {
         testCompile project(":graphics").sourceSets.test.output
         testCompile project(":base").sourceSets.test.output
+        compile project(":base")
+        compile project(":graphics")
     }
 
     test {
@@ -3278,6 +3327,8 @@ project(":media") {
             media name: "ffmpeg-3.3.3", ext: "tar.gz"
             media name: "ffmpeg-4.0.2", ext: "tar.gz"
         }
+        compile project(":base")
+        compile project(":graphics")
     }
 
     compileJava.dependsOn updateCacheIfNeeded
@@ -3856,8 +3907,18 @@ project(":web") {
 
     sourceSets {
         main
-        shims
-        test
+        shims {
+            java {
+                compileClasspath += sourceSets.main.output
+                runtimeClasspath += sourceSets.main.output
+            }
+        }
+        test {
+            java {
+                compileClasspath += sourceSets.shims.output
+                runtimeClasspath += sourceSets.shims.output
+            }
+        }
     }
 
     project.ext.moduleSourcePath = defaultModuleSourcePath
@@ -3869,6 +3930,10 @@ project(":web") {
         if (IS_COMPILE_WEBKIT) {
             icu name: "icu4c-${icuVersion}-data-bin-l", ext: "zip"
         }
+        compile project(":base")
+        compile project(":graphics")
+        compile project(":controls")
+        compile project(":media")
     }
 
     compileJava.dependsOn updateCacheIfNeeded
@@ -4034,7 +4099,7 @@ project(":web") {
         }
 
         def copyNativeTask = task("copyNative${t.capital}", type: Copy,
-                dependsOn: [compileNativeTask, , copyDumpTreeNativeTask]) {
+                dependsOn: [compileNativeTask, copyDumpTreeNativeTask]) {
             enabled =  (IS_COMPILE_WEBKIT)
             def library = rootProject.ext[t.upper].library
             from "$webkitOutputDir/$webkitConfig/$dllDir/${library('jfxwebkit')}"


### PR DESCRIPTION
There was a minor merge conflict at line 3933 while cherry picking the commit, otherwise it was clean.
Verified build on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8220222](https://bugs.openjdk.java.net/browse/JDK-8220222): build.gradle does not specify clearly the project dependencies


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/48.diff">https://git.openjdk.java.net/jfx11u/pull/48.diff</a>

</details>
