### PR TITLE
8211362: Restrict export of libjpeg symbols from libjavafx_iio.so

### DIFF
--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -299,8 +299,8 @@ LINUX.iio.nativeSource = [
     file("${project("graphics").projectDir}/src/main/native-iio"),
     file("${project("graphics").projectDir}/src/main/native-iio/libjpeg")]
 LINUX.iio.compiler = compiler
-LINUX.iio.ccFlags = [cFlags].flatten()
-LINUX.iio.linker = linker
+LINUX.iio.ccFlags = [cFlags, "-fvisibility=hidden"].flatten()
+LINUX.iio.linker = IS_STATIC_BUILD ? "ld" : linker
 LINUX.iio.linkFlags = [linkFlags].flatten()
 LINUX.iio.lib = "javafx_iio"
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -42,8 +42,13 @@ class LinkTask extends DefaultTask {
         project.exec({
             commandLine(linker);
             if ((project.IS_LINUX) && (project.IS_STATIC_BUILD)) {
-              args("rcs");
-              args("$lib");
+                if (linker.equals("ld")) {
+                    args("-r");
+                    args("-o");
+                } else {
+                    args("rcs");
+                }
+                args("$lib");
             }
             // Exclude parfait files (.bc)
             args(objectDir.listFiles().findAll{ !it.getAbsolutePath().endsWith(".bc") });


### PR DESCRIPTION
clean patch
8211362: Restrict export of libjpeg symbols from libjavafx_iio.so 
Reviewed-by: kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211362](https://bugs.openjdk.java.net/browse/JDK-8211362): Restrict export of libjpeg symbols from libjavafx_iio.so


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/51.diff">https://git.openjdk.java.net/jfx11u/pull/51.diff</a>

</details>
