### PR TITLE
8273732: Clarify review policies for clean backports in JavaFX update releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing to OpenJFX 11 Updates
 
 The OpenJFX 11 Updates repository is _not_ accepting new contributions. If you are looking to contribute to OpenJFX, please visit [openjdk/jfx](https://github.com/openjdk/jfx) instead.
 
-Important bug fixes that have already been fixed in the mainline can be backported with approval. New fixes should first go into the mainline, and then can be considered for backporting. Approval from one of the project leads is required prior to integrating the fix.
+Important bug fixes that have already been fixed in the mainline can be backported with prior approval. New fixes should first go into the mainline, and then can be considered for backporting. Approval from one of the project leads is required prior to creating the PR or integrating the fix.
 
 To backport a fix, import the patch from the jfx mainline into a branch of your personal fork of this repo. Then, create a [Backport Pull Request](https://wiki.openjdk.java.net/display/SKARA/Backports#Backports-BackportPullRequests), by creating the PR with the title:
 
@@ -12,3 +12,7 @@ Backport LONG-COMMIT-HASH
 ```
 
 where `LONG-COMMIT-HASH` is the long (40 char) commit hash of the fix as found in the main jfx repo. The Skara tooling will then note that it is a backport, and replace the title with the correct issue title.
+
+If Skara detemines that the backport is clean, the bot will add the `clean` label and mark it as `ready` for integration. _If_ a project lead has approved
+this bug for inclusion in the current update release, a review of a clean backport is optional; such a backport may be integrated without further review. If
+there is any concern over the risk of the backport, please ask for a review.


### PR DESCRIPTION
Clean backport of update to `CONTRIBUTING.md` to clarify that clean backports of approved fixes can be integrated without further review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273732](https://bugs.openjdk.java.net/browse/JDK-8273732): Clarify review policies for clean backports in JavaFX update releases


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/53.diff">https://git.openjdk.java.net/jfx11u/pull/53.diff</a>

</details>
