### PR TITLE
8274107: Cherry pick GTK WebKit 2.32.4 changes

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1112,6 +1112,20 @@ public:
     }
 
     template<int datasize>
+    ALWAYS_INLINE static bool isValidLDPImm(int immediate)
+    {
+        unsigned immedShiftAmount = memPairOffsetShift(false, MEMPAIROPSIZE_INT(datasize));
+        return isValidSignedImm7(immediate, immedShiftAmount);
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE static bool isValidLDPFPImm(int immediate)
+    {
+        unsigned immedShiftAmount = memPairOffsetShift(true, MEMPAIROPSIZE_FP(datasize));
+        return isValidSignedImm7(immediate, immedShiftAmount);
+    }
+
+    template<int datasize>
     ALWAYS_INLINE void ldp(RegisterID rt, RegisterID rt2, RegisterID rn, PairPostIndex simm)
     {
         CHECK_DATASIZE();
@@ -1126,17 +1140,45 @@ public:
     }
 
     template<int datasize>
-    ALWAYS_INLINE void ldp(RegisterID rt, RegisterID rt2, RegisterID rn, unsigned pimm = 0)
+    ALWAYS_INLINE void ldp(RegisterID rt, RegisterID rt2, RegisterID rn, int simm = 0)
     {
         CHECK_DATASIZE();
-        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_INT(datasize), false, MemOp_LOAD, pimm, rn, rt, rt2));
+        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_INT(datasize), false, MemOp_LOAD, simm, rn, rt, rt2));
     }
 
     template<int datasize>
-    ALWAYS_INLINE void ldnp(RegisterID rt, RegisterID rt2, RegisterID rn, unsigned pimm = 0)
+    ALWAYS_INLINE void ldnp(RegisterID rt, RegisterID rt2, RegisterID rn, int simm = 0)
     {
         CHECK_DATASIZE();
-        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_INT(datasize), false, MemOp_LOAD, pimm, rn, rt, rt2));
+        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_INT(datasize), false, MemOp_LOAD, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ldp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, PairPostIndex simm)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairPostIndex(MEMPAIROPSIZE_FP(datasize), true, MemOp_LOAD, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ldp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, PairPreIndex simm)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairPreIndex(MEMPAIROPSIZE_FP(datasize), true, MemOp_LOAD, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ldp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, int simm = 0)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_FP(datasize), true, MemOp_LOAD, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ldnp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, int simm = 0)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_FP(datasize), true, MemOp_LOAD, simm, rn, rt, rt2));
     }
 
     template<int datasize>
@@ -1741,6 +1783,18 @@ public:
     }
 
     template<int datasize>
+    ALWAYS_INLINE static bool isValidSTPImm(int immediate)
+    {
+        return isValidLDPImm<datasize>(immediate);
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE static bool isValidSTPFPImm(int immediate)
+    {
+        return isValidLDPFPImm<datasize>(immediate);
+    }
+
+    template<int datasize>
     ALWAYS_INLINE void stp(RegisterID rt, RegisterID rt2, RegisterID rn, PairPostIndex simm)
     {
         CHECK_DATASIZE();
@@ -1755,17 +1809,45 @@ public:
     }
 
     template<int datasize>
-    ALWAYS_INLINE void stp(RegisterID rt, RegisterID rt2, RegisterID rn, unsigned pimm = 0)
+    ALWAYS_INLINE void stp(RegisterID rt, RegisterID rt2, RegisterID rn, int simm = 0)
     {
         CHECK_DATASIZE();
-        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_INT(datasize), false, MemOp_STORE, pimm, rn, rt, rt2));
+        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_INT(datasize), false, MemOp_STORE, simm, rn, rt, rt2));
     }
 
     template<int datasize>
-    ALWAYS_INLINE void stnp(RegisterID rt, RegisterID rt2, RegisterID rn, unsigned pimm = 0)
+    ALWAYS_INLINE void stnp(RegisterID rt, RegisterID rt2, RegisterID rn, int simm = 0)
     {
         CHECK_DATASIZE();
-        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_INT(datasize), false, MemOp_STORE, pimm, rn, rt, rt2));
+        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_INT(datasize), false, MemOp_STORE, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void stp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, PairPostIndex simm)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairPostIndex(MEMPAIROPSIZE_FP(datasize), true, MemOp_STORE, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void stp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, PairPreIndex simm)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairPreIndex(MEMPAIROPSIZE_FP(datasize), true, MemOp_STORE, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void stp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, int simm = 0)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairOffset(MEMPAIROPSIZE_FP(datasize), true, MemOp_STORE, simm, rn, rt, rt2));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void stnp(FPRegisterID rt, FPRegisterID rt2, RegisterID rn, int simm = 0)
+    {
+        CHECK_DATASIZE();
+        insn(loadStoreRegisterPairNonTemporal(MEMPAIROPSIZE_FP(datasize), true, MemOp_STORE, simm, rn, rt, rt2));
     }
 
     template<int datasize>
@@ -3541,6 +3623,7 @@ protected:
         ASSERT(opc == (opc & 1)); // Only load or store, load signed 64 is handled via size.
         ASSERT(V || (size != MemPairOp_LoadSigned_32) || (opc == MemOp_LOAD)); // There isn't an integer store signed.
         unsigned immedShiftAmount = memPairOffsetShift(V, size);
+        RELEASE_ASSERT(isValidSignedImm7(immediate, immedShiftAmount));
         int imm7 = immediate >> immedShiftAmount;
         ASSERT((imm7 << immedShiftAmount) == immediate && isInt<7>(imm7));
         return (0x28800000 | size << 30 | V << 26 | opc << 22 | (imm7 & 0x7f) << 15 | rt2 << 10 | xOrSp(rn) << 5 | rt);
@@ -3572,6 +3655,7 @@ protected:
         ASSERT(opc == (opc & 1)); // Only load or store, load signed 64 is handled via size.
         ASSERT(V || (size != MemPairOp_LoadSigned_32) || (opc == MemOp_LOAD)); // There isn't an integer store signed.
         unsigned immedShiftAmount = memPairOffsetShift(V, size);
+        RELEASE_ASSERT(isValidSignedImm7(immediate, immedShiftAmount));
         int imm7 = immediate >> immedShiftAmount;
         ASSERT((imm7 << immedShiftAmount) == immediate && isInt<7>(imm7));
         return (0x29800000 | size << 30 | V << 26 | opc << 22 | (imm7 & 0x7f) << 15 | rt2 << 10 | xOrSp(rn) << 5 | rt);
@@ -3589,6 +3673,7 @@ protected:
         ASSERT(opc == (opc & 1)); // Only load or store, load signed 64 is handled via size.
         ASSERT(V || (size != MemPairOp_LoadSigned_32) || (opc == MemOp_LOAD)); // There isn't an integer store signed.
         unsigned immedShiftAmount = memPairOffsetShift(V, size);
+        RELEASE_ASSERT(isValidSignedImm7(immediate, immedShiftAmount));
         int imm7 = immediate >> immedShiftAmount;
         ASSERT((imm7 << immedShiftAmount) == immediate && isInt<7>(imm7));
         return (0x29000000 | size << 30 | V << 26 | opc << 22 | (imm7 & 0x7f) << 15 | rt2 << 10 | xOrSp(rn) << 5 | rt);
@@ -3606,6 +3691,7 @@ protected:
         ASSERT(opc == (opc & 1)); // Only load or store, load signed 64 is handled via size.
         ASSERT(V || (size != MemPairOp_LoadSigned_32) || (opc == MemOp_LOAD)); // There isn't an integer store signed.
         unsigned immedShiftAmount = memPairOffsetShift(V, size);
+        RELEASE_ASSERT(isValidSignedImm7(immediate, immedShiftAmount));
         int imm7 = immediate >> immedShiftAmount;
         ASSERT((imm7 << immedShiftAmount) == immediate && isInt<7>(imm7));
         return (0x28000000 | size << 30 | V << 26 | opc << 22 | (imm7 & 0x7f) << 15 | rt2 << 10 | xOrSp(rn) << 5 | rt);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,15 @@ ALWAYS_INLINE bool isValidScaledUImm12(int32_t offset)
 ALWAYS_INLINE bool isValidSignedImm9(int32_t value)
 {
     return isInt9(value);
+}
+
+ALWAYS_INLINE bool isValidSignedImm7(int32_t value, int alignmentShiftAmount)
+{
+    constexpr int32_t disallowedHighBits = 32 - 7;
+    int32_t shiftedValue = value >> alignmentShiftAmount;
+    bool fitsIn7Bits = shiftedValue == ((shiftedValue << disallowedHighBits) >> disallowedHighBits);
+    bool hasCorrectAlignment = value == (shiftedValue << alignmentShiftAmount);
+    return fitsIn7Bits && hasCorrectAlignment;
 }
 
 class ARM64LogicalImmediate {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1226,6 +1226,16 @@ public:
         m_assembler.ldnp<64>(dest1, dest2, src, offset.m_value);
     }
 
+    void loadPair64(RegisterID src, FPRegisterID dest1, FPRegisterID dest2)
+    {
+        loadPair64(src, TrustedImm32(0), dest1, dest2);
+    }
+
+    void loadPair64(RegisterID src, TrustedImm32 offset, FPRegisterID dest1, FPRegisterID dest2)
+    {
+        m_assembler.ldp<64>(dest1, dest2, src, offset.m_value);
+    }
+
     void abortWithReason(AbortReason reason)
     {
         // It is safe to use dataTempRegister directly since this is a crashing JIT Assert.
@@ -1548,6 +1558,16 @@ public:
     void storePair64WithNonTemporalAccess(RegisterID src1, RegisterID src2, RegisterID dest, TrustedImm32 offset)
     {
         m_assembler.stnp<64>(src1, src2, dest, offset.m_value);
+    }
+
+    void storePair64(FPRegisterID src1, FPRegisterID src2, RegisterID dest)
+    {
+        storePair64(src1, src2, dest, TrustedImm32(0));
+    }
+
+    void storePair64(FPRegisterID src1, FPRegisterID src2, RegisterID dest, TrustedImm32 offset)
+    {
+        m_assembler.stp<64>(src1, src2, dest, offset.m_value);
     }
 
     void store32(RegisterID src, ImplicitAddress address)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -1740,6 +1740,441 @@ void testMoveDoubleConditionallyFloatSameArg(MacroAssembler::DoubleCondition con
 
 #endif // CPU(X86_64) || CPU(ARM64)
 
+#if CPU(ARM64)
+void testLoadStorePair64Int64()
+{
+    constexpr uint64_t initialValue = 0x5555aaaabbbb8800ull;
+    constexpr uint64_t value1 = 42;
+    constexpr uint64_t value2 = 0xcafebabe12345678ull;
+
+    uint64_t buffer[10];
+
+    auto initBuffer = [&] {
+        for (unsigned i = 0; i < 10; ++i)
+            buffer[i] = initialValue + i;
+    };
+
+    struct Pair {
+        uint64_t value1;
+        uint64_t value2;
+    };
+
+    Pair pair;
+    auto initPair = [&] {
+        pair = { 0, 0 };
+    };
+
+    // Test loadPair64.
+    auto testLoadPair = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR0;
+        constexpr GPRReg pairGPR = GPRInfo::argumentGPR1;
+        jit.loadPair64(bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(CPURegister)), GPRInfo::regT2, GPRInfo::regT3);
+
+        jit.store64(GPRInfo::regT2, CCallHelpers::Address(pairGPR, 0));
+        jit.store64(GPRInfo::regT3, CCallHelpers::Address(pairGPR, sizeof(uint64_t)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto testLoadPair0 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, 0);
+    });
+
+    initBuffer();
+
+    initPair();
+    invoke<void>(testLoadPair0, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4);
+    CHECK_EQ(pair.value2, initialValue + 5);
+
+    initPair();
+    buffer[4] = value1;
+    buffer[5] = value2;
+    invoke<void>(testLoadPair0, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value1);
+    CHECK_EQ(pair.value2, value2);
+
+    auto testLoadPairMinus2 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, -2);
+    });
+
+    initPair();
+    invoke<void>(testLoadPairMinus2, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4 - 2);
+    CHECK_EQ(pair.value2, initialValue + 5 - 2);
+
+    initPair();
+    buffer[4 - 2] = value2;
+    buffer[5 - 2] = value1;
+    invoke<void>(testLoadPairMinus2, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value2);
+    CHECK_EQ(pair.value2, value1);
+
+    auto testLoadPairPlus3 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, 3);
+    });
+
+    initPair();
+    invoke<void>(testLoadPairPlus3, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4 + 3);
+    CHECK_EQ(pair.value2, initialValue + 5 + 3);
+
+    initPair();
+    buffer[4 + 3] = value1;
+    buffer[5 + 3] = value2;
+    invoke<void>(testLoadPairPlus3, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value1);
+    CHECK_EQ(pair.value2, value2);
+
+    // Test storePair64.
+    auto testStorePair = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR2;
+        jit.storePair64(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(CPURegister)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto testStorePair0 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, 0);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePair0, value1, value2, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], value1);
+    CHECK_EQ(buffer[5], value2);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairMinus2 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, -2);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairMinus2, value1, value2, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], value1);
+    CHECK_EQ(buffer[3], value2);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairPlus3 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, 3);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairPlus3, value1, value2, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], value1);
+    CHECK_EQ(buffer[8], value2);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    // Test storePair64 from 1 register.
+    auto testStorePairFromOneReg = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR1;
+        jit.storePair64(GPRInfo::argumentGPR0, GPRInfo::argumentGPR0, bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(CPURegister)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto testStorePairFromOneReg0 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, 0);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneReg0, value2, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], value2);
+    CHECK_EQ(buffer[5], value2);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairFromOneRegMinus2 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, -2);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneRegMinus2, value1, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], value1);
+    CHECK_EQ(buffer[3], value1);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairFromOneRegPlus3 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, 3);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneRegPlus3, value2, &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], value2);
+    CHECK_EQ(buffer[8], value2);
+    CHECK_EQ(buffer[9], initialValue + 9);
+}
+
+void testLoadStorePair64Double()
+{
+    constexpr double initialValue = 10000.275;
+    constexpr double value1 = 42.89;
+    constexpr double value2 = -555.321;
+
+    double buffer[10];
+
+    auto initBuffer = [&] {
+        for (unsigned i = 0; i < 10; ++i)
+            buffer[i] = initialValue + i;
+    };
+
+    struct Pair {
+        double value1;
+        double value2;
+    };
+
+    Pair pair;
+    auto initPair = [&] {
+        pair = { 0, 0 };
+    };
+
+    // Test loadPair64.
+    auto testLoadPair = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR0;
+        constexpr GPRReg pairGPR = GPRInfo::argumentGPR1;
+        jit.loadPair64(bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(double)), FPRInfo::fpRegT0, FPRInfo::fpRegT1);
+
+        jit.storeDouble(FPRInfo::fpRegT0, CCallHelpers::Address(pairGPR, 0));
+        jit.storeDouble(FPRInfo::fpRegT1, CCallHelpers::Address(pairGPR, sizeof(uint64_t)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto testLoadPair0 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, 0);
+    });
+
+    initBuffer();
+
+    initPair();
+    invoke<void>(testLoadPair0, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4);
+    CHECK_EQ(pair.value2, initialValue + 5);
+
+    initPair();
+    buffer[4] = value1;
+    buffer[5] = value2;
+    invoke<void>(testLoadPair0, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value1);
+    CHECK_EQ(pair.value2, value2);
+
+    auto testLoadPairMinus2 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, -2);
+    });
+
+    initPair();
+    invoke<void>(testLoadPairMinus2, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4 - 2);
+    CHECK_EQ(pair.value2, initialValue + 5 - 2);
+
+    initPair();
+    buffer[4 - 2] = value2;
+    buffer[5 - 2] = value1;
+    invoke<void>(testLoadPairMinus2, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value2);
+    CHECK_EQ(pair.value2, value1);
+
+    auto testLoadPairPlus3 = compile([&] (CCallHelpers& jit) {
+        testLoadPair(jit, 3);
+    });
+
+    initPair();
+    invoke<void>(testLoadPairPlus3, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, initialValue + 4 + 3);
+    CHECK_EQ(pair.value2, initialValue + 5 + 3);
+
+    initPair();
+    buffer[4 + 3] = value1;
+    buffer[5 + 3] = value2;
+    invoke<void>(testLoadPairPlus3, &buffer[4], &pair);
+    CHECK_EQ(pair.value1, value1);
+    CHECK_EQ(pair.value2, value2);
+
+    // Test storePair64.
+    auto testStorePair = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR2;
+        jit.move64ToDouble(GPRInfo::argumentGPR0, FPRInfo::fpRegT0);
+        jit.move64ToDouble(GPRInfo::argumentGPR1, FPRInfo::fpRegT1);
+        jit.storePair64(FPRInfo::fpRegT0, FPRInfo::fpRegT1, bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(double)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto asInt64 = [] (double value) {
+        return bitwise_cast<int64_t>(value);
+    };
+
+    auto testStorePair0 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, 0);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePair0, asInt64(value1), asInt64(value2), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], value1);
+    CHECK_EQ(buffer[5], value2);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairMinus2 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, -2);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairMinus2, asInt64(value1), asInt64(value2), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], value1);
+    CHECK_EQ(buffer[3], value2);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairPlus3 = compile([&] (CCallHelpers& jit) {
+        testStorePair(jit, 3);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairPlus3, asInt64(value1), asInt64(value2), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], value1);
+    CHECK_EQ(buffer[8], value2);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    // Test storePair64 from 1 register.
+    auto testStorePairFromOneReg = [] (CCallHelpers& jit, int offset) {
+        emitFunctionPrologue(jit);
+
+        constexpr GPRReg bufferGPR = GPRInfo::argumentGPR1;
+        jit.move64ToDouble(GPRInfo::argumentGPR0, FPRInfo::fpRegT0);
+        jit.storePair64(FPRInfo::fpRegT0, FPRInfo::fpRegT0, bufferGPR, CCallHelpers::TrustedImm32(offset * sizeof(double)));
+
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    };
+
+    auto testStorePairFromOneReg0 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, 0);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneReg0, asInt64(value2), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], value2);
+    CHECK_EQ(buffer[5], value2);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairFromOneRegMinus2 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, -2);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneRegMinus2, asInt64(value1), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], value1);
+    CHECK_EQ(buffer[3], value1);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], initialValue + 7);
+    CHECK_EQ(buffer[8], initialValue + 8);
+    CHECK_EQ(buffer[9], initialValue + 9);
+
+    auto testStorePairFromOneRegPlus3 = compile([&] (CCallHelpers& jit) {
+        testStorePairFromOneReg(jit, 3);
+    });
+
+    initBuffer();
+    invoke<void>(testStorePairFromOneRegPlus3, asInt64(value2), &buffer[4]);
+    CHECK_EQ(buffer[0], initialValue + 0);
+    CHECK_EQ(buffer[1], initialValue + 1);
+    CHECK_EQ(buffer[2], initialValue + 2);
+    CHECK_EQ(buffer[3], initialValue + 3);
+    CHECK_EQ(buffer[4], initialValue + 4);
+    CHECK_EQ(buffer[5], initialValue + 5);
+    CHECK_EQ(buffer[6], initialValue + 6);
+    CHECK_EQ(buffer[7], value2);
+    CHECK_EQ(buffer[8], value2);
+    CHECK_EQ(buffer[9], initialValue + 9);
+}
+#endif // CPU(ARM64)
+
 #if ENABLE(MASM_PROBE)
 void testProbeReadsArgumentRegisters()
 {
@@ -2654,6 +3089,8 @@ void run(const char* filter)
 #endif
 
 #if CPU(ARM64)
+    RUN(testLoadStorePair64Int64());
+    RUN(testLoadStorePair64Double());
     RUN(testMul32SignExtend());
 #endif
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,6 +72,8 @@ static const OpcodeGroupInitializer opcodeGroupList[] = {
     OPCODE_GROUP_ENTRY(0x0a, A64DOpcodeLogicalShiftedRegister),
     OPCODE_GROUP_ENTRY(0x0b, A64DOpcodeAddSubtractExtendedRegister),
     OPCODE_GROUP_ENTRY(0x0b, A64DOpcodeAddSubtractShiftedRegister),
+    OPCODE_GROUP_ENTRY(0x0c, A64DOpcodeLoadStoreRegisterPair),
+    OPCODE_GROUP_ENTRY(0x0d, A64DOpcodeLoadStoreRegisterPair),
     OPCODE_GROUP_ENTRY(0x11, A64DOpcodeAddSubtractImmediate),
     OPCODE_GROUP_ENTRY(0x12, A64DOpcodeMoveWide),
     OPCODE_GROUP_ENTRY(0x12, A64DOpcodeLogicalImmediate),
@@ -1363,9 +1365,9 @@ const char* A64DOpcodeLoadStoreRegisterPair::format()
     appendInstructionName(thisOpName);
     unsigned offsetShift;
     if (vBit()) {
-        appendFPRegisterName(rt(), size());
+        appendFPRegisterName(rt(), size() + 2);
         appendSeparator();
-        appendFPRegisterName(rt2(), size());
+        appendFPRegisterName(rt2(), size() + 2);
         offsetShift = size() + 2;
     } else {
         if (!lBit())

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -787,7 +787,7 @@ public:
 
 class A64DOpcodeLoadStoreRegisterPair : public A64DOpcodeLoadStore {
 public:
-    static constexpr uint32_t mask = 0x3a000000;
+    static constexpr uint32_t mask = 0x38000000;
     static constexpr uint32_t pattern = 0x28000000;
 
     DEFINE_STATIC_FORMAT(A64DOpcodeLoadStoreRegisterPair, thisObj);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -198,9 +198,9 @@ void JSGlobalObjectInspectorController::reportAPIException(JSGlobalObject* globa
     m_consoleAgent->addMessageToConsole(makeUnique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage, WTFMove(callStack)));
 }
 
-ConsoleClient* JSGlobalObjectInspectorController::consoleClient() const
+WeakPtr<ConsoleClient> JSGlobalObjectInspectorController::consoleClient() const
 {
-    return m_consoleClient.get();
+    return makeWeakPtr(m_consoleClient.get());
 }
 
 bool JSGlobalObjectInspectorController::developerExtrasEnabled() const

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.h
@@ -81,7 +81,7 @@ public:
 
     void reportAPIException(JSC::JSGlobalObject*, JSC::Exception*);
 
-    JSC::ConsoleClient* consoleClient() const;
+    WeakPtr<JSC::ConsoleClient> consoleClient() const;
 
     bool developerExtrasEnabled() const final;
     bool canAccessInspectedScriptState(JSC::JSGlobalObject*) const final { return true; }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -36,15 +36,15 @@ struct ProtoCallFrame;
 
 namespace LLInt {
 
-extern "C" SlowPathReturnType llint_trace_operand(CallFrame*, const Instruction*, int fromWhere, int operand);
-extern "C" SlowPathReturnType llint_trace_value(CallFrame*, const Instruction*, int fromWhere, VirtualRegister operand);
-extern "C" void llint_write_barrier_slow(CallFrame*, JSCell*) WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_trace_operand(CallFrame*, const Instruction*, int fromWhere, int operand) REFERENCED_FROM_ASM;
+extern "C" SlowPathReturnType llint_trace_value(CallFrame*, const Instruction*, int fromWhere, VirtualRegister operand) REFERENCED_FROM_ASM;
+extern "C" void llint_write_barrier_slow(CallFrame*, JSCell*) REFERENCED_FROM_ASM WTF_INTERNAL;
 
 #define LLINT_SLOW_PATH_DECL(name) \
     extern "C" SlowPathReturnType llint_##name(CallFrame* callFrame, const Instruction* pc)
 
 #define LLINT_SLOW_PATH_HIDDEN_DECL(name) \
-    LLINT_SLOW_PATH_DECL(name) WTF_INTERNAL
+    LLINT_SLOW_PATH_DECL(name) REFERENCED_FROM_ASM WTF_INTERNAL
 
 LLINT_SLOW_PATH_HIDDEN_DECL(trace_prologue);
 LLINT_SLOW_PATH_HIDDEN_DECL(trace_prologue_function_for_call);
@@ -144,13 +144,13 @@ LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_tail);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_super_sampler_begin);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_super_sampler_end);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_out_of_line_jump_target);
-extern "C" SlowPathReturnType llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) WTF_INTERNAL;
-extern "C" SlowPathReturnType llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue unused) WTF_INTERNAL;
-extern "C" SlowPathReturnType llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue callResult) WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
 #if ENABLE(C_LOOP)
-extern "C" SlowPathReturnType llint_stack_check_at_vm_entry(VM*, Register*) WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_stack_check_at_vm_entry(VM*, Register*) REFERENCED_FROM_ASM WTF_INTERNAL;
 #endif
-extern "C" SlowPathReturnType llint_check_vm_entry_permission(VM*, ProtoCallFrame*) WTF_INTERNAL;
-extern "C" NO_RETURN_DUE_TO_CRASH void llint_crash() WTF_INTERNAL;
+extern "C" SlowPathReturnType llint_check_vm_entry_permission(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" NO_RETURN_DUE_TO_CRASH void llint_crash() REFERENCED_FROM_ASM WTF_INTERNAL;
 
 } } // namespace JSC::LLInt

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ConsoleClient.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ConsoleClient.h
@@ -27,6 +27,7 @@
 
 #include "ConsoleTypes.h"
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace Inspector {
 class ScriptArguments;
@@ -37,7 +38,7 @@ namespace JSC {
 class CallFrame;
 class JSGlobalObject;
 
-class ConsoleClient {
+class ConsoleClient : public CanMakeWeakPtr<ConsoleClient> {
 public:
     virtual ~ConsoleClient() { }
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ConsoleObject.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/ConsoleObject.cpp
@@ -129,7 +129,7 @@ static String valueToStringWithUndefinedOrNullCheck(JSGlobalObject* globalObject
 
 static EncodedJSValue consoleLogWithLevel(JSGlobalObject* globalObject, CallFrame* callFrame, MessageLevel level)
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -164,7 +164,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncWarn, (JSGlobalObject* globalObject, Ca
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncClear, (JSGlobalObject* globalObject, CallFrame*))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -174,7 +174,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncClear, (JSGlobalObject* globalObject, C
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncDir, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -184,7 +184,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncDir, (JSGlobalObject* globalObject, Cal
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncDirXML, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncDirXML, (JSGlobalObject* globalObject, 
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTable, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -204,7 +204,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTable, (JSGlobalObject* globalObject, C
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTrace, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncAssert, (JSGlobalObject* globalObject, 
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncAssert, (JSGlobalObject* globalObject, 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncCount, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -247,7 +247,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncCount, (JSGlobalObject* globalObject, C
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncCountReset, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -262,7 +262,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncProfile, (JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -283,7 +283,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncProfileEnd, (JSGlobalObject* globalObje
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -304,7 +304,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTakeHeapSnapshot, (JSGlobalObject* glob
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -324,7 +324,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTakeHeapSnapshot, (JSGlobalObject* glob
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTime, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -338,7 +338,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTime, (JSGlobalObject* globalObject, Ca
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeLog, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -352,7 +352,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeLog, (JSGlobalObject* globalObject,
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeEnd, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -365,7 +365,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeEnd, (JSGlobalObject* globalObject,
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeStamp, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -375,7 +375,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncTimeStamp, (JSGlobalObject* globalObjec
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroup, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -385,7 +385,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroup, (JSGlobalObject* globalObject, C
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroupCollapsed, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -395,7 +395,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroupCollapsed, (JSGlobalObject* global
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroupEnd, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -405,7 +405,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncGroupEnd, (JSGlobalObject* globalObject
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncRecord, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -415,7 +415,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncRecord, (JSGlobalObject* globalObject, 
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncRecordEnd, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 
@@ -425,7 +425,7 @@ JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncRecordEnd, (JSGlobalObject* globalObjec
 
 JSC_DEFINE_HOST_FUNCTION(consoleProtoFuncScreenshot, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    ConsoleClient* client = globalObject->consoleClient();
+    auto client = globalObject->consoleClient();
     if (!client)
         return JSValue::encode(jsUndefined());
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -54,6 +54,7 @@
 #include "ClonedArguments.h"
 #include "CodeBlock.h"
 #include "CodeBlockSetInlines.h"
+#include "ConsoleClient.h"
 #include "ConsoleObject.h"
 #include "DateConstructor.h"
 #include "DatePrototype.h"
@@ -2327,6 +2328,11 @@ void JSGlobalObject::queueMicrotask(Ref<Microtask>&& task)
 void JSGlobalObject::reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception* exception)
 {
     dataLogLn("Uncaught Exception at run loop: ", exception->value());
+}
+
+void JSGlobalObject::setConsoleClient(WeakPtr<ConsoleClient>&& consoleClient)
+{
+    m_consoleClient = WTFMove(consoleClient);
 }
 
 void JSGlobalObject::setDebugger(Debugger* debugger)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -49,6 +49,7 @@
 #include <array>
 #include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
 
 struct OpaqueJSClass;
 struct OpaqueJSClassContextData;
@@ -560,7 +561,7 @@ public:
     String m_evalDisabledErrorMessage;
     String m_webAssemblyDisabledErrorMessage;
     RuntimeFlags m_runtimeFlags;
-    ConsoleClient* m_consoleClient { nullptr };
+    WeakPtr<ConsoleClient> m_consoleClient;
     Optional<unsigned> m_stackTraceLimit;
     WeakGCMap<GetValueFunc, JSCustomGetterFunction> m_customGetterFunctionMap;
     WeakGCMap<PutValueFunc, JSCustomSetterFunction> m_customSetterFunctionMap;
@@ -880,8 +881,8 @@ public:
     static ptrdiff_t globalLexicalBindingEpochOffset() { return OBJECT_OFFSETOF(JSGlobalObject, m_globalLexicalBindingEpoch); }
     unsigned* addressOfGlobalLexicalBindingEpoch() { return &m_globalLexicalBindingEpoch; }
 
-    void setConsoleClient(ConsoleClient* consoleClient) { m_consoleClient = consoleClient; }
-    ConsoleClient* consoleClient() const { return m_consoleClient; }
+    JS_EXPORT_PRIVATE void setConsoleClient(WeakPtr<ConsoleClient>&&);
+    WeakPtr<ConsoleClient> consoleClient() const { return m_consoleClient; }
 
     void setName(const String&);
     const String& name() const { return m_name; }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -416,11 +416,11 @@ RefPtr<Memory> Memory::tryCreate(PageCount initial, PageCount maximum, MemorySha
     if (UNLIKELY(Options::crashIfWebAssemblyCantFastMemory()))
         webAssemblyCouldntGetFastMemory();
 
+    switch (sharingMode) {
+    case MemorySharingMode::Default: {
     if (!initialBytes)
         return adoptRef(new Memory(initial, maximum, sharingMode, WTFMove(notifyMemoryPressure), WTFMove(syncTryToReclaimMemory), WTFMove(growSuccessCallback)));
 
-    switch (sharingMode) {
-    case MemorySharingMode::Default: {
         void* slowMemory = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, initialBytes);
         if (!slowMemory) {
             memoryManager().freePhysicalBytes(initialBytes);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -47,7 +47,7 @@ namespace LLInt {
     extern "C" SlowPathReturnType slow_path_wasm_##name(CallFrame* callFrame, const Instruction* pc, Wasm::Instance* instance)
 
 #define WASM_SLOW_PATH_HIDDEN_DECL(name) \
-    WASM_SLOW_PATH_DECL(name) WTF_INTERNAL
+    WASM_SLOW_PATH_DECL(name) REFERENCED_FROM_ASM WTF_INTERNAL
 
 #if ENABLE(WEBASSEMBLY_B3JIT)
 WASM_SLOW_PATH_HIDDEN_DECL(prologue_osr);
@@ -82,9 +82,9 @@ WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait32);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait64);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_notify);
 
-extern "C" SlowPathReturnType slow_path_wasm_throw_exception(CallFrame*, const Instruction*, Wasm::Instance* instance, Wasm::ExceptionType) WTF_INTERNAL;
-extern "C" SlowPathReturnType slow_path_wasm_popcount(const Instruction* pc, uint32_t) WTF_INTERNAL;
-extern "C" SlowPathReturnType slow_path_wasm_popcountll(const Instruction* pc, uint64_t) WTF_INTERNAL;
+extern "C" SlowPathReturnType slow_path_wasm_throw_exception(CallFrame*, const Instruction*, Wasm::Instance* instance, Wasm::ExceptionType) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" SlowPathReturnType slow_path_wasm_popcount(const Instruction* pc, uint32_t) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" SlowPathReturnType slow_path_wasm_popcountll(const Instruction* pc, uint64_t) REFERENCED_FROM_ASM WTF_INTERNAL;
 
 } } // namespace JSC::LLInt
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/CrossThreadTask.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/CrossThreadTask.h
@@ -85,7 +85,7 @@ void callMemberFunctionForCrossThreadTask(C* object, MF function, ArgsTuple&& ar
     callMemberFunctionForCrossThreadTaskImpl(object, function, std::forward<ArgsTuple>(args), ArgsIndicies());
 }
 
-template<typename T, typename std::enable_if<std::is_base_of<ThreadSafeRefCounted<T>, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
+template<typename T, typename std::enable_if<std::is_base_of<ThreadSafeRefCountedBase, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
 CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
 {
     return CrossThreadTask([callee = makeRefPtr(&callee), method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {
@@ -93,7 +93,7 @@ CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...
     });
 }
 
-template<typename T, typename std::enable_if<!std::is_base_of<ThreadSafeRefCounted<T>, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
+template<typename T, typename std::enable_if<!std::is_base_of<ThreadSafeRefCountedBase, T>::value, int>::type = 0, typename... Parameters, typename... Arguments>
 CrossThreadTask createCrossThreadTask(T& callee, void (T::*method)(Parameters...), const Arguments&... arguments)
 {
     return CrossThreadTask([callee = &callee, method, arguments = std::make_tuple(crossThreadCopy(arguments)...)]() mutable {

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/ObjectIdentifier.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/ObjectIdentifier.h
@@ -63,6 +63,7 @@ public:
 
     ObjectIdentifier(HashTableDeletedValueType) : m_identifier(hashTableDeletedValue()) { }
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
+    bool isValid() const { return isValidIdentifier(m_identifier); }
 
     template<typename Encoder> void encode(Encoder& encoder) const
     {

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/Ref.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/Ref.h
@@ -57,8 +57,8 @@ public:
         if (__asan_address_is_poisoned(this))
             __asan_unpoison_memory_region(this, sizeof(*this));
 #endif
-        if (m_ptr)
-            PtrTraits::unwrap(m_ptr)->deref();
+        if (auto* ptr = PtrTraits::exchange(m_ptr, nullptr))
+            ptr->deref();
     }
 
     Ref(T& object)

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/URLHelpers.cpp
@@ -67,12 +67,37 @@ void loadIDNAllowedScriptList()
 
 #endif // !PLATFORM(COCOA)
 
-static bool isArmenianLookalikeCharacter(UChar32 codePoint)
+template<UScriptCode> bool isLookalikeCharacterOfScriptType(UChar32);
+
+template<> bool isLookalikeCharacterOfScriptType<USCRIPT_ARMENIAN>(UChar32 codePoint)
 {
-    return codePoint == 0x0548 || codePoint == 0x054D || codePoint == 0x0578 || codePoint == 0x057D;
+    switch (codePoint) {
+    case 0x0548: /* ARMENIAN CAPITAL LETTER VO */
+    case 0x054D: /* ARMENIAN CAPITAL LETTER SEH */
+    case 0x0551: /* ARMENIAN CAPITAL LETTER CO */
+    case 0x0555: /* ARMENIAN CAPITAL LETTER OH */
+    case 0x0578: /* ARMENIAN SMALL LETTER VO */
+    case 0x057D: /* ARMENIAN SMALL LETTER SEH */
+    case 0x0581: /* ARMENIAN SMALL LETTER CO */
+    case 0x0585: /* ARMENIAN SMALL LETTER OH */
+        return true;
+    default:
+        return false;
+    }
 }
 
-static bool isArmenianScriptCharacter(UChar32 codePoint)
+template<> bool isLookalikeCharacterOfScriptType<USCRIPT_TAMIL>(UChar32 codePoint)
+{
+    switch (codePoint) {
+    case 0x0BE6: /* TAMIL DIGIT ZERO */
+        return true;
+    default:
+        return false;
+    }
+}
+
+template <UScriptCode ScriptType>
+bool isOfScriptType(UChar32 codePoint)
 {
     UErrorCode error = U_ZERO_ERROR;
     UScriptCode script = uscript_getScript(codePoint, &error);
@@ -80,8 +105,7 @@ static bool isArmenianScriptCharacter(UChar32 codePoint)
         LOG_ERROR("got ICU error while trying to look at scripts: %d", error);
         return false;
     }
-
-    return script == USCRIPT_ARMENIAN;
+    return script == ScriptType;
 }
 
 template<typename CharacterType> inline bool isASCIIDigitOrValidHostCharacter(CharacterType charCode)
@@ -106,7 +130,20 @@ template<typename CharacterType> inline bool isASCIIDigitOrValidHostCharacter(Ch
     }
 }
 
-static bool isLookalikeCharacter(const Optional<UChar32>& previousCodePoint, UChar32 charCode)
+template <UScriptCode ScriptType>
+bool isLookalikeSequence(const Optional<UChar32>& previousCodePoint, UChar32 codePoint)
+{
+    if (!previousCodePoint || *previousCodePoint == '/')
+        return false;
+
+    auto isLookalikePair = [] (UChar first, UChar second) {
+        return isLookalikeCharacterOfScriptType<ScriptType>(first) && !(isOfScriptType<ScriptType>(second) || isASCIIDigitOrValidHostCharacter(second));
+    };
+    return isLookalikePair(codePoint, *previousCodePoint)
+        || isLookalikePair(*previousCodePoint, codePoint);
+}
+
+static bool isLookalikeCharacter(const Optional<UChar32>& previousCodePoint, UChar32 codePoint)
 {
     // This function treats the following as unsafe, lookalike characters:
     // any non-printable character, any character considered as whitespace,
@@ -119,10 +156,10 @@ static bool isLookalikeCharacter(const Optional<UChar32>& previousCodePoint, UCh
     // slashes into an ASCII solidus. But one of the two callers uses this
     // on characters that have not been processed by ICU, so they are needed here.
 
-    if (!u_isprint(charCode) || u_isUWhiteSpace(charCode) || u_hasBinaryProperty(charCode, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
+    if (!u_isprint(codePoint) || u_isUWhiteSpace(codePoint) || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
         return true;
 
-    switch (charCode) {
+    switch (codePoint) {
     case 0x00BC: /* VULGAR FRACTION ONE QUARTER */
     case 0x00BD: /* VULGAR FRACTION ONE HALF */
     case 0x00BE: /* VULGAR FRACTION THREE QUARTERS */
@@ -250,19 +287,11 @@ static bool isLookalikeCharacter(const Optional<UChar32>& previousCodePoint, UCh
         return previousCodePoint == 0x0237 /* LATIN SMALL LETTER DOTLESS J */
             || previousCodePoint == 0x0131 /* LATIN SMALL LETTER DOTLESS I */
             || previousCodePoint == 0x05D5; /* HEBREW LETTER VAV */
-    case 0x0548: /* ARMENIAN CAPITAL LETTER VO */
-    case 0x054D: /* ARMENIAN CAPITAL LETTER SEH */
-    case 0x0578: /* ARMENIAN SMALL LETTER VO */
-    case 0x057D: /* ARMENIAN SMALL LETTER SEH */
-        return previousCodePoint
-            && !isASCIIDigitOrValidHostCharacter(previousCodePoint.value())
-            && !isArmenianScriptCharacter(previousCodePoint.value());
     case '.':
         return false;
     default:
-        return previousCodePoint
-            && isArmenianLookalikeCharacter(previousCodePoint.value())
-            && !(isArmenianScriptCharacter(charCode) || isASCIIDigitOrValidHostCharacter(charCode));
+        return isLookalikeSequence<USCRIPT_ARMENIAN>(previousCodePoint, codePoint)
+            || isLookalikeSequence<USCRIPT_TAMIL>(previousCodePoint, codePoint);
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/dtoa.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/dtoa.h
@@ -27,7 +27,9 @@
 
 namespace WTF {
 
-using NumberToStringBuffer = std::array<char, 123>;
+// Only toFixed() can use all the 124 positions. The format is:
+// <-> + <21 digits> + decimal point + <100 digits> + null char = 124.
+using NumberToStringBuffer = std::array<char, 124>;
 
 WTF_EXPORT_PRIVATE const char* numberToString(float, NumberToStringBuffer&);
 WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(float, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-class FetchBodyOwner : public RefCounted<FetchBodyOwner>, public ActiveDOMObject {
+class FetchBodyOwner : public RefCounted<FetchBodyOwner>, public ActiveDOMObject, public CanMakeWeakPtr<FetchBodyOwner> {
 public:
     FetchBodyOwner(ScriptExecutionContext&, Optional<FetchBody>&&, Ref<FetchHeaders>&&);
     ~FetchBodyOwner();

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 FetchBodySource::FetchBodySource(FetchBodyOwner& bodyOwner)
-    : m_bodyOwner(&bodyOwner)
+    : m_bodyOwner(makeWeakPtr(bodyOwner))
 {
 }
 
@@ -68,7 +68,6 @@ void FetchBodySource::doPull()
 void FetchBodySource::doCancel()
 {
     m_isCancelling = true;
-    ASSERT(m_bodyOwner || m_isClosed);
     if (!m_bodyOwner)
         return;
 
@@ -79,6 +78,7 @@ void FetchBodySource::doCancel()
 void FetchBodySource::close()
 {
 #if ASSERT_ENABLED
+    ASSERT(!m_isClosed);
     m_isClosed = true;
 #endif
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -57,7 +57,8 @@ private:
     void setActive() final;
     void setInactive() final;
 
-    FetchBodyOwner* m_bodyOwner;
+    WeakPtr<FetchBodyOwner> m_bodyOwner;
+
     bool m_isCancelling { false };
 #if ASSERT_ENABLED
     bool m_isClosed { false };

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -47,7 +47,7 @@ class FetchRequest;
 struct ReadableStreamChunk;
 class ReadableStreamSource;
 
-class FetchResponse final : public FetchBodyOwner, public CanMakeWeakPtr<FetchResponse> {
+class FetchResponse final : public FetchBodyOwner {
 public:
     using Type = ResourceResponse::Type;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -311,7 +311,8 @@ void IDBRequest::dispatchEvent(Event& event)
     else if (m_transaction && !m_transaction->didDispatchAbortOrCommit())
         targets = { this, m_transaction.get(), &m_transaction->database() };
 
-    m_hasPendingActivity = false;
+    if (event.isTrusted())
+        m_hasPendingActivity = false;
 
     {
         TransactionActivator activator(m_transaction.get());

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -584,8 +584,8 @@ IDBError MemoryIDBBackingStore::iterateCursor(const IDBResourceIdentifier& trans
 
 void MemoryIDBBackingStore::registerObjectStore(Ref<MemoryObjectStore>&& objectStore)
 {
-    ASSERT(!m_objectStoresByIdentifier.contains(objectStore->info().identifier()));
-    ASSERT(!m_objectStoresByName.contains(objectStore->info().name()));
+    RELEASE_ASSERT(!m_objectStoresByIdentifier.contains(objectStore->info().identifier()));
+    RELEASE_ASSERT(!m_objectStoresByName.contains(objectStore->info().name()));
 
     auto identifier = objectStore->info().identifier();
     m_objectStoresByName.set(objectStore->info().name(), &objectStore.get());

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -102,7 +102,7 @@ private:
     HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryBackingStoreTransaction>> m_transactions;
 
     HashMap<uint64_t, RefPtr<MemoryObjectStore>> m_objectStoresByIdentifier;
-    HashMap<String, MemoryObjectStore*> m_objectStoresByName;
+    HashMap<String, RefPtr<MemoryObjectStore>> m_objectStoresByName;
 };
 
 } // namespace IDBServer

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -46,7 +46,7 @@ class ServerOpenDBRequest;
 class UniqueIDBDatabase;
 class UniqueIDBDatabaseTransaction;
 
-class UniqueIDBDatabaseConnection : public RefCounted<UniqueIDBDatabaseConnection>, public Identified<UniqueIDBDatabaseConnection> {
+class UniqueIDBDatabaseConnection : public RefCounted<UniqueIDBDatabaseConnection>, public Identified<UniqueIDBDatabaseConnection>, public CanMakeWeakPtr<UniqueIDBDatabaseConnection> {
 public:
     static Ref<UniqueIDBDatabaseConnection> create(UniqueIDBDatabase&, ServerOpenDBRequest&);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -43,21 +43,27 @@ Ref<UniqueIDBDatabaseTransaction> UniqueIDBDatabaseTransaction::create(UniqueIDB
 }
 
 UniqueIDBDatabaseTransaction::UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConnection& connection, const IDBTransactionInfo& info)
-    : m_databaseConnection(&connection)
+    : m_databaseConnection(makeWeakPtr(&connection))
     , m_transactionInfo(info)
 {
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     if (m_transactionInfo.mode() == IDBTransactionMode::Versionchange)
         m_originalDatabaseInfo = makeUnique<IDBDatabaseInfo>(database->info());
 
-    m_databaseConnection->server()->registerTransaction(*this);
+    databaseConnection().server()->registerTransaction(*this);
 }
 
 UniqueIDBDatabaseTransaction::~UniqueIDBDatabaseTransaction()
 {
-    m_databaseConnection->server()->unregisterTransaction(*this);
+    databaseConnection().server()->unregisterTransaction(*this);
+}
+
+UniqueIDBDatabaseConnection& UniqueIDBDatabaseTransaction::databaseConnection()
+{
+    RELEASE_ASSERT(m_databaseConnection);
+    return *m_databaseConnection;
 }
 
 IDBDatabaseInfo* UniqueIDBDatabaseTransaction::originalDatabaseInfo() const
@@ -70,13 +76,13 @@ void UniqueIDBDatabaseTransaction::abort()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abort");
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->abortTransaction(*this, [this](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abort (callback)");
 
-        m_databaseConnection->didAbortTransaction(*this, error);
+        databaseConnection().didAbortTransaction(*this, error);
     });
 }
 
@@ -84,7 +90,7 @@ void UniqueIDBDatabaseTransaction::abortWithoutCallback()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::abortWithoutCallback");
 
-    m_databaseConnection->abortTransactionWithoutCallback(*this);
+    databaseConnection().abortTransactionWithoutCallback(*this);
 }
 
 bool UniqueIDBDatabaseTransaction::isVersionChange() const
@@ -101,12 +107,12 @@ void UniqueIDBDatabaseTransaction::commit()
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit");
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
 
     database->commitTransaction(*this, [this](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit (callback)");
 
-        m_databaseConnection->didCommitTransaction(*this, error);
+        databaseConnection().didCommitTransaction(*this, error);
     });
 }
 
@@ -117,16 +123,16 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->createObjectStore(*this, info, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createObjectStore (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didCreateObjectStore(IDBResultData::createObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection().didCreateObjectStore(IDBResultData::createObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didCreateObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didCreateObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -137,16 +143,16 @@ void UniqueIDBDatabaseTransaction::deleteObjectStore(const IDBRequestData& reque
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->deleteObjectStore(*this, objectStoreName, [this, requestData](const IDBError& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteObjectStore (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didDeleteObjectStore(IDBResultData::deleteObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection().didDeleteObjectStore(IDBResultData::deleteObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didDeleteObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didDeleteObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -157,16 +163,16 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->renameObjectStore(*this, objectStoreIdentifier, newName, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameObjectStore (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didRenameObjectStore(IDBResultData::renameObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection().didRenameObjectStore(IDBResultData::renameObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didRenameObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didRenameObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -176,16 +182,16 @@ void UniqueIDBDatabaseTransaction::clearObjectStore(const IDBRequestData& reques
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->clearObjectStore(*this, objectStoreIdentifier, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::clearObjectStore (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didClearObjectStore(IDBResultData::clearObjectStoreSuccess(requestData.requestIdentifier()));
+            databaseConnection().didClearObjectStore(IDBResultData::clearObjectStoreSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didClearObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didClearObjectStore(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -196,16 +202,16 @@ void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->createIndex(*this, info, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createIndex (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didCreateIndex(IDBResultData::createIndexSuccess(requestData.requestIdentifier()));
+            databaseConnection().didCreateIndex(IDBResultData::createIndexSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didCreateIndex(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didCreateIndex(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -216,16 +222,16 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->deleteIndex(*this, objectStoreIdentifier, indexName, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::createIndex (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didDeleteIndex(IDBResultData::deleteIndexSuccess(requestData.requestIdentifier()));
+            databaseConnection().didDeleteIndex(IDBResultData::deleteIndexSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didDeleteIndex(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didDeleteIndex(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -236,16 +242,16 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
     ASSERT(isVersionChange());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->renameIndex(*this, objectStoreIdentifier, indexIdentifier, newName, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::renameIndex (callback)");
 
         if (error.isNull())
-            m_databaseConnection->didRenameIndex(IDBResultData::renameIndexSuccess(requestData.requestIdentifier()));
+            databaseConnection().didRenameIndex(IDBResultData::renameIndexSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->didRenameIndex(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().didRenameIndex(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -257,16 +263,16 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
     ASSERT(!isReadOnly());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->putOrAdd(requestData, keyData, value, overwriteMode, [this, requestData](auto& error, const IDBKeyData& key) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::putOrAdd (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
+            databaseConnection().connectionToClient().didPutOrAdd(IDBResultData::putOrAddSuccess(requestData.requestIdentifier(), key));
         else
-            m_databaseConnection->connectionToClient().didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didPutOrAdd(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -276,16 +282,16 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->getRecord(requestData, getRecordData, [this, requestData](auto& error, const IDBGetResult& result) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getRecord (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
+            databaseConnection().connectionToClient().didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
         else
-            m_databaseConnection->connectionToClient().didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -295,16 +301,16 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->getAllRecords(requestData, getAllRecordsData, [this, requestData](auto& error, const IDBGetAllResult& result) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getAllRecords (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
+            databaseConnection().connectionToClient().didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
         else
-            m_databaseConnection->connectionToClient().didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -314,16 +320,16 @@ void UniqueIDBDatabaseTransaction::getCount(const IDBRequestData& requestData, c
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->getCount(requestData, keyRangeData, [this, requestData](auto& error, uint64_t count) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::getCount (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
+            databaseConnection().connectionToClient().didGetCount(IDBResultData::getCountSuccess(requestData.requestIdentifier(), count));
         else
-            m_databaseConnection->connectionToClient().didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didGetCount(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -333,16 +339,16 @@ void UniqueIDBDatabaseTransaction::deleteRecord(const IDBRequestData& requestDat
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->deleteRecord(requestData, keyRangeData, [this, requestData](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::deleteRecord (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
+            databaseConnection().connectionToClient().didDeleteRecord(IDBResultData::deleteRecordSuccess(requestData.requestIdentifier()));
         else
-            m_databaseConnection->connectionToClient().didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didDeleteRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -352,16 +358,16 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->openCursor(requestData, info, [this, requestData](auto& error, const IDBGetResult& result) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::openCursor (callback)");
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
+            databaseConnection().connectionToClient().didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
         else
-            m_databaseConnection->connectionToClient().didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -371,7 +377,7 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
 
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
 
-    auto database = m_databaseConnection->database();
+    auto database = databaseConnection().database();
     ASSERT(database);
 
     database->iterateCursor(requestData, data, [this, requestData, option = data.option](auto& error, const IDBGetResult& result) {
@@ -381,9 +387,9 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
             return;
 
         if (error.isNull())
-            m_databaseConnection->connectionToClient().didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
+            databaseConnection().connectionToClient().didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
         else
-            m_databaseConnection->connectionToClient().didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
+            databaseConnection().connectionToClient().didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
 }
 
@@ -392,7 +398,7 @@ const Vector<uint64_t>& UniqueIDBDatabaseTransaction::objectStoreIdentifiers()
     if (!m_objectStoreIdentifiers.isEmpty())
         return m_objectStoreIdentifiers;
 
-    auto& info = m_databaseConnection->database()->info();
+    auto& info = databaseConnection().database()->info();
     for (const auto& objectStoreName : info.objectStoreNames()) {
         auto objectStoreInfo = info.infoForExistingObjectStore(objectStoreName);
         ASSERT(objectStoreInfo);
@@ -410,7 +416,7 @@ void UniqueIDBDatabaseTransaction::didActivateInBackingStore(const IDBError& err
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::didActivateInBackingStore");
 
-    m_databaseConnection->connectionToClient().didStartTransaction(m_transactionInfo.identifier(), error);
+    databaseConnection().connectionToClient().didStartTransaction(m_transactionInfo.identifier(), error);
 }
 
 } // namespace IDBServer

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -58,7 +58,7 @@ public:
 
     ~UniqueIDBDatabaseTransaction();
 
-    UniqueIDBDatabaseConnection& databaseConnection() { return *m_databaseConnection; }
+    UniqueIDBDatabaseConnection& databaseConnection();
     const IDBTransactionInfo& info() const { return m_transactionInfo; }
     bool isVersionChange() const;
     bool isReadOnly() const;
@@ -94,7 +94,7 @@ public:
 private:
     UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConnection&, const IDBTransactionInfo&);
 
-    UniqueIDBDatabaseConnection* m_databaseConnection;
+    WeakPtr<UniqueIDBDatabaseConnection> m_databaseConnection;
     IDBTransactionInfo m_transactionInfo;
 
     std::unique_ptr<IDBDatabaseInfo> m_originalDatabaseInfo;

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -64,7 +64,7 @@ namespace WebCore {
 
 LibWebRTCMediaEndpoint::LibWebRTCMediaEndpoint(LibWebRTCPeerConnectionBackend& peerConnection, LibWebRTCProvider& client)
     : m_peerConnectionBackend(peerConnection)
-    , m_peerConnectionFactory(*client.factory())
+    , m_peerConnectionFactory(client.factory())
     , m_createSessionDescriptionObserver(*this)
     , m_setLocalSessionDescriptionObserver(*this)
     , m_setRemoteSessionDescriptionObserver(*this)
@@ -236,13 +236,13 @@ bool LibWebRTCMediaEndpoint::addTrack(LibWebRTCRtpSenderBackend& sender, MediaSt
     switch (track.privateTrack().type()) {
     case RealtimeMediaSource::Type::Audio: {
         auto audioSource = RealtimeOutgoingAudioSource::create(track.privateTrack());
-        rtcTrack = m_peerConnectionFactory.CreateAudioTrack(track.id().utf8().data(), audioSource.ptr());
+        rtcTrack = m_peerConnectionFactory->CreateAudioTrack(track.id().utf8().data(), audioSource.ptr());
         source = WTFMove(audioSource);
         break;
     }
     case RealtimeMediaSource::Type::Video: {
         auto videoSource = RealtimeOutgoingVideoSource::create(track.privateTrack());
-        rtcTrack = m_peerConnectionFactory.CreateVideoTrack(track.id().utf8().data(), videoSource.ptr());
+        rtcTrack = m_peerConnectionFactory->CreateVideoTrack(track.id().utf8().data(), videoSource.ptr());
         source = WTFMove(videoSource);
         break;
     }
@@ -456,13 +456,13 @@ std::pair<LibWebRTCRtpSenderBackend::Source, rtc::scoped_refptr<webrtc::MediaStr
         break;
     case RealtimeMediaSource::Type::Audio: {
         auto audioSource = RealtimeOutgoingAudioSource::create(track.privateTrack());
-        rtcTrack = m_peerConnectionFactory.CreateAudioTrack(track.id().utf8().data(), audioSource.ptr());
+        rtcTrack = m_peerConnectionFactory->CreateAudioTrack(track.id().utf8().data(), audioSource.ptr());
         source = WTFMove(audioSource);
         break;
     }
     case RealtimeMediaSource::Type::Video: {
         auto videoSource = RealtimeOutgoingVideoSource::create(track.privateTrack());
-        rtcTrack = m_peerConnectionFactory.CreateVideoTrack(track.id().utf8().data(), videoSource.ptr());
+        rtcTrack = m_peerConnectionFactory->CreateVideoTrack(track.id().utf8().data(), videoSource.ptr());
         source = WTFMove(videoSource);
         break;
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -180,7 +180,7 @@ private:
 #endif
 
     LibWebRTCPeerConnectionBackend& m_peerConnectionBackend;
-    webrtc::PeerConnectionFactoryInterface& m_peerConnectionFactory;
+    rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> m_backend;
 
     friend CreateSessionDescriptionObserver<LibWebRTCMediaEndpoint>;

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -312,7 +312,7 @@ ExceptionOr<void> AudioNode::disconnect(AudioNode& destinationNode, unsigned out
     if (outputIndex >= numberOfOutputs())
         return Exception { IndexSizeError, "output index is out of bounds"_s };
 
-    if (outputIndex >= destinationNode.numberOfInputs())
+    if (inputIndex >= destinationNode.numberOfInputs())
         return Exception { IndexSizeError, "input index is out of bounds"_s };
 
     auto* output = this->output(outputIndex);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -82,13 +82,13 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!jsConstructor->isConstructor(vm))
-        return Exception { TypeError, "Class definitition passed to registerProcessor() is not a constructor"_s };
+        return Exception { TypeError, "Class definition passed to registerProcessor() is not a constructor"_s };
 
     auto prototype = jsConstructor->getPrototype(vm, globalObject);
     RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
 
     if (!prototype.isObject())
-        return Exception { TypeError, "Class definitition passed to registerProcessor() has invalid prototype"_s };
+        return Exception { TypeError, "Class definition passed to registerProcessor() has invalid prototype"_s };
 
     auto parameterDescriptorsValue = jsConstructor->get(globalObject, JSC::Identifier::fromString(vm, "parameterDescriptors"));
     RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
@@ -110,7 +110,11 @@ ExceptionOr<void> AudioWorkletGlobalScope::registerProcessor(String&& name, Ref<
         }
     }
 
-    m_processorConstructorMap.add(name, WTFMove(processorContructor));
+    auto addResult = m_processorConstructorMap.add(name, WTFMove(processorContructor));
+
+    // We've already checked at the beginning of this function but then we ran some JS so we need to check again.
+    if (!addResult.isNewEntry)
+        return Exception { NotSupportedError, "A processor was already registered with this name"_s };
 
     thread().messagingProxy().postTaskToAudioWorklet([name = name.isolatedCopy(), parameterDescriptors = crossThreadCopy(parameterDescriptors)](AudioWorklet& worklet) mutable {
         ASSERT(isMainThread());

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -65,15 +65,6 @@ static JSObject* toJSObject(JSValueInWrappedObject& wrapper)
     return wrapper ? jsCast<JSObject*>(static_cast<JSValue>(wrapper)) : nullptr;
 }
 
-static void forEachChannelDataJSArray(JSGlobalObject& globalObject, JSArray& jsArray, const Function<void(unsigned busIndex, unsigned channelIndex, JSFloat32Array& channelData)>& apply)
-{
-    for (unsigned busIndex = 0, busCount = jsArray.length(); busIndex < busCount; ++busIndex) {
-        auto* channelsArray = jsCast<JSArray*>(jsArray.getIndex(&globalObject, busIndex));
-        for (unsigned channelIndex = 0, channelCount = channelsArray->length(); channelIndex < channelCount; ++channelIndex)
-            apply(busIndex, channelIndex, *jsCast<JSFloat32Array*>(channelsArray->getIndex(&globalObject, channelIndex)));
-    }
-}
-
 static JSFloat32Array* constructJSFloat32Array(JSGlobalObject& globalObject, unsigned length, const float* data = nullptr)
 {
     auto* jsArray = JSFloat32Array::create(&globalObject, globalObject.typedArrayStructure(TypeFloat32), length);
@@ -143,70 +134,65 @@ static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, const JSArr
     }
 }
 
-static void copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vector<RefPtr<AudioBus>>& buses, JSArray& jsArray)
-{
-    forEachChannelDataJSArray(globalObject, jsArray, [&](unsigned busIndex, unsigned channelIndex, JSFloat32Array& channelData) {
-        auto* channel = buses[busIndex]->channel(channelIndex);
-        ASSERT(channelData.length() == channel->length());
-        memcpy(channelData.typedVector(), channel->mutableData(), sizeof(float) * channel->length());
-    });
-}
-
-static void copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObject, const HashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, JSObject& jsObject)
-{
-    for (auto& pair : paramValuesMap) {
-        auto* jsTypedArray = jsCast<JSFloat32Array*>(jsObject.get(&globalObject, Identifier::fromString(vm, pair.key)));
-        ASSERT(pair.value->size() >= jsTypedArray->length());
-        memcpy(jsTypedArray->typedVector(), pair.value->data(), sizeof(float) * jsTypedArray->length());
-    }
-}
-
-template<typename T>
-static bool busTopologyMatchesJSArray(JSGlobalObject& globalObject, const Vector<T>& buses, JSArray* jsArray)
+static bool copyDataFromBusesToJSArray(VM& vm, JSGlobalObject& globalObject, const Vector<RefPtr<AudioBus>>& buses, JSArray* jsArray)
 {
     if (!jsArray)
         return false;
 
-    ASSERT_WITH_MESSAGE(jsArray->length() == buses.size(), "Number of inputs/outputs cannot change after construction");
-
-    for (unsigned i = 0; i < buses.size(); ++i) {
-        auto& bus = buses[i];
-        auto* channelsArray = jsCast<JSArray*>(jsArray->getIndex(&globalObject, i));
+    for (size_t busIndex = 0; busIndex < buses.size(); ++busIndex) {
+        auto& bus = buses[busIndex];
+        auto* jsChannelsArray = jsDynamicCast<JSArray*>(vm, jsArray->getIndex(&globalObject, busIndex));
         unsigned numberOfChannels = busChannelCount(bus.get());
-        if (channelsArray->length() != numberOfChannels)
+        if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
             return false;
-
-        for (unsigned j = 0; j < numberOfChannels; ++j) {
-            auto* channel = bus->channel(j);
-            auto* jsChannelData = jsCast<JSFloat32Array*>(channelsArray->getIndex(&globalObject, j));
-            if (jsChannelData->length() != channel->length())
+        for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
+            auto* channel = bus->channel(channelIndex);
+            auto* jsChannelArray = jsDynamicCast<JSFloat32Array*>(vm, jsChannelsArray->getIndex(&globalObject, channelIndex));
+            if (!jsChannelArray || jsChannelArray->length() != channel->length())
                 return false;
+            memcpy(jsChannelArray->typedVector(), channel->mutableData(), sizeof(float) * jsChannelArray->length());
         }
     }
-
     return true;
 }
 
-static bool parameterMapTopologyMatchesJSObject(VM& vm, JSGlobalObject& globalObject, const HashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, JSObject* jsObject)
+static bool copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObject, const HashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap, JSObject* jsObject)
 {
     if (!jsObject)
         return false;
 
     for (auto& pair : paramValuesMap) {
-        auto* jsTypedArray = jsCast<JSFloat32Array*>(jsObject->get(&globalObject, Identifier::fromString(vm, pair.key)));
+        auto* jsTypedArray = jsDynamicCast<JSFloat32Array*>(vm, jsObject->get(&globalObject, Identifier::fromString(vm, pair.key)));
+        if (!jsTypedArray)
+            return false;
         unsigned expectedLength = pair.value->containsConstantValue() ? 1 : pair.value->size();
         if (jsTypedArray->length() != expectedLength)
             return false;
+        memcpy(jsTypedArray->typedVector(), pair.value->data(), sizeof(float) * jsTypedArray->length());
     }
-
     return true;
 }
 
-static void zeroJSArray(JSGlobalObject& globalObject, JSArray& jsArray)
+static bool zeroJSArray(VM& vm, JSGlobalObject& globalObject, const Vector<Ref<AudioBus>>& outputs, JSArray* jsArray)
 {
-    forEachChannelDataJSArray(globalObject, jsArray, [](unsigned, unsigned, JSFloat32Array& channelData) {
-        memset(channelData.typedVector(), 0, sizeof(float) * channelData.length());
-    });
+    if (!jsArray)
+        return false;
+
+    for (size_t busIndex = 0; busIndex < outputs.size(); ++busIndex) {
+        auto& bus = outputs[busIndex];
+        auto* jsChannelsArray = jsDynamicCast<JSArray*>(vm, jsArray->getIndex(&globalObject, busIndex));
+        unsigned numberOfChannels = busChannelCount(bus.get());
+        if (!jsChannelsArray || jsChannelsArray->length() != numberOfChannels)
+            return false;
+        for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
+            auto* channel = bus->channel(channelIndex);
+            auto* jsChannelArray = jsDynamicCast<JSFloat32Array*>(vm, jsChannelsArray->getIndex(&globalObject, channelIndex));
+            if (!jsChannelArray || jsChannelArray->length() != channel->length())
+                return false;
+            memset(jsChannelArray->typedVector(), 0, sizeof(float) * jsChannelArray->length());
+        }
+    }
+    return true;
 }
 
 ExceptionOr<Ref<AudioWorkletProcessor>> AudioWorkletProcessor::create(ScriptExecutionContext& context)
@@ -230,21 +216,15 @@ AudioWorkletProcessor::AudioWorkletProcessor(const AudioWorkletProcessorConstruc
 void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObject, MarkedArgumentBuffer& args, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const HashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap)
 {
     // For performance reasons, we cache the arrays passed to JS and reconstruct them only when the topology changes.
-    if (busTopologyMatchesJSArray(globalObject, inputs, toJSArray(m_jsInputs)))
-        copyDataFromBusesToJSArray(globalObject, inputs, *toJSArray(m_jsInputs));
-    else
+    if (!copyDataFromBusesToJSArray(vm, globalObject, inputs, toJSArray(m_jsInputs)))
         m_jsInputs = { constructFrozenJSArray(vm, globalObject, inputs, ShouldPopulateWithBusData::Yes) };
     args.append(m_jsInputs);
 
-    if (busTopologyMatchesJSArray(globalObject, outputs, toJSArray(m_jsOutputs)))
-        zeroJSArray(globalObject, *toJSArray(m_jsOutputs));
-    else
+    if (!zeroJSArray(vm, globalObject, outputs, toJSArray(m_jsOutputs)))
         m_jsOutputs = { constructFrozenJSArray(vm, globalObject, outputs, ShouldPopulateWithBusData::No) };
     args.append(m_jsOutputs);
 
-    if (parameterMapTopologyMatchesJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues)))
-        copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, *toJSObject(m_jsParamValues));
-    else
+    if (!copyDataFromParameterMapToJSObject(vm, globalObject, paramValuesMap, toJSObject(m_jsParamValues)))
         m_jsParamValues = { constructFrozenKeyValueObject(vm, globalObject, paramValuesMap) };
     args.append(m_jsParamValues);
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/animation/WebAnimation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/animation/WebAnimation.cpp
@@ -120,7 +120,7 @@ void WebAnimation::remove()
     // This object could be deleted after either clearing the effect or timeline relationship.
     auto protectedThis = makeRef(*this);
     setEffectInternal(nullptr);
-    setTimelineInternal(nullptr);
+    setTimeline(nullptr);
 }
 
 void WebAnimation::suspendEffectInvalidation()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -122,9 +122,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsDOMWindowInstanceFunction_postMessageNonCaching, (JSG
 template<typename Visitor>
 void JSDOMWindow::visitAdditionalChildren(Visitor& visitor)
 {
-    if (Frame* frame = wrapped().frame())
-        visitor.addOpaqueRoot(frame);
-
     visitor.addOpaqueRoot(&wrapped());
 
     // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildren() would call this. But

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/ScriptCachedFrameData.cpp
@@ -91,7 +91,7 @@ void ScriptCachedFrameData::restore(Frame& frame)
         }
 
         if (page)
-            windowProxy->window()->setConsoleClient(&page->console());
+            windowProxy->window()->setConsoleClient(makeWeakPtr(page->console()));
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/ScriptController.cpp
@@ -276,7 +276,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
     if (Page* page = m_frame.page()) {
         windowProxy.attachDebugger(page->debugger());
         windowProxy.window()->setProfileGroup(page->group().identifier());
-        windowProxy.window()->setConsoleClient(&page->console());
+        windowProxy.window()->setConsoleClient(makeWeakPtr(page->console()));
     }
 
     m_frame.loader().dispatchDidClearWindowObjectInWorld(world);

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -188,7 +188,7 @@ void WindowProxy::setDOMWindow(AbstractDOMWindow* newDOMWindow)
         windowProxy->attachDebugger(page ? page->debugger() : nullptr);
         if (page)
             windowProxy->window()->setProfileGroup(page->group().identifier());
-        windowProxy->window()->setConsoleClient(page ? &page->console() : nullptr);
+        windowProxy->window()->setConsoleClient(page ? makeWeakPtr(page->console()) : nullptr);
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSCalculationValue.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSCalculationValue.h
@@ -44,22 +44,6 @@ class CSSParserTokenRange;
 class CSSToLengthConversionData;
 class RenderStyle;
 
-// FIXME: Unify with CSSPrimitiveValue::UnitCategory.
-enum class CalculationCategory : uint8_t {
-    Number = 0,
-    Length,
-    Percent,
-    PercentNumber,
-    PercentLength,
-    Angle,
-    Time,
-    Frequency,
-    // TODO:
-    // Flex,
-    // Resolution
-    Other
-};
-
 class CSSCalcExpressionNode : public RefCounted<CSSCalcExpressionNode> {
 public:
     enum Type {

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -330,9 +330,10 @@ static ExceptionOr<FontSelectionRequest> computeFontSelectionRequest(MutableStyl
     return {{ weightSelectionValue, stretchSelectionValue, styleSelectionValue }};
 }
 
-static HashSet<UChar32> codePointsFromString(StringView stringView)
+using CodePointsMap = HashSet<UChar32, DefaultHash<UChar32>, WTF::UnsignedWithZeroKeyHashTraits<UChar32>>;
+static CodePointsMap codePointsFromString(StringView stringView)
 {
-    HashSet<UChar32> result;
+    CodePointsMap result;
     auto graphemeClusters = stringView.graphemeClusters();
     for (auto cluster : graphemeClusters) {
         ASSERT(cluster.length() > 0);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/ComposedTreeIterator.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/ComposedTreeIterator.cpp
@@ -164,6 +164,8 @@ void ComposedTreeIterator::traverseNextInShadowTree()
         if (auto* assignedNodes = slot.assignedNodes()) {
             context().slotNodeIndex = 0;
             auto* assignedNode = assignedNodes->at(0).get();
+            ASSERT(assignedNode);
+            ASSERT(assignedNode->parentElement());
             m_contextStack.append(Context(*assignedNode->parentElement(), *assignedNode, Context::Slotted));
             return;
         }
@@ -198,8 +200,8 @@ bool ComposedTreeIterator::advanceInSlot(int direction)
         return false;
 
     auto* slotNode = assignedNodes.at(context().slotNodeIndex).get();
-    if (!slotNode)
-        return false;
+    ASSERT(slotNode);
+    ASSERT(slotNode->parentElement());
     m_contextStack.append(Context(*slotNode->parentElement(), *slotNode, Context::Slotted));
     return true;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/ContainerNode.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/ContainerNode.cpp
@@ -210,6 +210,7 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 {
     NodeVector postInsertionNotificationTargets;
     {
+        WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
         if (UNLIKELY(containerNode.isShadowRoot() || containerNode.isInShadowTree()))
@@ -628,6 +629,9 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
     ASSERT(oldChild.parentNode() == this);
 
     destroyRenderTreeIfNeeded(oldChild);
+
+    if (UNLIKELY(hasShadowRootContainingSlots()))
+        shadowRoot()->willRemoveAssignedNode(oldChild);
 
     if (nextChild) {
         nextChild->setPreviousSibling(previousChild);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.cpp
@@ -1870,21 +1870,20 @@ bool Document::hidden() const
 
 void Document::registerMediaElement(HTMLMediaElement& element)
 {
-    m_mediaElements.add(&element);
+    m_mediaElements.add(element);
 }
 
 void Document::unregisterMediaElement(HTMLMediaElement& element)
 {
-    m_mediaElements.remove(&element);
+    m_mediaElements.remove(element);
 }
 
 void Document::forEachMediaElement(const Function<void(HTMLMediaElement&)>& function)
 {
-    Vector<Ref<HTMLMediaElement>> elements;
-    for (auto* element : m_mediaElements)
-        elements.append(*element);
-    for (auto& element : elements)
-        function(element);
+    ASSERT(!m_mediaElements.hasNullReferences());
+    m_mediaElements.forEach([&](auto& element) {
+        function(makeRef(element));
+    });
 }
 
 #endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Document.h
@@ -1858,7 +1858,7 @@ private:
     HashSet<Element*> m_documentSuspensionCallbackElements;
 
 #if ENABLE(VIDEO)
-    HashSet<HTMLMediaElement*> m_mediaElements;
+    WeakHashSet<HTMLMediaElement> m_mediaElements;
 #endif
 
 #if ENABLE(VIDEO)

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Element.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Element.h
@@ -728,8 +728,6 @@ private:
 
     void attachAttributeNodeIfNeeded(Attr&);
 
-    void didChangeRenderer(RenderObject*) final;
-
 #if ASSERT_ENABLED
     WEBCORE_EXPORT bool fastAttributeLookupAllowed(const QualifiedName&) const;
 #endif

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2682,6 +2682,7 @@ template<TreeType treeType> Node* commonInclusiveAncestor(const Node& a, const N
 
 template Node* commonInclusiveAncestor<Tree>(const Node&, const Node&);
 template Node* commonInclusiveAncestor<ComposedTree>(const Node&, const Node&);
+template Node* commonInclusiveAncestor<ShadowIncludingTree>(const Node&, const Node&);
 
 static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
@@ -193,6 +193,11 @@ public:
     bool isSVGElement() const { return hasNodeFlag(NodeFlag::IsSVGElement); }
     bool isMathMLElement() const { return hasNodeFlag(NodeFlag::IsMathMLElement); }
 
+    bool isUnknownElement() const { return hasNodeFlag(NodeFlag::IsUnknownElement); }
+    bool isHTMLUnknownElement() const { return isHTMLElement() && isUnknownElement(); }
+    bool isSVGUnknownElement() const { return isSVGElement() && isUnknownElement(); }
+    bool isMathMLUnknownElement() const { return isMathMLElement() && isUnknownElement(); }
+
     bool isPseudoElement() const { return pseudoId() != PseudoId::None; }
     bool isBeforePseudoElement() const { return pseudoId() == PseudoId::Before; }
     bool isAfterPseudoElement() const { return pseudoId() == PseudoId::After; }
@@ -216,6 +221,9 @@ public:
 
     bool hasSyntheticAttrChildNodes() const { return hasNodeFlag(NodeFlag::HasSyntheticAttrChildNodes); }
     void setHasSyntheticAttrChildNodes(bool flag) { setNodeFlag(NodeFlag::HasSyntheticAttrChildNodes, flag); }
+
+    bool hasShadowRootContainingSlots() const { return hasNodeFlag(NodeFlag::HasShadowRootContainingSlots); }
+    void setHasShadowRootContainingSlots(bool flag) { setNodeFlag(NodeFlag::HasShadowRootContainingSlots, flag); }
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
@@ -535,8 +543,8 @@ protected:
         IsShadowRoot = 1 << 9,
         IsConnected = 1 << 10,
         IsInShadowTree = 1 << 11,
-        HasEventTargetData = 1 << 12,
-        // UnusedFlag = 1 << 13,
+        IsUnknownElement = 1 << 12,
+        HasEventTargetData = 1 << 13,
 
         // These bits are used by derived classes, pulled up here so they can
         // be stored in the same memory word as the Node bits above.
@@ -561,7 +569,8 @@ protected:
 
         InclusiveAncestorStateForForm = 1 << 28,
         InclusiveAncestorStateForCanvas = 1 << 29,
-        // Bits 30-31 are free.
+        HasShadowRootContainingSlots = 1 << 30,
+        // Bit 31 is free.
     };
 
     enum class TabIndexState : uint8_t {
@@ -723,8 +732,6 @@ private:
     static void moveShadowTreeToNewDocument(ShadowRoot&, Document& oldDocument, Document& newDocument);
     static void moveTreeToNewScope(Node&, TreeScope& oldScope, TreeScope& newScope);
     void moveNodeToNewDocument(Document& oldDocument, Document& newDocument);
-
-    virtual void didChangeRenderer(RenderObject*) { };
 
     struct NodeRareDataDeleter {
         void operator()(NodeRareData*) const;

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Position.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Position.cpp
@@ -1594,12 +1594,13 @@ Position makeDeprecatedLegacyPosition(const BoundaryPoint& point)
 
 Optional<BoundaryPoint> makeBoundaryPoint(const Position& position)
 {
-    if (position.isNull())
+    auto container = makeRefPtr(position.containerNode());
+    if (!container)
         return WTF::nullopt;
-    return BoundaryPoint { *position.containerNode(), static_cast<unsigned>(position.computeOffsetInContainerNode()) };
+    return BoundaryPoint { container.releaseNonNull(), static_cast<unsigned>(position.computeOffsetInContainerNode()) };
 }
 
-PartialOrdering documentOrder(const Position& a, const Position& b)
+template<TreeType treeType> PartialOrdering treeOrder(const Position& a, const Position& b)
 {
     if (a.isNull() || b.isNull())
         return a.isNull() && b.isNull() ? PartialOrdering::equivalent : PartialOrdering::unordered;
@@ -1608,7 +1609,7 @@ PartialOrdering documentOrder(const Position& a, const Position& b)
     auto bContainer = b.containerNode();
 
     if (!aContainer || !bContainer) {
-        if (!commonInclusiveAncestor<ComposedTree>(*a.anchorNode(), *b.anchorNode()))
+        if (!commonInclusiveAncestor<treeType>(*a.anchorNode(), *b.anchorNode()))
             return PartialOrdering::unordered;
         if (!aContainer && !bContainer && a.anchorType() == b.anchorType())
             return PartialOrdering::equivalent;
@@ -1619,8 +1620,16 @@ PartialOrdering documentOrder(const Position& a, const Position& b)
 
     // FIXME: Avoid computing node offset for cases where we don't need to.
 
-    return treeOrder<ComposedTree>(*makeBoundaryPoint(a), *makeBoundaryPoint(b));
+    return treeOrder<treeType>(*makeBoundaryPoint(a), *makeBoundaryPoint(b));
 }
+
+PartialOrdering documentOrder(const Position& a, const Position& b)
+{
+    return treeOrder<ComposedTree>(a, b);
+}
+
+template PartialOrdering treeOrder<ComposedTree>(const Position&, const Position&);
+template PartialOrdering treeOrder<ShadowIncludingTree>(const Position&, const Position&);
 
 } // namespace WebCore
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Position.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Position.h
@@ -221,6 +221,7 @@ private:
 bool operator==(const Position&, const Position&);
 bool operator!=(const Position&, const Position&);
 
+template<TreeType treeType> PartialOrdering treeOrder(const Position&, const Position&);
 WEBCORE_EXPORT PartialOrdering documentOrder(const Position&, const Position&);
 bool operator<(const Position&, const Position&);
 bool operator>(const Position&, const Position&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/ShadowRoot.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/ShadowRoot.h
@@ -93,6 +93,7 @@ public:
     void slotFallbackDidChange(HTMLSlotElement&);
     void resolveSlotsBeforeNodeInsertionOrRemoval();
     void willRemoveAllChildren(ContainerNode&);
+    void willRemoveAssignedNode(const Node&);
 
     void didRemoveAllChildrenOfShadowHost();
     void didChangeDefaultSlot();

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/SlotAssignment.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/SlotAssignment.cpp
@@ -120,6 +120,13 @@ void SlotAssignment::addSlotElementByName(const AtomString& name, HTMLSlotElemen
         return makeUnique<Slot>();
     });
     auto& slot = *addResult.iterator->value;
+
+    if (!m_slotAssignmentsIsValid)
+        assignSlots(shadowRoot);
+
+    shadowRoot.host()->setHasShadowRootContainingSlots(true);
+    m_slotElementCount++;
+
     bool needsSlotchangeEvent = shadowRoot.shouldFireSlotchangeEvent() && hasAssignedNodes(shadowRoot, slot);
 
     slot.elementCount++;
@@ -147,8 +154,15 @@ void SlotAssignment::removeSlotElementByName(const AtomString& name, HTMLSlotEle
     m_slotElementsForConsistencyCheck.remove(&slotElement);
 #endif
 
-    if (auto* host = shadowRoot.host()) // FIXME: We should be able to do a targeted reconstruction.
+    ASSERT(m_slotElementCount > 0);
+    m_slotElementCount--;
+
+    if (auto host = makeRefPtr(shadowRoot.host())) {
+        // FIXME: We should be able to do a targeted reconstruction.
         host->invalidateStyleAndRenderersForSubtree();
+        if (!m_slotElementCount)
+            host->setHasShadowRootContainingSlots(false);
+    }
 
     auto* slot = m_slots.get(slotNameFromAttributeValue(name));
     RELEASE_ASSERT(slot && slot->hasSlotElements());
@@ -293,14 +307,15 @@ void SlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowRoot& 
     if (!slot)
         return;
 
+    RenderTreeUpdater::tearDownRenderersAfterSlotChange(*shadowRoot.host());
+    shadowRoot.host()->invalidateStyleForSubtree();
+
     slot->assignedNodes.clear();
     m_slotAssignmentsIsValid = false;
 
     auto slotElement = makeRefPtr(findFirstSlotElement(*slot, shadowRoot));
     if (!slotElement)
         return;
-
-    shadowRoot.host()->invalidateStyleAndRenderersForSubtree();
 
     if (shadowRoot.shouldFireSlotchangeEvent())
         slotElement->enqueueSlotChangeEvent();
@@ -329,6 +344,23 @@ const Vector<WeakPtr<Node>>* SlotAssignment::assignedNodesForSlot(const HTMLSlot
         return nullptr;
 
     return &slot->assignedNodes;
+}
+
+void SlotAssignment::willRemoveAssignedNode(const Node& node)
+{
+    if (!m_slotAssignmentsIsValid)
+        return;
+
+    if (!is<Text>(node) && !is<Element>(node))
+        return;
+
+    auto* slot = m_slots.get(slotNameForHostChild(node));
+    if (!slot || slot->assignedNodes.isEmpty())
+        return;
+
+    slot->assignedNodes.removeFirstMatching([&node](const auto& item) {
+        return item.get() == &node;
+    });
 }
 
 const AtomString& SlotAssignment::slotNameForHostChild(const Node& child) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/SlotAssignment.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/SlotAssignment.h
@@ -60,6 +60,7 @@ public:
     void didChangeSlot(const AtomString&, ShadowRoot&);
 
     const Vector<WeakPtr<Node>>* assignedNodesForSlot(const HTMLSlotElement&, ShadowRoot&);
+    void willRemoveAssignedNode(const Node&);
 
     virtual void hostChildElementDidChange(const Element&, ShadowRoot&);
 
@@ -103,6 +104,7 @@ private:
     bool m_willBeRemovingAllChildren { false };
     unsigned m_slotMutationVersion { 0 };
     unsigned m_slotResolutionVersion { 0 };
+    unsigned m_slotElementCount { 0 };
 };
 
 inline void ShadowRoot::resolveSlotsBeforeNodeInsertionOrRemoval()
@@ -131,10 +133,7 @@ inline void ShadowRoot::didChangeDefaultSlot()
 
 inline void ShadowRoot::hostChildElementDidChange(const Element& childElement)
 {
-    if (!m_slotAssignment)
-        return;
-    if (m_host)
-        RenderTreeUpdater::tearDownRenderers(*m_host);
+    if (m_slotAssignment)
     m_slotAssignment->hostChildElementDidChange(childElement, *this);
 }
 
@@ -145,6 +144,12 @@ inline void ShadowRoot::hostChildElementDidChangeSlotAttribute(Element& element,
     m_slotAssignment->didChangeSlot(oldValue, *this);
     m_slotAssignment->didChangeSlot(newValue, *this);
     RenderTreeUpdater::tearDownRenderers(element);
+}
+
+inline void ShadowRoot::willRemoveAssignedNode(const Node& node)
+{
+    if (m_slotAssignment)
+        m_slotAssignment->willRemoveAssignedNode(node);
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/TaskSource.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/TaskSource.h
@@ -36,6 +36,7 @@ enum class TaskSource : uint8_t {
     MediaElement,
     Microtask,
     Networking,
+    PerformanceTimeline,
     PostedMessageQueue,
     UserInteraction,
     WebGL,

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/make_names.pl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/make_names.pl
@@ -1277,8 +1277,15 @@ END
 
     if ($parameters{customElementInterfaceName}) {
         print F <<END
-    if (element->isCustomElementUpgradeCandidate())
+    if (!element->isUnknownElement())
         return createWrapper<$parameters{customElementInterfaceName}>(globalObject, WTFMove(element));
+END
+;
+    }
+
+    if ("$parameters{namespace}Element" eq $parameters{fallbackJSInterfaceName}) {
+        print F <<END
+    ASSERT(element->is$parameters{fallbackJSInterfaceName}());
 END
 ;
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -172,7 +172,7 @@ ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* sty
 
 void ApplyStyleCommand::updateStartEnd(const Position& newStart, const Position& newEnd)
 {
-    ASSERT(!(newStart > newEnd));
+    ASSERT(!is_gt(treeOrder<ShadowIncludingTree>(newStart, newEnd)));
 
     if (!m_useEndingSelection && (newStart != m_start || newEnd != m_end))
         m_useEndingSelection = true;
@@ -1068,7 +1068,7 @@ void ApplyStyleCommand::removeInlineStyle(EditingStyle& style, const Position& s
     ASSERT(end.isNotNull());
     ASSERT(start.anchorNode()->isConnected());
     ASSERT(end.anchorNode()->isConnected());
-    ASSERT(start <= end);
+    ASSERT(is_lteq(treeOrder<ShadowIncludingTree>(start, end)));
     // FIXME: We should assert that start/end are not in the middle of a text node.
 
     Position pushDownStart = start.downstream();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/Editing.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/Editing.cpp
@@ -628,12 +628,12 @@ Node* highestNodeToRemoveInPruning(Node* node)
 {
     Node* previousNode = nullptr;
     auto* rootEditableElement = node ? node->rootEditableElement() : nullptr;
-    for (; node; node = node->parentNode()) {
-        if (auto* renderer = node->renderer()) {
-            if (!renderer->canHaveChildren() || hasARenderedDescendant(node, previousNode) || rootEditableElement == node)
+    for (auto currentNode = makeRefPtr(node); currentNode; currentNode = currentNode->parentNode()) {
+        if (auto* renderer = currentNode->renderer()) {
+            if (!renderer->canHaveChildren() || hasARenderedDescendant(currentNode.get(), previousNode) || rootEditableElement == currentNode.get())
                 return previousNode;
         }
-        previousNode = node;
+        previousNode = currentNode.get();
     }
     return nullptr;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.h
@@ -252,6 +252,8 @@ public:
     void setShouldShowBlockCursor(bool);
 
     bool isInDocumentTree() const;
+    bool isConnectedToDocument() const;
+
     RefPtr<Range> associatedLiveRange();
     void associateLiveRange(Range&);
     void disassociateLiveRange();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -191,9 +191,9 @@ void IndentOutdentCommand::outdentParagraph()
         splitElement(*enclosingNode, highestInlineNode ? *highestInlineNode : *visibleStartOfParagraph.deepEquivalent().deprecatedNode());
     }
     auto placeholder = HTMLBRElement::create(document());
-    auto* placeholderPtr = placeholder.ptr();
-    insertNodeBefore(WTFMove(placeholder), *splitBlockquoteNode);
-    moveParagraph(startOfParagraph(visibleStartOfParagraph), endOfParagraph(visibleEndOfParagraph), positionBeforeNode(placeholderPtr), true);
+    insertNodeBefore(placeholder, *splitBlockquoteNode);
+    if (placeholder->isConnected())
+        moveParagraph(startOfParagraph(visibleStartOfParagraph), endOfParagraph(visibleEndOfParagraph), positionBeforeNode(placeholder.ptr()), true);
 }
 
 // FIXME: We should merge this function with ApplyBlockElementCommand::formatSelection

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -313,7 +313,7 @@ void InsertParagraphSeparatorCommand::doApply()
         insertionPosition = positionInParentAfterNode(br.ptr());
         // If the insertion point is a break element, there is nothing else
         // we need to do.
-        if (visiblePos.deepEquivalent().anchorNode()->renderer()->isBR()) {
+        if (auto* renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
             setEndingSelection(VisibleSelection(insertionPosition, Affinity::Downstream, endingSelection().isDirectional()));
             return;
         }

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/VisiblePosition.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/VisiblePosition.cpp
@@ -800,7 +800,7 @@ VisiblePositionRange makeVisiblePositionRange(const Optional<SimpleRange>& range
 PartialOrdering documentOrder(const VisiblePosition& a, const VisiblePosition& b)
 {
     // FIXME: Should two positions with different affinity be considered equivalent or not?
-    return documentOrder(a.deepEquivalent(), b.deepEquivalent());
+    return treeOrder<ComposedTree>(a.deepEquivalent(), b.deepEquivalent());
 }
 
 bool intersects(const VisiblePositionRange& a, const VisiblePositionRange& b)

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/VisibleSelection.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/VisibleSelection.h
@@ -87,6 +87,7 @@ public:
     bool isNonOrphanedRange() const { return isRange() && !start().isOrphan() && !end().isOrphan(); }
     bool isNoneOrOrphaned() const { return isNone() || start().isOrphan() || end().isOrphan(); }
     bool isOrphan() const;
+    RefPtr<Document> document() const;
 
     bool isBaseFirst() const { return m_anchorIsFirst; }
     bool isDirectional() const { return m_isDirectional; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
@@ -697,7 +697,7 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node* startNode, No
                 }
             }
         }
-        ASSERT(next || !pastEnd);
+        ASSERT(next || !pastEnd || n->containsIncludingShadowDOM(pastEnd));
 
         if (isBlock(n) && canHaveChildrenForEditing(*n) && next == pastEnd) {
             // Don't write out empty block containers that aren't fully selected.

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLElement.h
@@ -86,7 +86,6 @@ public:
     bool hasDirectionAuto() const;
     TextDirection directionalityIfhasDirAutoAttribute(bool& isAuto) const;
 
-    virtual bool isHTMLUnknownElement() const { return false; }
     virtual bool isTextControlInnerTextElement() const { return false; }
 
     bool willRespondToMouseMoveEvents() override;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5854,7 +5854,7 @@ bool HTMLMediaElement::removeEventListener(const AtomString& eventType, EventLis
 
 void HTMLMediaElement::enqueuePlaybackTargetAvailabilityChangedEvent()
 {
-    bool hasTargets = m_mediaSession->hasWirelessPlaybackTargets();
+    bool hasTargets = m_mediaSession && mediaSession().hasWirelessPlaybackTargets();
     ALWAYS_LOG(LOGIDENTIFIER, "hasTargets = ", hasTargets);
     auto event = WebKitPlaybackTargetAvailabilityEvent::create(eventNames().webkitplaybacktargetavailabilitychangedEvent, hasTargets);
     event->setTarget(this);
@@ -7667,7 +7667,7 @@ MediaProducer::MediaStateFlags HTMLMediaElement::mediaState() const
             state |= RequiresPlaybackTargetMonitoring;
     }
 
-    bool requireUserGesture = m_mediaSession->hasBehaviorRestriction(MediaElementSession::RequireUserGestureToAutoplayToExternalDevice);
+    bool requireUserGesture = m_mediaSession && mediaSession().hasBehaviorRestriction(MediaElementSession::RequireUserGestureToAutoplayToExternalDevice);
     if (m_readyState >= HAVE_METADATA && !requireUserGesture && !m_failedToPlayToWirelessTarget)
         state |= ExternalDeviceAutoPlayCandidate;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -272,6 +272,7 @@ void HTMLPlugInElement::swapRendererTimerFired()
 
     // Create a shadow root, which will trigger the code to add a snapshot container
     // and reattach, thus making a new Renderer.
+    Ref<HTMLPlugInElement> protectedThis(*this);
     ensureUserAgentShadowRoot();
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLUnknownElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLUnknownElement.h
@@ -43,11 +43,9 @@ public:
 
 private:
     HTMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : HTMLElement(tagName, document, CreateHTMLElement)
+        : HTMLElement(tagName, document, CreateHTMLElement | NodeFlag::IsUnknownElement)
     {
     }
-
-    bool isHTMLUnknownElement() const final { return true; }
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/ImageBitmap.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/ImageBitmap.cpp
@@ -640,6 +640,8 @@ class PendingImageBitmap final : public ActiveDOMObject, public FileReaderLoader
 public:
     static void fetch(ScriptExecutionContext& scriptExecutionContext, RefPtr<Blob>&& blob, ImageBitmapOptions&& options, Optional<IntRect> rect, ImageBitmap::Promise&& promise)
     {
+        if (scriptExecutionContext.activeDOMObjectsAreStopped())
+            return;
         auto pendingImageBitmap = new PendingImageBitmap(scriptExecutionContext, WTFMove(blob), WTFMove(options), WTFMove(rect), WTFMove(promise));
         pendingImageBitmap->start(scriptExecutionContext);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/InputType.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/InputType.cpp
@@ -929,8 +929,9 @@ ExceptionOr<void> InputType::applyStep(int count, AnyStepHandling anyStepHandlin
     if (newValue > stepRange.maximum())
         newValue = stepRange.maximum();
 
+    auto protectedThis = makeRef(*this);
     auto result = setValueAsDecimal(newValue, eventBehavior);
-    if (result.hasException())
+    if (result.hasException() || !element())
         return result;
 
     if (AXObjectCache* cache = element()->document().existingAXObjectCache())

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -176,10 +176,10 @@ void InspectorInstrumentation::didRemoveDOMNodeImpl(InstrumentingAgents& instrum
         domAgent->didRemoveDOMNode(node);
 }
 
-void InspectorInstrumentation::nodeLayoutContextChangedImpl(InstrumentingAgents& instrumentingAgents, Node& node, RenderObject* oldRenderer)
+void InspectorInstrumentation::nodeLayoutContextChangedImpl(InstrumentingAgents& instrumentingAgents, Node& node, RenderObject* newRenderer)
 {
     if (auto* cssAgent = instrumentingAgents.enabledCSSAgent())
-        cssAgent->nodeLayoutContextTypeChanged(node, oldRenderer);
+        cssAgent->nodeLayoutContextTypeChanged(node, newRenderer);
 }
 
 void InspectorInstrumentation::willModifyDOMAttrImpl(InstrumentingAgents& instrumentingAgents, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -604,11 +604,11 @@ inline void InspectorInstrumentation::didRemoveDOMNode(Document& document, Node&
         didRemoveDOMNodeImpl(*agents, node);
 }
 
-inline void InspectorInstrumentation::nodeLayoutContextChanged(Node& node, RenderObject* oldRenderer)
+inline void InspectorInstrumentation::nodeLayoutContextChanged(Node& node, RenderObject* newRenderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(node.document()))
-        nodeLayoutContextChangedImpl(*agents, node, oldRenderer);
+        nodeLayoutContextChangedImpl(*agents, node, newRenderer);
 }
 
 inline void InspectorInstrumentation::willModifyDOMAttr(Document& document, Element& element, const AtomString& oldValue, const AtomString& newValue)

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -304,6 +304,7 @@ InspectorCSSAgent::InspectorCSSAgent(WebAgentContext& context)
     : InspectorAgentBase("CSS"_s, context)
     , m_frontendDispatcher(makeUnique<CSSFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(CSSBackendDispatcher::create(context.backendDispatcher, this))
+    , m_layoutContextTypeChangedTimer(*this, &InspectorCSSAgent::layoutContextTypeChangedTimerFired)
 {
 }
 
@@ -326,6 +327,9 @@ void InspectorCSSAgent::reset()
     m_nodeToInspectorStyleSheet.clear();
     m_documentToInspectorStyleSheet.clear();
     m_documentToKnownCSSStyleSheets.clear();
+    m_nodesWithPendingLayoutContextTypeChanges.clear();
+    if (m_layoutContextTypeChangedTimer.isActive())
+        m_layoutContextTypeChangedTimer.stop();
     m_layoutContextTypeChangedMode = Protocol::CSS::LayoutContextTypeChangedMode::Observed;
     resetPseudoStates();
 }
@@ -963,14 +967,10 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::setLayoutContextTypeChangedMode
     return { };
 }
 
-void InspectorCSSAgent::nodeLayoutContextTypeChanged(Node& node, RenderObject* oldRenderer)
+void InspectorCSSAgent::nodeLayoutContextTypeChanged(Node& node, RenderObject* newRenderer)
 {
     auto* domAgent = m_instrumentingAgents.persistentDOMAgent();
     if (!domAgent)
-        return;
-
-    auto newLayoutContextType = layoutContextTypeForRenderer(node.renderer());
-    if (newLayoutContextType == layoutContextTypeForRenderer(oldRenderer))
         return;
 
     auto nodeId = domAgent->boundNodeId(&node);
@@ -981,7 +981,15 @@ void InspectorCSSAgent::nodeLayoutContextTypeChanged(Node& node, RenderObject* o
     if (!nodeId)
         return;
 
-    m_frontendDispatcher->nodeLayoutContextTypeChanged(nodeId, WTFMove(newLayoutContextType));
+    m_nodesWithPendingLayoutContextTypeChanges.set(nodeId, layoutContextTypeForRenderer(newRenderer));
+    if (!m_layoutContextTypeChangedTimer.isActive())
+        m_layoutContextTypeChangedTimer.startOneShot(0_s);
+}
+
+void InspectorCSSAgent::layoutContextTypeChangedTimerFired()
+{
+    for (auto&& [nodeId, layoutContextType] : std::exchange(m_nodesWithPendingLayoutContextTypeChanges, { }))
+        m_frontendDispatcher->nodeLayoutContextTypeChanged(nodeId, WTFMove(layoutContextType));
 }
 
 InspectorStyleSheetForInlineStyle& InspectorCSSAgent::asInspectorStyleSheet(StyledElement& element)

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -30,6 +30,7 @@
 #include "InspectorStyleSheet.h"
 #include "InspectorWebAgentBase.h"
 #include "SecurityContext.h"
+#include "Timer.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -156,6 +157,7 @@ private:
     Ref<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>> buildArrayForMatchedRuleList(const Vector<RefPtr<const StyleRule>>&, Style::Resolver&, Element&, PseudoId);
     RefPtr<Inspector::Protocol::CSS::CSSStyle> buildObjectForAttributesStyle(StyledElement&);
 
+    void layoutContextTypeChangedTimerFired();
 
     void resetPseudoStates();
 
@@ -172,6 +174,9 @@ private:
 
     int m_lastStyleSheetId { 1 };
     bool m_creatingViaInspectorStyleSheet { false };
+
+    HashMap<Inspector::Protocol::DOM::NodeId, Optional<Inspector::Protocol::CSS::LayoutContextType>> m_nodesWithPendingLayoutContextTypeChanges;
+    Timer m_layoutContextTypeChangedTimer;
     Inspector::Protocol::CSS::LayoutContextTypeChangedMode m_layoutContextTypeChangedMode { Inspector::Protocol::CSS::LayoutContextTypeChangedMode::Observed };
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentWriter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentWriter.cpp
@@ -192,6 +192,8 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         document->contentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(existingDocument->contentSecurityPolicy()->takeNavigationRequestsToUpgrade());
     }
 
+    auto protectedFrame = makeRef(*m_frame);
+
     m_frame->loader().didBeginDocument(dispatch);
 
     document->implicitOpen();

--- a/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLElement.cpp
@@ -50,8 +50,8 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(MathMLElement);
 
 using namespace MathMLNames;
 
-MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document)
-    : StyledElement(tagName, document, CreateMathMLElement)
+MathMLElement::MathMLElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+    : StyledElement(tagName, document, constructionType)
 {
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLElement.h
@@ -90,7 +90,7 @@ public:
     virtual void updateSelectedChild() { }
 
 protected:
-    MathMLElement(const QualifiedName& tagName, Document&);
+    MathMLElement(const QualifiedName& tagName, Document&, ConstructionType = CreateMathMLElement);
 
     void parseAttribute(const QualifiedName&, const AtomString&) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLUnknownElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mathml/MathMLUnknownElement.h
@@ -41,7 +41,7 @@ public:
 
 private:
     MathMLUnknownElement(const QualifiedName& tagName, Document& document)
-        : MathMLElement(tagName, document)
+        : MathMLElement(tagName, document, CreateMathMLElement | NodeFlag::IsUnknownElement)
     {
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/ActivityStateChangeObserver.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/ActivityStateChangeObserver.h
@@ -26,10 +26,11 @@
 #pragma once
 
 #include "ActivityState.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class ActivityStateChangeObserver {
+class ActivityStateChangeObserver : public CanMakeWeakPtr<ActivityStateChangeObserver> {
 public:
     virtual ~ActivityStateChangeObserver()
     {

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -578,7 +578,7 @@ static ExceptionOr<SelectorQuery&> selectorQueryInFrame(Frame* frame, const Stri
     if (!frame)
         return Exception { NotSupportedError };
 
-    Document* document = frame->document();
+    RefPtr document = frame->document();
     if (!document)
         return Exception { NotSupportedError };
 
@@ -729,7 +729,8 @@ Navigator& DOMWindow::navigator()
 Performance& DOMWindow::performance() const
 {
     if (!m_performance) {
-        MonotonicTime timeOrigin = document() && document()->loader() ? document()->loader()->timing().referenceMonotonicTime() : MonotonicTime::now();
+        RefPtr documentLoader = document() ? document()->loader() : nullptr;
+        auto timeOrigin = documentLoader ? documentLoader->timing().referenceMonotonicTime() : MonotonicTime::now();
         m_performance = Performance::create(document(), timeOrigin);
     }
     ASSERT(m_performance->scriptExecutionContext() == document());
@@ -774,7 +775,7 @@ VisualViewport& DOMWindow::visualViewport()
 
 bool DOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
 
@@ -812,7 +813,7 @@ ExceptionOr<Storage*> DOMWindow::sessionStorage()
     if (!isCurrentlyDisplayedInFrame())
         return nullptr;
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return nullptr;
 
@@ -836,7 +837,7 @@ ExceptionOr<Storage*> DOMWindow::localStorage()
     if (!isCurrentlyDisplayedInFrame())
         return nullptr;
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return nullptr;
 
@@ -870,7 +871,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObjec
     if (!isCurrentlyDisplayedInFrame())
         return { };
 
-    Document* sourceDocument = incumbentWindow.document();
+    RefPtr sourceDocument = incumbentWindow.document();
 
     // Compute the target origin.  We need to do this synchronously in order
     // to generate the SyntaxError exception correctly.
@@ -904,7 +905,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObjec
 
     // Capture stack trace only when inspector front-end is loaded as it may be time consuming.
     RefPtr<ScriptCallStack> stackTrace;
-    if (InspectorInstrumentation::consoleAgentEnabled(sourceDocument))
+    if (InspectorInstrumentation::consoleAgentEnabled(sourceDocument.get()))
         stackTrace = createScriptCallStack(JSExecState::currentState());
 
     auto postMessageIdentifier = InspectorInstrumentation::willPostMessage(*frame());
@@ -919,7 +920,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObjec
         if (!isCurrentlyDisplayedInFrame())
         return;
 
-    Ref<Frame> frame = *this->frame();
+        Ref frame = *this->frame();
         if (targetOrigin) {
         // Check target origin now since the target document may have changed since the timer was scheduled.
             if (!targetOrigin->isSameSchemeHostPort(document()->securityOrigin())) {
@@ -961,7 +962,7 @@ DOMSelection* DOMWindow::getSelection()
 
 Element* DOMWindow::frameElement() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
@@ -970,42 +971,41 @@ Element* DOMWindow::frameElement() const
 
 void DOMWindow::focus(DOMWindow& incumbentWindow)
 {
-    auto* frame = this->frame();
-    auto* openerFrame = frame ? frame->loader().opener() : nullptr;
+    RefPtr frame = this->frame();
+    RefPtr openerFrame = frame ? frame->loader().opener() : nullptr;
     focus(openerFrame && openerFrame != frame && incumbentWindow.frame() == openerFrame);
 }
 
 void DOMWindow::focus(bool allowFocus)
 {
-    if (!frame())
+    RefPtr frame = this->frame();
+    if (!frame)
         return;
 
-    auto protectedFrame = makeRefPtr(frame());
-
-    Page* page = protectedFrame->page();
+    Page* page = frame->page();
     if (!page)
         return;
 
-    allowFocus = allowFocus || WindowFocusAllowedIndicator::windowFocusAllowed() || !protectedFrame->settings().windowFocusRestricted();
+    allowFocus = allowFocus || WindowFocusAllowedIndicator::windowFocusAllowed() || !frame->settings().windowFocusRestricted();
 
     // If we're a top level window, bring the window to the front.
-    if (protectedFrame->isMainFrame() && allowFocus)
+    if (frame->isMainFrame() && allowFocus)
         page->chrome().focus();
 
-    if (!protectedFrame->hasHadUserInteraction() && !isSameSecurityOriginAsMainFrame())
+    if (!frame->hasHadUserInteraction() && !isSameSecurityOriginAsMainFrame())
         return;
 
     // Clear the current frame's focused node if a new frame is about to be focused.
-    auto focusedFrame = makeRefPtr(page->focusController().focusedFrame());
-    if (focusedFrame && focusedFrame != protectedFrame)
+    RefPtr focusedFrame = page->focusController().focusedFrame();
+    if (focusedFrame && focusedFrame != frame)
         focusedFrame->document()->setFocusedElement(nullptr);
 
-    protectedFrame->eventHandler().focusDocumentView();
+    frame->eventHandler().focusDocumentView();
 }
 
 void DOMWindow::blur()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1031,7 +1031,7 @@ void DOMWindow::close(Document& document)
 
 void DOMWindow::close()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1058,7 +1058,7 @@ void DOMWindow::close()
 
 void DOMWindow::print()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1084,7 +1084,7 @@ void DOMWindow::print()
 
 void DOMWindow::stop()
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1095,11 +1095,12 @@ void DOMWindow::stop()
 
 void DOMWindow::alert(const String& message)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
-    if (document()->isSandboxed(SandboxModals)) {
+    RefPtr document = this->document();
+    if (document->isSandboxed(SandboxModals)) {
         printErrorMessage("Use of window.alert is not allowed in a sandboxed frame when the allow-modals flag is not set.");
         return;
     }
@@ -1113,12 +1114,12 @@ void DOMWindow::alert(const String& message)
         return;
     }
 
-    if (!document()->securityOrigin().isSameOriginDomain(document()->topDocument().securityOrigin())) {
+    if (!document->securityOrigin().isSameOriginDomain(document->topDocument().securityOrigin())) {
         printErrorMessage("Use of window.alert is not allowed in different origin-domain iframes.");
         return;
     }
 
-    frame->document()->updateStyleIfNeeded();
+    document->updateStyleIfNeeded();
 #if ENABLE(POINTER_LOCK)
     page->pointerLockController().requestPointerUnlock();
 #endif
@@ -1128,11 +1129,12 @@ void DOMWindow::alert(const String& message)
 
 bool DOMWindow::confirmForBindings(const String& message)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
 
-    if (document()->isSandboxed(SandboxModals)) {
+    RefPtr document = this->document();
+    if (document->isSandboxed(SandboxModals)) {
         printErrorMessage("Use of window.confirm is not allowed in a sandboxed frame when the allow-modals flag is not set.");
         return false;
     }
@@ -1146,12 +1148,12 @@ bool DOMWindow::confirmForBindings(const String& message)
         return false;
     }
 
-    if (!document()->securityOrigin().isSameOriginDomain(document()->topDocument().securityOrigin())) {
+    if (!document->securityOrigin().isSameOriginDomain(document->topDocument().securityOrigin())) {
         printErrorMessage("Use of window.confirm is not allowed in different origin-domain iframes.");
         return false;
     }
 
-    frame->document()->updateStyleIfNeeded();
+    document->updateStyleIfNeeded();
 #if ENABLE(POINTER_LOCK)
     page->pointerLockController().requestPointerUnlock();
 #endif
@@ -1161,11 +1163,12 @@ bool DOMWindow::confirmForBindings(const String& message)
 
 String DOMWindow::prompt(const String& message, const String& defaultValue)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return String();
 
-    if (document()->isSandboxed(SandboxModals)) {
+    RefPtr document = this->document();
+    if (document->isSandboxed(SandboxModals)) {
         printErrorMessage("Use of window.prompt is not allowed in a sandboxed frame when the allow-modals flag is not set.");
         return String();
     }
@@ -1179,12 +1182,12 @@ String DOMWindow::prompt(const String& message, const String& defaultValue)
         return String();
     }
 
-    if (!document()->securityOrigin().isSameOriginDomain(document()->topDocument().securityOrigin())) {
+    if (!document->securityOrigin().isSameOriginDomain(document->topDocument().securityOrigin())) {
         printErrorMessage("Use of window.prompt is not allowed in different origin-domain iframes.");
         return String();
     }
 
-    frame->document()->updateStyleIfNeeded();
+    document->updateStyleIfNeeded();
 #if ENABLE(POINTER_LOCK)
     page->pointerLockController().requestPointerUnlock();
 #endif
@@ -1223,13 +1226,13 @@ int DOMWindow::outerHeight() const
     if (!frame())
         return 0;
 
-    auto* view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
+    RefPtr view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
     if (!view)
         return 0;
 
     return view->frameRect().height();
 #else
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1247,13 +1250,13 @@ int DOMWindow::outerWidth() const
     if (!frame())
         return 0;
 
-    auto* view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
+    RefPtr view = frame()->isMainFrame() ? frame()->view() : frame()->mainFrame().view();
     if (!view)
         return 0;
 
     return view->frameRect().width();
 #else
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1271,14 +1274,14 @@ int DOMWindow::innerHeight() const
         return 0;
 
     // Force enough layout in the parent document to ensure that the FrameView has been resized.
-    if (auto ownerElement = makeRefPtr(frameElement()))
+    if (RefPtr ownerElement = frameElement())
         ownerElement->document().updateLayoutIfDimensionsOutOfDate(*ownerElement, HeightDimensionsCheck);
 
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
-    auto view = makeRefPtr(frame->view());
+    RefPtr view = frame->view();
     if (!view)
         return 0;
 
@@ -1294,11 +1297,11 @@ int DOMWindow::innerWidth() const
     if (auto ownerElement = makeRefPtr(frameElement()))
         ownerElement->document().updateLayoutIfDimensionsOutOfDate(*ownerElement, WidthDimensionsCheck);
 
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
-    auto view = makeRefPtr(frame->view());
+    RefPtr view = frame->view();
     if (!view)
         return 0;
 
@@ -1307,7 +1310,7 @@ int DOMWindow::innerWidth() const
 
 int DOMWindow::screenX() const
 {
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1320,7 +1323,7 @@ int DOMWindow::screenX() const
 
 int DOMWindow::screenY() const
 {
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
@@ -1333,11 +1336,11 @@ int DOMWindow::screenY() const
 
 int DOMWindow::scrollX() const
 {
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
-    auto view = makeRefPtr(frame->view());
+    RefPtr view = frame->view();
     if (!view)
         return 0;
 
@@ -1348,11 +1351,11 @@ int DOMWindow::scrollX() const
     frame->document()->updateLayoutIgnorePendingStylesheets();
 
     // Layout may have affected the current frame:
-    auto frameAfterLayout = makeRefPtr(this->frame());
+    RefPtr frameAfterLayout = this->frame();
     if (!frameAfterLayout)
         return 0;
 
-    auto viewAfterLayout = makeRefPtr(frameAfterLayout->view());
+    RefPtr viewAfterLayout = frameAfterLayout->view();
     if (!viewAfterLayout)
         return 0;
 
@@ -1361,11 +1364,11 @@ int DOMWindow::scrollX() const
 
 int DOMWindow::scrollY() const
 {
-    auto frame = makeRefPtr(this->frame());
+    RefPtr frame = this->frame();
     if (!frame)
         return 0;
 
-    auto view = makeRefPtr(frame->view());
+    RefPtr view = frame->view();
     if (!view)
         return 0;
 
@@ -1376,11 +1379,11 @@ int DOMWindow::scrollY() const
     frame->document()->updateLayoutIgnorePendingStylesheets();
 
     // Layout may have affected the current frame:
-    auto frameAfterLayout = makeRefPtr(this->frame());
+    RefPtr frameAfterLayout = this->frame();
     if (!frameAfterLayout)
         return 0;
 
-    auto viewAfterLayout = makeRefPtr(frameAfterLayout->view());
+    RefPtr viewAfterLayout = frameAfterLayout->view();
     if (!viewAfterLayout)
         return 0;
 
@@ -1389,7 +1392,7 @@ int DOMWindow::scrollY() const
 
 bool DOMWindow::closed() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return true;
 
@@ -1407,7 +1410,7 @@ unsigned DOMWindow::length() const
 
 String DOMWindow::name() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return String();
 
@@ -1416,7 +1419,7 @@ String DOMWindow::name() const
 
 void DOMWindow::setName(const String& string)
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1427,7 +1430,7 @@ void DOMWindow::setStatus(const String& string)
 {
     m_status = string;
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1443,7 +1446,7 @@ void DOMWindow::setDefaultStatus(const String& string)
 {
     m_defaultStatus = string;
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
@@ -1457,11 +1460,11 @@ void DOMWindow::setDefaultStatus(const String& string)
 
 WindowProxy* DOMWindow::opener() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
-    auto* openerFrame = frame->loader().opener();
+    RefPtr openerFrame = frame->loader().opener();
     if (!openerFrame)
         return nullptr;
 
@@ -1470,17 +1473,17 @@ WindowProxy* DOMWindow::opener() const
 
 void DOMWindow::disownOpener()
 {
-    if (auto* frame = this->frame())
+    if (RefPtr frame = this->frame())
         frame->loader().setOpener(nullptr);
 }
 
 WindowProxy* DOMWindow::parent() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
-    auto* parentFrame = frame->tree().parent();
+    RefPtr parentFrame = frame->tree().parent();
     if (parentFrame)
         return &parentFrame->windowProxy();
 
@@ -1489,7 +1492,7 @@ WindowProxy* DOMWindow::parent() const
 
 WindowProxy* DOMWindow::top() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return nullptr;
 
@@ -1536,7 +1539,7 @@ bool DOMWindow::consumeTransientActivation()
     if (!hasTransientActivation())
         return false;
 
-    for (Frame* frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
+    for (RefPtr frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
         auto* window = frame->window();
         if (!window || window->lastActivationTimestamp() != MonotonicTime::infinity())
             window->setLastActivationTimestamp(-MonotonicTime::infinity());
@@ -1552,22 +1555,22 @@ void DOMWindow::notifyActivated(MonotonicTime activationTime)
     if (!frame())
         return;
 
-    for (Frame* ancestor = frame() ? frame()->tree().parent() : nullptr; ancestor; ancestor = ancestor->tree().parent()) {
+    for (RefPtr ancestor = frame() ? frame()->tree().parent() : nullptr; ancestor; ancestor = ancestor->tree().parent()) {
         if (auto* window = ancestor->window())
             window->setLastActivationTimestamp(activationTime);
     }
 
-    auto* securityOrigin = this->securityOrigin();
+    RefPtr securityOrigin = this->securityOrigin();
     if (!securityOrigin)
         return;
 
-    auto* descendant = frame();
+    RefPtr descendant = frame();
     while ((descendant = descendant->tree().traverseNext(frame()))) {
         auto* descendantWindow = descendant->window();
         if (!descendantWindow)
             continue;
 
-        auto* descendantSecurityOrigin = descendantWindow->securityOrigin();
+        RefPtr descendantSecurityOrigin = descendantWindow->securityOrigin();
         if (!descendantSecurityOrigin || !descendantSecurityOrigin->isSameOriginAs(*securityOrigin))
             continue;
 
@@ -1597,7 +1600,7 @@ RefPtr<CSSRuleList> DOMWindow::getMatchedCSSRules(Element* element, const String
     if (pseudoType == CSSSelector::PseudoElementUnknown && !pseudoElement.isEmpty())
         return nullptr;
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     frame->document()->styleScope().flushPendingUpdate();
 
     unsigned rulesToInclude = Style::Resolver::AuthorCSSRules;
@@ -1680,11 +1683,11 @@ void DOMWindow::scrollBy(const ScrollToOptions& options) const
 
     document()->updateLayoutIgnorePendingStylesheets();
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return;
 
-    auto view = makeRefPtr(frame->view());
+    RefPtr view = frame->view();
     if (!view)
         return;
 
@@ -1730,7 +1733,7 @@ void DOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping clamping
 
 bool DOMWindow::allowedToChangeWindowGeometry() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return false;
     if (!frame->page())
@@ -1795,7 +1798,7 @@ void DOMWindow::resizeTo(float width, float height) const
 
 ExceptionOr<int> DOMWindow::setTimeout(JSC::JSGlobalObject& state, std::unique_ptr<ScheduledAction> action, int timeout, Vector<JSC::Strong<JSC::Unknown>>&& arguments)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return Exception { InvalidAccessError };
 
@@ -1812,7 +1815,7 @@ ExceptionOr<int> DOMWindow::setTimeout(JSC::JSGlobalObject& state, std::unique_p
 
 void DOMWindow::clearTimeout(int timeoutId)
 {
-    ScriptExecutionContext* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
     DOMTimer::removeById(*context, timeoutId);
@@ -1820,7 +1823,7 @@ void DOMWindow::clearTimeout(int timeoutId)
 
 ExceptionOr<int> DOMWindow::setInterval(JSC::JSGlobalObject& state, std::unique_ptr<ScheduledAction> action, int timeout, Vector<JSC::Strong<JSC::Unknown>>&& arguments)
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return Exception { InvalidAccessError };
 
@@ -1845,7 +1848,7 @@ void DOMWindow::clearInterval(int timeoutId)
 
 int DOMWindow::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return 0;
     return document->requestAnimationFrame(WTFMove(callback));
@@ -1863,7 +1866,7 @@ int DOMWindow::webkitRequestAnimationFrame(Ref<RequestAnimationFrameCallback>&& 
 
 void DOMWindow::cancelAnimationFrame(int id)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return;
     document->cancelAnimationFrame(id);
@@ -1887,7 +1890,7 @@ void DOMWindow::cancelIdleCallback(int id)
 
 void DOMWindow::createImageBitmap(ImageBitmap::Source&& source, ImageBitmapOptions&& options, ImageBitmap::Promise&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document) {
         promise.reject(InvalidStateError);
         return;
@@ -1897,7 +1900,7 @@ void DOMWindow::createImageBitmap(ImageBitmap::Source&& source, ImageBitmapOptio
 
 void DOMWindow::createImageBitmap(ImageBitmap::Source&& source, int sx, int sy, int sw, int sh, ImageBitmapOptions&& options, ImageBitmap::Promise&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document) {
         promise.reject(InvalidStateError);
         return;
@@ -1907,7 +1910,7 @@ void DOMWindow::createImageBitmap(ImageBitmap::Source&& source, int sx, int sy, 
 
 bool DOMWindow::isSecureContext() const
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document)
         return false;
     return document->isSecureContext();
@@ -1945,7 +1948,7 @@ bool DOMWindow::addEventListener(const AtomString& eventType, Ref<EventListener>
     if (!EventTarget::addEventListener(eventType, WTFMove(listener), options))
         return false;
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (document) {
         document->addListenerTypeIfNeeded(eventType);
         if (eventNames().isWheelEventType(eventType))
@@ -2084,7 +2087,7 @@ void DOMWindow::startListeningForDeviceOrientationIfNecessary()
 
     String innerMessage;
     if (!isAllowedToUseDeviceOrientation(innerMessage) || !hasPermissionToReceiveDeviceMotionOrOrientationEvents(innerMessage)) {
-        if (auto* document = this->document())
+        if (RefPtr document = this->document())
             document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device orientation events will be fired, reason: ", innerMessage, "."));
         return;
     }
@@ -2113,7 +2116,7 @@ void DOMWindow::startListeningForDeviceMotionIfNecessary()
     String innerMessage;
     if (!isAllowedToUseDeviceMotion(innerMessage) || !hasPermissionToReceiveDeviceMotionOrOrientationEvents(innerMessage)) {
         failedToRegisterDeviceMotionEventListener();
-        if (auto* document = this->document())
+        if (RefPtr document = this->document())
             document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, makeString("No device motion events will be fired, reason: ", innerMessage, "."));
         return;
     }
@@ -2155,10 +2158,9 @@ void DOMWindow::failedToRegisterDeviceMotionEventListener()
 
 void DOMWindow::incrementScrollEventListenersCount()
 {
-    Document* document = this->document();
+    RefPtr document = this->document();
     if (++m_scrollEventListenerCount == 1 && document == &document->topDocument()) {
-        Frame* frame = this->frame();
-        if (frame && frame->page())
+        if (RefPtr frame = this->frame(); frame && frame->page())
             frame->page()->chrome().client().setNeedsScrollNotifications(*frame, true);
     }
 }
@@ -2189,7 +2191,7 @@ bool DOMWindow::removeEventListener(const AtomString& eventType, EventListener& 
     if (!EventTarget::removeEventListener(eventType, listener, options.capture))
         return false;
 
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (document) {
         if (eventNames().isWheelEventType(eventType))
             document->didRemoveWheelEventHandler(*document);
@@ -2255,8 +2257,8 @@ void DOMWindow::dispatchLoadEvent()
         protectedLoader->timing().markLoadEventEnd();
 
     // Send a separate load event to the element that owns this frame.
-    if (frame()) {
-        if (auto* owner = frame()->ownerElement())
+    if (RefPtr ownerFrame = frame()) {
+        if (RefPtr owner = ownerFrame->ownerElement())
             owner->dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }
 
@@ -2338,7 +2340,7 @@ void DOMWindow::removeAllEventListeners()
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
-    if (Document* document = this->document())
+    if (RefPtr document = this->document())
         document->didRemoveEventTargetNode(*document);
 #endif
 
@@ -2375,12 +2377,12 @@ void DOMWindow::setLocation(DOMWindow& activeWindow, const URL& completedURL, Se
     if (!isCurrentlyDisplayedInFrame())
         return;
 
-    Document* activeDocument = activeWindow.document();
+    RefPtr activeDocument = activeWindow.document();
     if (!activeDocument)
         return;
 
-    auto* frame = this->frame();
-    if (!activeDocument->canNavigate(frame, completedURL))
+    RefPtr frame = this->frame();
+    if (!activeDocument->canNavigate(frame.get(), completedURL))
         return;
 
     if (isInsecureScriptAccess(activeWindow, completedURL.string()))
@@ -2481,11 +2483,11 @@ bool DOMWindow::isInsecureScriptAccess(DOMWindow& activeWindow, const String& ur
 
 ExceptionOr<RefPtr<Frame>> DOMWindow::createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures& windowFeatures, DOMWindow& activeWindow, Frame& firstFrame, Frame& openerFrame, const WTF::Function<void(DOMWindow&)>& prepareDialogFunction)
 {
-    Frame* activeFrame = activeWindow.frame();
+    RefPtr activeFrame = activeWindow.frame();
     if (!activeFrame)
         return RefPtr<Frame> { nullptr };
 
-    Document* activeDocument = activeWindow.document();
+    RefPtr activeDocument = activeWindow.document();
     if (!activeDocument)
         return RefPtr<Frame> { nullptr };
 
@@ -2542,7 +2544,7 @@ ExceptionOr<RefPtr<Frame>> DOMWindow::createWindow(const String& urlString, cons
 ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWindow& firstWindow, const String& urlStringToOpen, const AtomString& frameName, const String& windowFeaturesString)
 {
 #if ENABLE(RESOURCE_LOAD_STATISTICS)
-    if (auto* document = this->document()) {
+    if (RefPtr document = this->document()) {
         if (document->settings().needsSiteSpecificQuirks() && urlStringToOpen == Quirks::BBCRadioPlayerURLString()) {
             auto radioPlayerDomain = RegistrableDomain(URL(URL(), Quirks::staticRadioPlayerURLString()));
             auto BBCDomain = RegistrableDomain(URL(URL(), Quirks::BBCRadioPlayerURLString()));
@@ -2555,11 +2557,11 @@ ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWin
     if (!isCurrentlyDisplayedInFrame())
         return RefPtr<WindowProxy> { nullptr };
 
-    auto* activeDocument = activeWindow.document();
+    RefPtr activeDocument = activeWindow.document();
     if (!activeDocument)
         return RefPtr<WindowProxy> { nullptr };
 
-    auto* firstFrame = firstWindow.frame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame)
         return RefPtr<WindowProxy> { nullptr };
 
@@ -2569,9 +2571,9 @@ ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWin
 
 #if ENABLE(CONTENT_EXTENSIONS)
     auto* page = firstFrame->page();
-    auto* firstFrameDocument = firstFrame->document();
-    auto* mainFrameDocument = firstFrame->mainFrame().document();
-    auto* mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
+    RefPtr firstFrameDocument = firstFrame->document();
+    RefPtr mainFrameDocument = firstFrame->mainFrame().document();
+    RefPtr mainFrameDocumentLoader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && mainFrameDocumentLoader) {
         auto results = page->userContentProvider().processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *mainFrameDocumentLoader);
         if (results.summary.blockedLoad)
@@ -2579,30 +2581,30 @@ ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWin
     }
 #endif
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame)
         return RefPtr<WindowProxy> { nullptr };
 
     if (!firstWindow.allowPopUp()) {
         // Because FrameTree::findFrameForNavigation() returns true for empty strings, we must check for empty frame names.
         // Otherwise, illegitimate window.open() calls with no name will pass right through the popup blocker.
-        if (frameName.isEmpty() || !frame->loader().findFrameForNavigation(frameName, activeDocument))
+        if (frameName.isEmpty() || !frame->loader().findFrameForNavigation(frameName, activeDocument.get()))
             return RefPtr<WindowProxy> { nullptr };
     }
 
     // Get the target frame for the special cases of _top and _parent.
     // In those cases, we schedule a location change right now and return early.
-    Frame* targetFrame = nullptr;
+    RefPtr<Frame> targetFrame;
     if (equalIgnoringASCIICase(frameName, "_top"))
         targetFrame = &frame->tree().top();
     else if (equalIgnoringASCIICase(frameName, "_parent")) {
-        if (Frame* parent = frame->tree().parent())
+        if (RefPtr parent = frame->tree().parent())
             targetFrame = parent;
         else
             targetFrame = frame;
     }
     if (targetFrame) {
-        if (!activeDocument->canNavigate(targetFrame))
+        if (!activeDocument->canNavigate(targetFrame.get()))
             return RefPtr<WindowProxy> { nullptr };
 
         URL completedURL = firstFrame->document()->completeURL(urlString);
@@ -2635,11 +2637,11 @@ void DOMWindow::showModalDialog(const String& urlString, const String& dialogFea
         return;
     if (!activeWindow.frame())
         return;
-    Frame* firstFrame = firstWindow.frame();
+    RefPtr firstFrame = firstWindow.frame();
     if (!firstFrame)
         return;
 
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     auto* page = frame->page();
     if (!page)
         return;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
@@ -485,7 +485,7 @@ bool EventHandler::updateSelectionForMouseDownDispatchingSelectStart(Node* targe
 
 void EventHandler::selectClosestWordFromHitTestResult(const HitTestResult& result, AppendTrailingWhitespace appendTrailingWhitespace)
 {
-    Node* targetNode = result.targetNode();
+    RefPtr targetNode = result.targetNode();
     VisibleSelection newSelection;
 
     if (targetNode && targetNode->renderer()) {
@@ -498,7 +498,7 @@ void EventHandler::selectClosestWordFromHitTestResult(const HitTestResult& resul
         if (appendTrailingWhitespace == ShouldAppendTrailingWhitespace && newSelection.isRange())
             newSelection.appendTrailingWhitespace();
 
-        updateSelectionForMouseDownDispatchingSelectStart(targetNode, expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
+        updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
     }
 }
 
@@ -522,7 +522,7 @@ VisibleSelection EventHandler::selectClosestWordFromHitTestResultBasedOnLookup(c
 
 void EventHandler::selectClosestContextualWordFromMouseEvent(const MouseEventWithHitTestResults& mouseEvent)
 {
-    Node* targetNode = mouseEvent.targetNode();
+    RefPtr targetNode = mouseEvent.targetNode();
     const HitTestResult& result = mouseEvent.hitTestResult();
     VisibleSelection newSelection;
     bool appendTrailingWhitespace = shouldAppendTrailingWhitespace(mouseEvent, m_frame);
@@ -540,15 +540,15 @@ void EventHandler::selectClosestContextualWordFromMouseEvent(const MouseEventWit
         if (appendTrailingWhitespace == ShouldAppendTrailingWhitespace && newSelection.isRange())
             newSelection.appendTrailingWhitespace();
 
-        updateSelectionForMouseDownDispatchingSelectStart(targetNode, expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
+        updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
     }
 }
 
 void EventHandler::selectClosestContextualWordOrLinkFromMouseEvent(const MouseEventWithHitTestResults& result)
 {
-    Element* urlElement = result.hitTestResult().URLElement();
+    RefPtr urlElement = result.hitTestResult().URLElement();
     if (!urlElement || !isDraggableLink(*urlElement)) {
-        if (Node* targetNode = result.targetNode()) {
+        if (RefPtr targetNode = result.targetNode()) {
             if (isEditableNode(*targetNode))
                 return selectClosestWordFromMouseEvent(result);
         }
@@ -556,15 +556,14 @@ void EventHandler::selectClosestContextualWordOrLinkFromMouseEvent(const MouseEv
         return selectClosestContextualWordFromMouseEvent(result);
     }
 
-    Node* targetNode = result.targetNode();
-
+    RefPtr targetNode = result.targetNode();
     if (targetNode && targetNode->renderer() && mouseDownMayStartSelect()) {
         VisibleSelection newSelection;
         VisiblePosition pos(targetNode->renderer()->positionForPoint(result.localPoint(), nullptr));
         if (pos.isNotNull() && pos.deepEquivalent().deprecatedNode()->isDescendantOf(*urlElement))
-            newSelection = VisibleSelection::selectionFromContentsOfNode(urlElement);
+            newSelection = VisibleSelection::selectionFromContentsOfNode(urlElement.get());
 
-        updateSelectionForMouseDownDispatchingSelectStart(targetNode, expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
+        updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::WordGranularity);
     }
 }
 
@@ -591,7 +590,7 @@ bool EventHandler::handleMousePressEventTripleClick(const MouseEventWithHitTestR
     if (event.event().button() != LeftButton)
         return false;
 
-    Node* targetNode = event.targetNode();
+    RefPtr targetNode = event.targetNode();
     if (!(targetNode && targetNode->renderer() && mouseDownMayStartSelect()))
         return false;
 
@@ -602,7 +601,7 @@ bool EventHandler::handleMousePressEventTripleClick(const MouseEventWithHitTestR
         newSelection.expandUsingGranularity(TextGranularity::ParagraphGranularity);
     }
 
-    return updateSelectionForMouseDownDispatchingSelectStart(targetNode, expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::ParagraphGranularity);
+    return updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), expandSelectionToRespectSelectOnMouseDown(*targetNode, newSelection), TextGranularity::ParagraphGranularity);
 }
 
 static uint64_t textDistance(const Position& start, const Position& end)
@@ -618,7 +617,7 @@ bool EventHandler::handleMousePressEventSingleClick(const MouseEventWithHitTestR
     Ref<Frame> protectedFrame(m_frame);
 
     m_frame.document()->updateLayoutIgnorePendingStylesheets();
-    Node* targetNode = event.targetNode();
+    RefPtr targetNode = event.targetNode();
     if (!targetNode || !targetNode->renderer() || !mouseDownMayStartSelect() || m_mouseDownDelegatedFocus)
         return false;
 
@@ -637,7 +636,7 @@ bool EventHandler::handleMousePressEventSingleClick(const MouseEventWithHitTestR
 
     VisiblePosition visiblePosition(targetNode->renderer()->positionForPoint(event.localPoint(), nullptr));
     if (visiblePosition.isNull())
-        visiblePosition = VisiblePosition(firstPositionInOrBeforeNode(targetNode));
+        visiblePosition = VisiblePosition(firstPositionInOrBeforeNode(targetNode.get()));
     Position pos = visiblePosition.deepEquivalent();
 
     VisibleSelection newSelection = m_frame.selection().selection();
@@ -682,7 +681,7 @@ bool EventHandler::handleMousePressEventSingleClick(const MouseEventWithHitTestR
         newSelection = expandSelectionToRespectSelectOnMouseDown(*targetNode, visiblePosition);
     }
 
-    bool handled = updateSelectionForMouseDownDispatchingSelectStart(targetNode, newSelection, granularity);
+    bool handled = updateSelectionForMouseDownDispatchingSelectStart(targetNode.get(), newSelection, granularity);
 
     if (event.event().button() == MiddleButton) {
         // Ignore handled, since we want to paste to where the caret was placed anyway.
@@ -801,21 +800,22 @@ bool EventHandler::handleMousePressEvent(const MouseEventWithHitTestResults& eve
 VisiblePosition EventHandler::selectionExtentRespectingEditingBoundary(const VisibleSelection& selection, const LayoutPoint& localPoint, Node* targetNode)
 {
     FloatPoint selectionEndPoint = localPoint;
-    Element* editableElement = selection.rootEditableElement();
+    RefPtr editableElement = selection.rootEditableElement();
 
     if (!targetNode || !targetNode->renderer())
         return VisiblePosition();
 
+    RefPtr adjustedTarget = targetNode;
     if (editableElement && !editableElement->contains(targetNode)) {
         if (!editableElement->renderer())
             return VisiblePosition();
 
         FloatPoint absolutePoint = targetNode->renderer()->localToAbsolute(FloatPoint(selectionEndPoint));
         selectionEndPoint = editableElement->renderer()->absoluteToLocal(absolutePoint);
-        targetNode = editableElement;
+        adjustedTarget = editableElement;
     }
 
-    return targetNode->renderer()->positionForPoint(LayoutPoint(selectionEndPoint), nullptr);
+    return adjustedTarget->renderer()->positionForPoint(LayoutPoint(selectionEndPoint), nullptr);
 }
 
 #if ENABLE(DRAG_SUPPORT)
@@ -844,13 +844,13 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
     if (handleDrag(event, checkDragHysteresis))
         return true;
 
-    Node* targetNode = event.targetNode();
+    RefPtr targetNode = event.targetNode();
     if (event.event().button() != LeftButton || !targetNode)
         return false;
 
     RenderObject* renderer = targetNode->renderer();
     if (!renderer) {
-        Element* parent = targetNode->parentOrShadowHostElement();
+        RefPtr parent = targetNode->parentOrShadowHostElement();
         if (!parent)
             return false;
 
@@ -907,8 +907,8 @@ bool EventHandler::eventMayStartDrag(const PlatformMouseEvent& event) const
     HitTestResult result(view->windowToContents(event.position()));
     document->hitTest(hitType, result);
     DragState state;
-    Element* targetElement = result.targetElement();
-    return targetElement && page->dragController().draggableElement(&m_frame, targetElement, result.roundedPointInInnerNodeFrame(), state);
+    RefPtr targetElement = result.targetElement();
+    return targetElement && page->dragController().draggableElement(&m_frame, targetElement.get(), result.roundedPointInInnerNodeFrame(), state);
 }
 
 void EventHandler::updateSelectionForMouseDrag()
@@ -937,14 +937,14 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
     if (!mouseDownMayStartSelect())
         return;
 
-    Node* target = hitTestResult.targetNode();
+    RefPtr target = hitTestResult.targetNode();
     if (!target)
         return;
 
     if (!HTMLElement::shouldUpdateSelectionForMouseDrag(*target, m_frame.selection().selection()))
         return;
 
-    VisiblePosition targetPosition = selectionExtentRespectingEditingBoundary(m_frame.selection().selection(), hitTestResult.localPoint(), target);
+    VisiblePosition targetPosition = selectionExtentRespectingEditingBoundary(m_frame.selection().selection(), hitTestResult.localPoint(), target.get());
 
     // Don't modify the selection if we're not on a node.
     if (targetPosition.isNull())
@@ -956,7 +956,7 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
 
     // Special case to limit selection to the containing block for SVG text.
     // FIXME: Isn't there a better non-SVG-specific way to do this?
-    if (Node* selectionBaseNode = newSelection.base().deprecatedNode()) {
+    if (RefPtr selectionBaseNode = newSelection.base().deprecatedNode()) {
         if (RenderObject* selectionBaseRenderer = selectionBaseNode->renderer()) {
             if (selectionBaseRenderer->isSVGText()) {
                 if (target->renderer()->containingBlock() != selectionBaseRenderer->containingBlock())
@@ -966,7 +966,7 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
     }
 
 
-    if (m_selectionInitiationState == HaveNotStartedSelection && !dispatchSelectStart(target)) {
+    if (m_selectionInitiationState == HaveNotStartedSelection && !dispatchSelectStart(target.get())) {
         m_mouseDownMayStartSelect = false;
         return;
     }
@@ -977,20 +977,20 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
         newSelection = VisibleSelection(targetPosition);
     }
 
-    Node* rootUserSelectAllForMousePressNode = Position::rootUserSelectAllForNode(m_mousePressNode.get());
-    if (rootUserSelectAllForMousePressNode && rootUserSelectAllForMousePressNode == Position::rootUserSelectAllForNode(target)) {
-        newSelection.setBase(positionBeforeNode(rootUserSelectAllForMousePressNode).upstream(CanCrossEditingBoundary));
-        newSelection.setExtent(positionAfterNode(rootUserSelectAllForMousePressNode).downstream(CanCrossEditingBoundary));
+    RefPtr rootUserSelectAllForMousePressNode = Position::rootUserSelectAllForNode(m_mousePressNode.get());
+    if (rootUserSelectAllForMousePressNode && rootUserSelectAllForMousePressNode == Position::rootUserSelectAllForNode(target.get())) {
+        newSelection.setBase(positionBeforeNode(rootUserSelectAllForMousePressNode.get()).upstream(CanCrossEditingBoundary));
+        newSelection.setExtent(positionAfterNode(rootUserSelectAllForMousePressNode.get()).downstream(CanCrossEditingBoundary));
     } else {
         // Reset base for user select all when base is inside user-select-all area and extent < base.
         if (rootUserSelectAllForMousePressNode && target->renderer()->positionForPoint(hitTestResult.localPoint(), nullptr) < m_mousePressNode->renderer()->positionForPoint(m_dragStartPosition, nullptr))
-            newSelection.setBase(positionAfterNode(rootUserSelectAllForMousePressNode).downstream(CanCrossEditingBoundary));
+            newSelection.setBase(positionAfterNode(rootUserSelectAllForMousePressNode.get()).downstream(CanCrossEditingBoundary));
 
-        Node* rootUserSelectAllForTarget = Position::rootUserSelectAllForNode(target);
+        RefPtr rootUserSelectAllForTarget = Position::rootUserSelectAllForNode(target.get());
         if (rootUserSelectAllForTarget && m_mousePressNode->renderer() && target->renderer()->positionForPoint(hitTestResult.localPoint(), nullptr) < m_mousePressNode->renderer()->positionForPoint(m_dragStartPosition, nullptr))
-            newSelection.setExtent(positionBeforeNode(rootUserSelectAllForTarget).upstream(CanCrossEditingBoundary));
+            newSelection.setExtent(positionBeforeNode(rootUserSelectAllForTarget.get()).upstream(CanCrossEditingBoundary));
         else if (rootUserSelectAllForTarget && m_mousePressNode->renderer())
-            newSelection.setExtent(positionAfterNode(rootUserSelectAllForTarget).downstream(CanCrossEditingBoundary));
+            newSelection.setExtent(positionAfterNode(rootUserSelectAllForTarget.get()).downstream(CanCrossEditingBoundary));
         else
             newSelection.setExtent(targetPosition);
     }
@@ -1055,7 +1055,7 @@ bool EventHandler::handleMouseReleaseEvent(const MouseEventWithHitTestResults& e
             && m_frame.selection().isRange()
             && event.event().button() != RightButton) {
         VisibleSelection newSelection;
-        Node* node = event.targetNode();
+        RefPtr node = event.targetNode();
         bool caretBrowsing = m_frame.settings().caretBrowsingEnabled();
         bool allowSelectionChanges = true;
         if (node && node->renderer() && (caretBrowsing || node->hasEditableStyle())) {
@@ -1152,12 +1152,10 @@ HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, Optio
     // We always send hitTestResultAtPoint to the main frame if we have one,
     // otherwise we might hit areas that are obscured by higher frames.
     if (!m_frame.isMainFrame()) {
-        Frame& mainFrame = m_frame.mainFrame();
-        FrameView* frameView = m_frame.view();
-        FrameView* mainView = mainFrame.view();
-        if (frameView && mainView) {
+        Ref mainFrame = m_frame.mainFrame();
+        if (RefPtr frameView = m_frame.view(), mainView = mainFrame->view(); frameView && mainView) {
             IntPoint mainFramePoint = mainView->rootViewToContents(frameView->contentsToRootView(roundedIntPoint(point)));
-            return mainFrame.eventHandler().hitTestResultAtPoint(mainFramePoint, hitType, padding);
+            return mainFrame->eventHandler().hitTestResultAtPoint(mainFramePoint, hitType);
         }
     }
 
@@ -1165,11 +1163,11 @@ HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, Optio
     unsigned nonNegativePaddingHeight = std::max<LayoutUnit>(0, padding.height()).toUnsigned();
 
     // We should always start hit testing a clean tree.
-    if (auto* frameView = m_frame.view())
+    if (RefPtr frameView = m_frame.view())
         frameView->updateLayoutAndStyleIfNeededRecursive();
 
     HitTestResult result(point, nonNegativePaddingHeight, nonNegativePaddingWidth, nonNegativePaddingHeight, nonNegativePaddingWidth);
-    auto* document = m_frame.document();
+    RefPtr document = m_frame.document();
     if (!document)
         return result;
 
@@ -1191,7 +1189,7 @@ void EventHandler::stopAutoscrollTimer(bool rendererIsBeingDestroyed)
 
 bool EventHandler::scrollOverflow(ScrollDirection direction, ScrollGranularity granularity, Node* startingNode)
 {
-    Node* node = startingNode;
+    RefPtr node = startingNode;
 
     if (!node)
         node = m_frame.document()->focusedElement();
@@ -1212,7 +1210,7 @@ bool EventHandler::scrollOverflow(ScrollDirection direction, ScrollGranularity g
 
 bool EventHandler::logicalScrollOverflow(ScrollLogicalDirection direction, ScrollGranularity granularity, Node* startingNode)
 {
-    Node* node = startingNode;
+    RefPtr node = startingNode;
 
     if (!node)
         node = m_frame.document()->focusedElement();
@@ -1240,8 +1238,8 @@ bool EventHandler::scrollRecursively(ScrollDirection direction, ScrollGranularit
     m_frame.document()->updateLayoutIgnorePendingStylesheets();
     if (scrollOverflow(direction, granularity, startingNode))
         return true;
-    Frame* frame = &m_frame;
-    FrameView* view = frame->view();
+    RefPtr frame = &m_frame;
+    RefPtr view = frame->view();
     if (view && view->scroll(direction, granularity))
         return true;
     frame = frame->tree().parent();
@@ -1259,8 +1257,8 @@ bool EventHandler::logicalScrollRecursively(ScrollLogicalDirection direction, Sc
     m_frame.document()->updateLayoutIgnorePendingStylesheets();
     if (logicalScrollOverflow(direction, granularity, startingNode))
         return true;
-    Frame* frame = &m_frame;
-    FrameView* view = frame->view();
+    RefPtr frame = &m_frame;
+    RefPtr view = frame->view();
 
     bool scrolled = false;
 #if PLATFORM(COCOA)
@@ -1369,11 +1367,11 @@ void EventHandler::updateCursor()
             return;
     }
 
-    FrameView* view = m_frame.view();
+    RefPtr view = m_frame.view();
     if (!view)
         return;
 
-    auto* document = m_frame.document();
+    RefPtr document = m_frame.document();
     if (!document)
         return;
 
@@ -1424,7 +1422,7 @@ Optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bool sh
         return pointerCursor();
     }
 
-    Node* node = result.targetNode();
+    RefPtr node = result.targetNode();
     if (!node)
         return WTF::nullopt;
 
@@ -1501,7 +1499,7 @@ Optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bool sh
     case CursorType::Auto: {
         bool editable = node->hasEditableStyle();
 
-        if (useHandCursor(node, result.isOverLink(), shiftKey))
+        if (useHandCursor(node.get(), result.isOverLink(), shiftKey))
             return handCursor();
 
         bool inResizer = false;
@@ -1730,7 +1728,7 @@ bool EventHandler::handleMousePressEvent(const PlatformMouseEvent& platformMouse
 #if ENABLE(PAN_SCROLLING)
     // We store whether pan scrolling is in progress before calling stopAutoscrollTimer()
     // because it will set m_autoscrollType to NoAutoscroll on return.
-    bool isPanScrollInProgress = m_frame.mainFrame().eventHandler().panScrollInProgress();
+    bool isPanScrollInProgress = Ref(m_frame.mainFrame())->eventHandler().panScrollInProgress();
     stopAutoscrollTimer();
     if (isPanScrollInProgress) {
         // We invalidate the click when exiting pan scrolling so that we don't inadvertently navigate
@@ -2005,7 +2003,7 @@ bool EventHandler::handleMouseMoveEvent(const PlatformMouseEvent& platformMouseE
     }
 
     if (!newSubframe || mouseEvent.scrollbar()) {
-        if (auto* view = m_frame.view())
+        if (RefPtr view = m_frame.view())
             updateCursor(*view, mouseEvent.hitTestResult(), platformMouseEvent.shiftKey());
     }
 
@@ -2268,13 +2266,12 @@ Element* EventHandler::draggingElement() const
     return dragState().source.get();
 }
 
-static bool targetIsFrame(Node* target, Frame*& frame)
+static std::pair<bool, RefPtr<Frame>> contentFrameForNode(Node* target)
 {
     if (!is<HTMLFrameElementBase>(target))
-        return false;
+        return { false, nullptr };
 
-    frame = downcast<HTMLFrameElementBase>(*target).contentFrame();
-    return true;
+    return { true, downcast<HTMLFrameElementBase>(*target).contentFrame() };
 }
 
 static Optional<DragOperation> convertDropZoneOperationToDragOperation(const String& dragOperation)
@@ -2360,12 +2357,12 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
     MouseEventWithHitTestResults mouseEvent = prepareMouseEvent(hitType, event);
 
     RefPtr<Element> newTarget;
-    if (Node* targetNode = mouseEvent.targetNode()) {
+    if (RefPtr targetNode = mouseEvent.targetNode()) {
         // Drag events should never go to non-element nodes (following IE, and proper mouseover/out dispatch)
         if (!is<Element>(*targetNode))
             newTarget = targetNode->parentOrShadowHostElement();
         else
-            newTarget = downcast<Element>(targetNode);
+            newTarget = static_pointer_cast<Element>(WTFMove(targetNode));
     }
 
     m_autoscrollController->updateDragAndDrop(newTarget.get(), event.position(), event.timestamp());
@@ -2377,8 +2374,7 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
         // LayoutTests/fast/events/drag-in-frames.html.
         //
         // Moreover, this ordering conforms to section 7.9.4 of the HTML 5 spec. <http://dev.w3.org/html5/spec/Overview.html#drag-and-drop-processing-model>.
-        Frame* targetFrame;
-        if (targetIsFrame(newTarget.get(), targetFrame)) {
+        if (auto [isFrameOwner, targetFrame] = contentFrameForNode(newTarget.get()); isFrameOwner) {
             if (targetFrame)
                 response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
         } else if (newTarget) {
@@ -2387,7 +2383,7 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
             response = dispatchDragEnterOrDragOverEvent(eventNames().dragenterEvent, *newTarget, event, makePasteboard(), sourceOperationMask, draggingFiles);
         }
 
-        if (targetIsFrame(m_dragTarget.get(), targetFrame)) {
+        if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.get()); isFrameOwner) {
             // FIXME: Recursing again here doesn't make sense if the newTarget and m_dragTarget were in the same frame.
             if (targetFrame)
                 response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
@@ -2403,8 +2399,7 @@ EventHandler::DragTargetResponse EventHandler::updateDragAndDrop(const PlatformM
             m_shouldOnlyFireDragOverEvent = true;
         }
     } else {
-        Frame* targetFrame;
-        if (targetIsFrame(newTarget.get(), targetFrame)) {
+        if (auto [isFrameOwner, targetFrame] = contentFrameForNode(newTarget.get()); isFrameOwner) {
             if (targetFrame)
                 response = targetFrame->eventHandler().updateDragAndDrop(event, makePasteboard, sourceOperationMask, draggingFiles);
         } else if (newTarget) {
@@ -2423,8 +2418,7 @@ void EventHandler::cancelDragAndDrop(const PlatformMouseEvent& event, std::uniqu
 {
     Ref<Frame> protectedFrame(m_frame);
 
-    Frame* targetFrame;
-    if (targetIsFrame(m_dragTarget.get(), targetFrame)) {
+    if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.get()); isFrameOwner) {
         if (targetFrame)
             targetFrame->eventHandler().cancelDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles);
     } else if (m_dragTarget) {
@@ -2441,9 +2435,8 @@ bool EventHandler::performDragAndDrop(const PlatformMouseEvent& event, std::uniq
 {
     Ref<Frame> protectedFrame(m_frame);
 
-    Frame* targetFrame;
     bool preventedDefault = false;
-    if (targetIsFrame(m_dragTarget.get(), targetFrame)) {
+    if (auto [isFrameOwner, targetFrame] = contentFrameForNode(m_dragTarget.get()); isFrameOwner) {
         if (targetFrame)
             preventedDefault = targetFrame->eventHandler().performDragAndDrop(event, WTFMove(pasteboard), sourceOperationMask, draggingFiles);
     } else if (m_dragTarget) {
@@ -2495,7 +2488,7 @@ MouseEventWithHitTestResults EventHandler::prepareMouseEvent(const HitTestReques
 
 static bool hierarchyHasCapturingEventListeners(Element* element, const AtomString& pointerEventName, const AtomString& compatibilityMouseEventName)
 {
-    for (ContainerNode* curr = element; curr; curr = curr->parentInComposedTree()) {
+    for (RefPtr<ContainerNode> curr = element; curr; curr = curr->parentInComposedTree()) {
         if (curr->hasCapturingEventListeners(pointerEventName) || curr->hasCapturingEventListeners(compatibilityMouseEventName))
             return true;
     }
@@ -2505,7 +2498,7 @@ static bool hierarchyHasCapturingEventListeners(Element* element, const AtomStri
 void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node* targetNode, const PlatformMouseEvent& platformMouseEvent, FireMouseOverOut fireMouseOverOut)
 {
     Ref<Frame> protectedFrame(m_frame);
-    Element* targetElement = nullptr;
+    RefPtr<Element> targetElement;
 
     // If we're capturing, we always go right to that element.
     if (m_capturingMouseEventsElement)
@@ -2596,7 +2589,8 @@ void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node*
 
 void EventHandler::notifyScrollableAreasOfMouseEvents(const AtomString& eventType, Element* lastElementUnderMouse, Element* elementUnderMouse)
 {
-    auto* frameView = m_frame.view();
+    Ref protectedFrame = m_frame;
+    RefPtr frameView = m_frame.view();
     if (!frameView)
         return;
 
@@ -2673,7 +2667,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     m_mouseDownDelegatedFocus = false;
 
     // If clicking on a frame scrollbar, do not make any change to which element is focused.
-    auto* view = m_frame.view();
+    RefPtr view = m_frame.view();
     if (view && view->scrollbarAtPoint(platformMouseEvent.position()))
         return true;
 
@@ -2688,7 +2682,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     // Walk up the DOM tree to search for an element to focus.
     RefPtr<Element> element;
     for (element = m_elementUnderMouse.get(); element; element = element->parentElementInComposedTree()) {
-        if (auto* shadowRoot = element->shadowRoot()) {
+        if (RefPtr shadowRoot = element->shadowRoot()) {
             if (shadowRoot->delegatesFocus()) {
                 element = findFirstMouseFocusableElementInComposedTree(*element);
                 m_mouseDownDelegatedFocus = true;
@@ -2727,7 +2721,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 
 bool EventHandler::isInsideScrollbar(const IntPoint& windowPoint) const
 {
-    if (auto* document = m_frame.document()) {
+    if (RefPtr document = m_frame.document()) {
         HitTestResult result { windowPoint };
         document->hitTest(OptionSet<HitTestRequest::RequestType> { HitTestRequest::ReadOnly, HitTestRequest::DisallowUserAgentShadowContent }, result);
         return result.scrollbar();
@@ -2848,6 +2842,7 @@ bool EventHandler::completeWidgetWheelEvent(const PlatformWheelEvent& event, con
 
 bool EventHandler::handleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps)
 {
+    Ref protectedFrame = m_frame;
 #if ENABLE(KINETIC_SCROLLING)
     if (wheelEvent.isGestureStart())
         m_wheelScrollGestureState = WTF::nullopt;
@@ -2862,14 +2857,13 @@ bool EventHandler::handleWheelEvent(const PlatformWheelEvent& wheelEvent, Option
 
 bool EventHandler::handleWheelEventInternal(const PlatformWheelEvent& event, OptionSet<WheelEventProcessingSteps> processingSteps, OptionSet<EventHandling>& handling)
 {
-    auto* document = m_frame.document();
+    RefPtr document = m_frame.document();
     if (!document)
         return false;
 
     Ref<Frame> protectedFrame(m_frame);
-    RefPtr<FrameView> protector(m_frame.view());
 
-    FrameView* view = m_frame.view();
+    RefPtr view = m_frame.view();
     if (!view)
         return false;
 
@@ -3128,8 +3122,8 @@ bool EventHandler::sendContextMenuEvent(const PlatformMouseEvent& event)
 {
     Ref<Frame> protectedFrame(m_frame);
 
-    Document* doc = m_frame.document();
-    FrameView* view = m_frame.view();
+    RefPtr doc = m_frame.document();
+    RefPtr view = m_frame.view();
     if (!view)
         return false;
 
@@ -3166,11 +3160,11 @@ bool EventHandler::sendContextMenuEventForKey()
 {
     Ref<Frame> protectedFrame(m_frame);
 
-    FrameView* view = m_frame.view();
+    RefPtr view = m_frame.view();
     if (!view)
         return false;
 
-    Document* doc = m_frame.document();
+    RefPtr doc = m_frame.document();
     if (!doc)
         return false;
 
@@ -3186,7 +3180,7 @@ bool EventHandler::sendContextMenuEventForKey()
 #endif
     IntPoint location;
 
-    Element* focusedElement = doc->focusedElement();
+    RefPtr focusedElement = doc->focusedElement();
     const VisibleSelection& selection = m_frame.selection().selection();
     Position start = selection.start();
 
@@ -3215,13 +3209,13 @@ bool EventHandler::sendContextMenuEventForKey()
     IntPoint position = view->contentsToRootView(location);
     IntPoint globalPosition = view->hostWindow()->rootViewToScreen(IntRect(position, IntSize())).location();
 
-    Node* targetNode = doc->focusedElement();
+    RefPtr<Node> targetNode = doc->focusedElement();
     if (!targetNode)
         targetNode = doc;
 
     // Use the focused node as the target for hover and active.
     HitTestResult result(position);
-    result.setInnerNode(targetNode);
+    result.setInnerNode(targetNode.get());
     doc->updateHoverActiveState(OptionSet<HitTestRequest::RequestType> { HitTestRequest::Active, HitTestRequest::DisallowUserAgentShadowContent }, result.targetElement());
 
     // The contextmenu event is a mouse event even when invoked using the keyboard.
@@ -3311,8 +3305,8 @@ void EventHandler::fakeMouseMoveEventTimerFired()
 {
     ASSERT(!m_mousePressed);
 
-    FrameView* view = m_frame.view();
-    if (!view)
+    Ref protectedFrame = m_frame;
+    if (!m_frame.view())
         return;
 
     if (!m_frame.page() || !m_frame.page()->isVisible() || !m_frame.page()->focusController().isActive())
@@ -3347,8 +3341,8 @@ void EventHandler::hoverTimerFired()
 
     Ref<Frame> protectedFrame(m_frame);
 
-    if (auto* document = m_frame.document()) {
-        if (FrameView* view = m_frame.view()) {
+    if (RefPtr document = m_frame.document()) {
+        if (RefPtr view = m_frame.view()) {
             HitTestResult result(view->windowToContents(m_lastKnownMousePosition));
             constexpr OptionSet<HitTestRequest::RequestType> hitType { HitTestRequest::Move, HitTestRequest::DisallowUserAgentShadowContent };
             document->hitTest(hitType, result);
@@ -3372,6 +3366,7 @@ void EventHandler::imageExtractionTimerFired()
 
 bool EventHandler::handleAccessKey(const PlatformKeyboardEvent& event)
 {
+    Ref protectedFrame = m_frame;
     // FIXME: Ignoring the state of Shift key is what neither IE nor Firefox do.
     // IE matches lower and upper case access keys regardless of Shift key state - but if both upper and
     // lower case variants are present in a document, the correct element is matched based on Shift key state.
@@ -3397,7 +3392,7 @@ bool EventHandler::needsKeyboardEventDisambiguationQuirks() const
 #if ENABLE(FULLSCREEN_API)
 bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& keyEvent) const
 {
-    Document* document = m_frame.document();
+    RefPtr document = m_frame.document();
     if (document->fullscreenManager().isFullscreenKeyboardInputAllowed())
         return true;
 
@@ -3418,7 +3413,8 @@ bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& ke
 
 bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
 {
-    Document* topDocument = m_frame.document() ? &m_frame.document()->topDocument() : nullptr;
+    Ref protectedFrame = m_frame;
+    RefPtr topDocument = m_frame.document() ? &m_frame.document()->topDocument() : nullptr;
     MonotonicTime savedLastHandledUserGestureTimestamp;
     bool savedUserDidInteractWithPage = topDocument ? topDocument->userDidInteractWithPage() : false;
 
@@ -3485,7 +3481,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
         capsLockStateMayHaveChanged();
 
 #if ENABLE(PAN_SCROLLING)
-    if (m_frame.mainFrame().eventHandler().panScrollInProgress()) {
+    if (Ref(m_frame.mainFrame())->eventHandler().panScrollInProgress()) {
         // If a key is pressed while the panScroll is in progress then we want to stop
         if (initialKeyEvent.type() == PlatformEvent::KeyDown || initialKeyEvent.type() == PlatformEvent::RawKeyDown)
             stopAutoscrollTimer();
@@ -3623,7 +3619,7 @@ static FocusDirection focusDirectionForKey(const AtomString& keyIdentifier)
 
 static void setInitialKeyboardSelection(Frame& frame, SelectionDirection direction)
 {
-    Document* document = frame.document();
+    RefPtr document = frame.document();
     if (!document)
         return;
 
@@ -3632,23 +3628,23 @@ static void setInitialKeyboardSelection(Frame& frame, SelectionDirection directi
     if (!selection.isNone())
         return;
 
-    Element* focusedElement = document->focusedElement();
+    RefPtr focusedElement = document->focusedElement();
     VisiblePosition visiblePosition;
 
     switch (direction) {
     case SelectionDirection::Backward:
     case SelectionDirection::Left:
         if (focusedElement)
-            visiblePosition = VisiblePosition(positionBeforeNode(focusedElement));
+            visiblePosition = VisiblePosition(positionBeforeNode(focusedElement.get()));
         else
-            visiblePosition = endOfDocument(document);
+            visiblePosition = endOfDocument(document.get());
         break;
     case SelectionDirection::Forward:
     case SelectionDirection::Right:
         if (focusedElement)
-            visiblePosition = VisiblePosition(positionAfterNode(focusedElement));
+            visiblePosition = VisiblePosition(positionAfterNode(focusedElement.get()));
         else
-            visiblePosition = startOfDocument(document);
+            visiblePosition = startOfDocument(document.get());
         break;
     }
 
@@ -3808,8 +3804,8 @@ void EventHandler::invalidateDataTransfer()
 
 static void removeDraggedContentDocumentMarkersFromAllFramesInPage(Page& page)
 {
-    for (Frame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (auto* document = frame->document())
+    for (RefPtr frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        if (RefPtr document = frame->document())
             document->markers().removeMarkers(DocumentMarker::DraggedContent);
     }
 
@@ -4183,7 +4179,6 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
         event.setDefaultHandled();
 }
 
-
 void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, KeyboardEvent& event)
 {
     ASSERT(event.type() == eventNames().keydownEvent);
@@ -4390,15 +4385,16 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
             if (freshTouchEvents) {
                 result = hitTestResultAtPoint(pagePoint, hitType | HitTestRequest::AllowChildFrameContent);
                 m_originatingTouchPointTargetKey = touchPointTargetKey;
-            } else if (m_originatingTouchPointDocument.get() && m_originatingTouchPointDocument->frame()) {
-                LayoutPoint pagePointInOriginatingDocument = documentPointForWindowPoint(*m_originatingTouchPointDocument->frame(), point.pos());
-                result = hitTestResultInFrame(m_originatingTouchPointDocument->frame(), pagePointInOriginatingDocument, hitType);
+            } else if (m_originatingTouchPointDocument && m_originatingTouchPointDocument->frame()) {
+                Ref frame = *m_originatingTouchPointDocument->frame();
+                LayoutPoint pagePointInOriginatingDocument = documentPointForWindowPoint(frame, point.pos());
+                result = hitTestResultInFrame(frame.ptr(), pagePointInOriginatingDocument, hitType);
                 if (!result.innerNode())
                     continue;
             } else
                 continue;
 
-            Element* element = result.targetElement();
+            RefPtr element = result.targetElement();
             ASSERT(element);
 
             if (element && InspectorInstrumentation::handleTouchEvent(m_frame, *element))
@@ -4433,7 +4429,7 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
         auto& document = downcast<Node>(*touchTarget).document();
         if (!document.hasTouchEventHandlers())
             continue;
-        auto* targetFrame = document.frame();
+        RefPtr targetFrame = document.frame();
         if (!targetFrame)
             continue;
 
@@ -4447,7 +4443,7 @@ bool EventHandler::handleTouchEvent(const PlatformTouchEvent& event)
         int adjustedPageX = lroundf(pagePoint.x() / scaleFactor);
         int adjustedPageY = lroundf(pagePoint.y() / scaleFactor);
 
-        auto touch = Touch::create(targetFrame, touchTarget.get(), point.id(),
+        auto touch = Touch::create(targetFrame.get(), touchTarget.get(), point.id(),
             point.screenPos().x(), point.screenPos().y(), adjustedPageX, adjustedPageY,
             point.radiusX(), point.radiusY(), point.rotationAngle(), point.force());
 
@@ -4574,7 +4570,7 @@ bool EventHandler::passWheelEventToWidget(const PlatformWheelEvent& event, Widge
     if (!is<FrameView>(widget))
         return false;
 
-    return downcast<FrameView>(widget).frame().eventHandler().handleWheelEvent(event, processingSteps);
+    return Ref(downcast<FrameView>(widget).frame())->eventHandler().handleWheelEvent(event, processingSteps);
 }
 
 bool EventHandler::tabsToAllFormControls(KeyboardEvent*) const

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Page.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Page.cpp
@@ -1404,12 +1404,12 @@ void Page::setIsInWindowInternal(bool isInWindow)
 
 void Page::addActivityStateChangeObserver(ActivityStateChangeObserver& observer)
 {
-    m_activityStateChangeObservers.add(&observer);
+    m_activityStateChangeObservers.add(observer);
 }
 
 void Page::removeActivityStateChangeObserver(ActivityStateChangeObserver& observer)
 {
-    m_activityStateChangeObservers.remove(&observer);
+    m_activityStateChangeObservers.remove(observer);
 }
 
 void Page::layoutIfNeeded()
@@ -2255,8 +2255,8 @@ void Page::setActivityState(OptionSet<ActivityState::Flag> activityState)
     if (changed.containsAny({ActivityState::IsVisible, ActivityState::IsVisuallyIdle, ActivityState::IsAudible, ActivityState::IsLoading, ActivityState::IsCapturingMedia }))
         updateTimerThrottlingState();
 
-    for (auto* observer : m_activityStateChangeObservers)
-        observer->activityStateDidChange(oldActivityState, m_activityState);
+    for (auto& observer : m_activityStateChangeObservers)
+        observer.activityStateDidChange(oldActivityState, m_activityState);
 
     if (wasVisibleAndActive != isVisibleAndActive())
         PlatformMediaSessionManager::updateNowPlayingInfoIfNecessary();

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Page.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Page.h
@@ -54,6 +54,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Ref.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -1056,7 +1057,7 @@ private:
     Ref<UserContentProvider> m_userContentProvider;
     Ref<VisitedLinkStore> m_visitedLinkStore;
     RefPtr<WheelEventTestMonitor> m_wheelEventTestMonitor;
-    HashSet<ActivityStateChangeObserver*> m_activityStateChangeObservers;
+    WeakHashSet<ActivityStateChangeObserver> m_activityStateChangeObservers;
 
 #if ENABLE(RESOURCE_USAGE)
     std::unique_ptr<ResourceUsageOverlay> m_resourceUsageOverlay;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Performance.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Performance.h
@@ -36,8 +36,9 @@
 #include "DOMHighResTimeStamp.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include "GenericTaskQueue.h"
 #include "ReducedResolutionSeconds.h"
+#include "ScriptExecutionContext.h"
+#include "Timer.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/Variant.h>
 
@@ -134,13 +135,13 @@ private:
     // https://w3c.github.io/resource-timing/#dfn-resource-timing-buffer-full-flag
     bool m_resourceTimingBufferFullFlag { false };
     bool m_waitingForBackupBufferToBeProcessed { false };
+    bool m_hasScheduledTimingBufferDeliveryTask { false };
 
     MonotonicTime m_timeOrigin;
 
     RefPtr<PerformancePaintTiming> m_firstContentfulPaint;
     std::unique_ptr<PerformanceUserTiming> m_userTiming;
 
-    GenericTaskQueue<ScriptExecutionContext> m_performanceTimelineTaskQueue;
     ListHashSet<RefPtr<PerformanceObserver>> m_observers;
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/PrintContext.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/PrintContext.cpp
@@ -191,15 +191,15 @@ void PrintContext::begin(float width, float height)
     if (!frame())
         return;
 
-    auto& frame = *this->frame();
+    auto frame = makeRef(*this->frame());
     // This function can be called multiple times to adjust printing parameters without going back to screen mode.
     m_isPrinting = true;
 
     FloatSize originalPageSize = FloatSize(width, height);
-    FloatSize minLayoutSize = frame.resizePageRectsKeepingRatio(originalPageSize, FloatSize(width * minimumShrinkFactor(), height * minimumShrinkFactor()));
+    FloatSize minLayoutSize = frame->resizePageRectsKeepingRatio(originalPageSize, FloatSize(width * minimumShrinkFactor(), height * minimumShrinkFactor()));
 
     // This changes layout, so callers need to make sure that they don't paint to screen while in printing mode.
-    frame.setPrinting(true, minLayoutSize, originalPageSize, maximumShrinkFactor() / minimumShrinkFactor(), AdjustViewSize);
+    frame->setPrinting(true, minLayoutSize, originalPageSize, maximumShrinkFactor() / minimumShrinkFactor(), AdjustViewSize);
 }
 
 float PrintContext::computeAutomaticScaleFactor(const FloatSize& availablePaperSize)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/CalculationValue.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/CalculationValue.cpp
@@ -180,9 +180,9 @@ bool CalcExpressionOperation::operator==(const CalcExpressionNode& other) const
 
 bool operator==(const CalcExpressionOperation& a, const CalcExpressionOperation& b)
 {
-    if (a.getOperator() != b.getOperator())
+    if (a.getOperator() != b.getOperator() || a.destinationCategory() != b.destinationCategory())
         return false;
-    // Maybe Vectors of unique_ptrs should always do deep compare?
+    // FIXME: Would be nice to have a helper function for doing a deep compare on a vector of pointers.
     if (a.children().size() != b.children().size())
         return false;
     for (unsigned i = 0; i < a.children().size(); ++i) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/CalculationValue.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/CalculationValue.h
@@ -42,6 +42,19 @@ class TextStream;
 
 namespace WebCore {
 
+// FIXME: Find a way to unify this with CSSPrimitiveValue::UnitCategory?
+enum class CalculationCategory : uint8_t {
+    Number,
+    Length,
+    Percent,
+    PercentNumber,
+    PercentLength,
+    Angle,
+    Time,
+    Frequency,
+    Other
+};
+
 // Don't change these values; parsing uses them.
 enum class CalcOperator : uint8_t {
     Add = '+',
@@ -151,9 +164,10 @@ bool operator==(const CalcExpressionInversion&, const CalcExpressionInversion&);
 
 class CalcExpressionOperation final : public CalcExpressionNode {
 public:
-    CalcExpressionOperation(Vector<std::unique_ptr<CalcExpressionNode>>&& children, CalcOperator);
+    CalcExpressionOperation(Vector<std::unique_ptr<CalcExpressionNode>>&& children, CalcOperator, CalculationCategory destinationCategory = CalculationCategory::Other);
 
     CalcOperator getOperator() const { return m_operator; }
+    CalculationCategory destinationCategory() const { return m_destinationCategory; }
 
     const Vector<std::unique_ptr<CalcExpressionNode>>& children() const { return m_children; }
 
@@ -164,6 +178,7 @@ private:
 
     Vector<std::unique_ptr<CalcExpressionNode>> m_children;
     CalcOperator m_operator;
+    CalculationCategory m_destinationCategory { CalculationCategory::Other };
 };
 
 class CalcExpressionBlendLength final : public CalcExpressionNode {
@@ -237,10 +252,11 @@ inline bool operator==(const CalcExpressionLength& a, const CalcExpressionLength
     return a.length() == b.length();
 }
 
-inline CalcExpressionOperation::CalcExpressionOperation(Vector<std::unique_ptr<CalcExpressionNode>>&& children, CalcOperator op)
+inline CalcExpressionOperation::CalcExpressionOperation(Vector<std::unique_ptr<CalcExpressionNode>>&& children, CalcOperator op, CalculationCategory destinationCategory)
     : CalcExpressionNode(CalcExpressionNodeType::Operation)
     , m_children(WTFMove(children))
     , m_operator(op)
+    , m_destinationCategory(destinationCategory)
 {
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/GenericTaskQueue.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/GenericTaskQueue.h
@@ -58,7 +58,7 @@ private:
 };
 
 template<>
-class TaskDispatcher<Timer> : public CanMakeWeakPtr<TaskDispatcher<Timer>> {
+class TaskDispatcher<Timer> : public CanMakeWeakPtr<TaskDispatcher<Timer>, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     TaskDispatcher();
@@ -82,17 +82,20 @@ public:
     GenericTaskQueue()
         : m_dispatcher(makeUniqueRef<TaskDispatcher<T>>())
     {
+        ASSERT(isMainThread());
     }
 
     explicit GenericTaskQueue(T& t)
         : m_dispatcher(makeUniqueRef<TaskDispatcher<T>>(&t))
     {
+        ASSERT(isMainThread());
     }
 
     explicit GenericTaskQueue(T* t)
         : m_dispatcher(makeUniqueRef<TaskDispatcher<T>>(t))
         , m_isClosed(!t)
     {
+        ASSERT(isMainThread());
     }
 
     ~GenericTaskQueue()

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/SharedBuffer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/SharedBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
  * Copyright (C) 2015 Canon Inc. All rights reserved.
  *
@@ -345,7 +345,12 @@ const char* SharedBufferDataView::data() const
 RefPtr<SharedBuffer> utf8Buffer(const String& string)
 {
     // Allocate a buffer big enough to hold all the characters.
-    const int length = string.length();
+    const size_t length = string.length();
+    if constexpr (String::MaxLength > std::numeric_limits<size_t>::max() / 3) {
+        if (length > std::numeric_limits<size_t>::max() / 3)
+            return nullptr;
+    }
+
     Vector<char> buffer(length * 3);
 
     // Convert to runs of 8-bit characters.

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
@@ -56,6 +56,9 @@ String MIMETypeRegistry::preferredExtensionForMIMEType(const String& mimeType)
     if (mimeType.isEmpty())
         return String();
 
+    if (mimeType.startsWith("text/plain"))
+        return String();
+
     String returnValue;
     char* extension;
     if (xdg_mime_get_simple_globs(mimeType.utf8().data(), &extension, 1)) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
@@ -921,8 +921,12 @@ bool RenderBlock::simplifiedLayout()
     // relative positioned container. So if we can have fixed pos objects in our positioned objects list check if any of them
     // are statically positioned and thus need to move with their absolute ancestors.
     bool canContainFixedPosObjects = canContainFixedPositionObjects();
-    if (posChildNeedsLayout() || canContainFixedPosObjects)
+    if (posChildNeedsLayout() || canContainFixedPosObjects) {
+        // FIXME: Remove this early return once https://webkit.org/b/228125 is fixed.
+        if (!hasPositionedObjects())
+            return false;
         layoutPositionedObjects(false, !posChildNeedsLayout() && canContainFixedPosObjects);
+    }
 
     // Recompute our overflow information.
     // FIXME: We could do better here by computing a temporary overflow object from layoutPositionedObjects and only

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.cpp
@@ -589,24 +589,23 @@ RenderPtr<RenderObject> RenderElement::detachRendererInternal(RenderObject& rend
     return RenderPtr<RenderObject>(&renderer);
 }
 
+static inline RenderBlock* nearestNonAnonymousContainingBlockIncludingSelf(RenderElement* renderer)
+{
+    while (renderer && (!is<RenderBlock>(*renderer) || renderer->isAnonymousBlock()))
+        renderer = renderer->containingBlock();
+    return downcast<RenderBlock>(renderer);
+}
+
 RenderBlock* RenderElement::containingBlockForFixedPosition() const
 {
-    auto* renderer = parent();
-    while (renderer && !renderer->canContainFixedPositionObjects())
-        renderer = renderer->parent();
-
-    ASSERT(!renderer || !renderer->isAnonymousBlock());
-    return downcast<RenderBlock>(renderer);
+    auto* ancestor = parent();
+    while (ancestor && !ancestor->canContainFixedPositionObjects())
+        ancestor = ancestor->parent();
+    return nearestNonAnonymousContainingBlockIncludingSelf(ancestor);
 }
 
 RenderBlock* RenderElement::containingBlockForAbsolutePosition() const
 {
-    auto nearestNonAnonymousContainingBlockIncludingSelf = [&] (auto* renderer) {
-        while (renderer && (!is<RenderBlock>(*renderer) || renderer->isAnonymousBlock()))
-            renderer = renderer->containingBlock();
-        return downcast<RenderBlock>(renderer);
-    };
-
     if (is<RenderInline>(*this) && style().position() == PositionType::Relative) {
         // A relatively positioned RenderInline forwards its absolute positioned descendants to
         // its nearest non-anonymous containing block (to avoid having positioned objects list in RenderInlines).
@@ -2177,8 +2176,8 @@ void RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded()
     if (is<RenderBlock>(*this))
         downcast<RenderBlock>(*this).resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants();
     else {
-        // Relatively positioned inline boxes can have absolutely positioned block children. We need to reset them as well.
-        for (auto& descendant : childrenOfType<RenderBlock>(*this))
+        // Relatively positioned inline boxes can have absolutely positioned block descendants. We need to reset them as well.
+        for (auto& descendant : descendantsOfType<RenderBlock>(*this))
             descendant.resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants();
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderElement.h
@@ -70,6 +70,7 @@ public:
     RenderObject* firstChild() const { return m_firstChild; }
     RenderObject* lastChild() const { return m_lastChild; }
 
+    // Note that even if these 2 "canContain" functions return true for a particular renderer, it does not necessarily mean the renderer is the containing block (see containingBlockForAbsolute(Fixed)Position).
     bool canContainFixedPositionObjects() const;
     bool canContainAbsolutelyPositionedObjects() const;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderGrid.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderGrid.cpp
@@ -31,6 +31,7 @@
 #include "GridLayoutFunctions.h"
 #include "GridPositionsResolver.h"
 #include "GridTrackSizingAlgorithm.h"
+#include "InspectorInstrumentation.h"
 #include "LayoutRepainter.h"
 #include "RenderChildIterator.h"
 #include "RenderLayer.h"
@@ -56,9 +57,14 @@ RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
 {
     // All of our children must be block level.
     setChildrenInline(false);
+
+    InspectorInstrumentation::nodeLayoutContextChanged(element, this);
 }
 
-RenderGrid::~RenderGrid() = default;
+RenderGrid::~RenderGrid()
+{
+    InspectorInstrumentation::nodeLayoutContextChanged(element(), nullptr);
+}
 
 StyleSelfAlignmentData RenderGrid::selfAlignmentForChild(GridAxis axis, const RenderBox& child, const RenderStyle* gridStyle) const
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -174,6 +174,7 @@ void RenderLineBreak::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) co
 void RenderLineBreak::updateFromStyle()
 {
     m_cachedLineHeight = invalidLineHeight;
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(isInline());
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderListMarker.cpp
@@ -1093,7 +1093,9 @@ void RenderListMarker::styleDidChange(StyleDifference diff, const RenderStyle* o
         if (style().listStylePosition() != oldStyle->listStylePosition() || style().listStyleType() != oldStyle->listStyleType() || (style().listStyleType() == ListStyleType::String && style().listStyleStringValue() != oldStyle->listStyleStringValue()))
             setNeedsLayoutAndPrefWidthsRecalc();
         if (oldStyle->isDisplayInlineType() && !style().isDisplayInlineType()) {
-            delete m_inlineBoxWrapper;
+            setNeedsLayoutAndPrefWidthsRecalc();
+            if (m_inlineBoxWrapper)
+                m_inlineBoxWrapper->dirtyLineBoxes();
             m_inlineBoxWrapper = nullptr;
         }
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderObject.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderObject.h
@@ -1150,9 +1150,7 @@ inline RenderObject::SetLayoutNeededForbiddenScope::SetLayoutNeededForbiddenScop
 
 inline void Node::setRenderer(RenderObject* renderer)
 {
-    auto oldRenderer = this->renderer();
     m_rendererWithStyleFlags.setPointer(renderer);
-    didChangeRenderer(oldRenderer);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/line/BreakingContext.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/line/BreakingContext.h
@@ -1236,7 +1236,9 @@ inline InlineIterator BreakingContext::handleEndOfLine()
         // Empty inline elements like <span></span> can produce such lines and now we just ignore these break opportunities
         // at the start of a line, if no width has been committed yet.
         // Behave as if it was actually empty and consume at least one object.
-        m_lineBreak.increment();
+        auto overflowingBoxIsInlineLevelBox = m_lineBreak.renderer() && !m_lineBreak.renderer()->isFloatingOrOutOfFlowPositioned();
+        if (overflowingBoxIsInlineLevelBox)
+            m_lineBreak.increment();
     }
 
     // Sanity check our whitespace collapsing transitions.

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -101,6 +101,7 @@ void RenderMathMLRow::stretchVerticalOperatorsAndLayoutChildren()
         if (auto renderOperator = toVerticalStretchyOperator(child)) {
             renderOperator->stretchTo(stretchAscent, stretchDescent);
             renderOperator->layoutIfNeeded();
+            child->layoutIfNeeded();
         }
     }
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -353,12 +353,18 @@ bool SVGInlineTextBox::acquirePaintingResource(GraphicsContext*& context, float 
         return false;
 
     if (!m_paintingResource->applyResource(renderer, style, context, paintingResourceMode())) {
-        if (fallbackColor.isValid()) {
+        if (!fallbackColor.isValid()) {
+            m_paintingResource = nullptr;
+            return false;
+        }
+
             RenderSVGResourceSolidColor* fallbackResource = RenderSVGResource::sharedSolidPaintingResource();
             fallbackResource->setColor(fallbackColor);
 
             m_paintingResource = fallbackResource;
-            m_paintingResource->applyResource(renderer, style, context, paintingResourceMode());
+        if (!m_paintingResource->applyResource(renderer, style, context, paintingResourceMode())) {
+            m_paintingResource = nullptr;
+            return false;
         }
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -70,7 +70,8 @@ private:
     void attachIgnoringContinuation(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild = nullptr);
     void attachToRenderGrid(RenderGrid& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
     void attachToRenderElement(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
-    void attachToRenderElementInternal(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr);
+    enum class ReinsertAfterMove { No, Yes };
+    void attachToRenderElementInternal(RenderElement& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild = nullptr, ReinsertAfterMove = ReinsertAfterMove::No);
 
     enum class WillBeDestroyed { No, Yes };
     RenderPtr<RenderObject> detachFromRenderElement(RenderElement& parent, RenderObject& child, WillBeDestroyed = WillBeDestroyed::Yes) WARN_UNUSED_RETURN;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -288,7 +288,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::Block::detach(RenderBlock& parent, Re
     // with inline content, then we can fold the inline content back together.
     auto prev = makeWeakPtr(oldChild.previousSibling());
     auto next = makeWeakPtr(oldChild.nextSibling());
-    bool canMergeAnonymousBlocks = canMergeContiguousAnonymousBlocks(oldChild, prev.get(), next.get());
+    bool canMergeAnonymousBlocks = canCollapseAnonymousBlock == CanCollapseAnonymousBlock::Yes && canMergeContiguousAnonymousBlocks(oldChild, prev.get(), next.get());
 
     auto takenChild = m_builder.detachFromRenderElement(parent, oldChild);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -237,6 +237,9 @@ void RenderTreeUpdater::popParent()
     if (parent.element)
         updateAfterDescendants(*parent.element, parent.updates);
 
+    if (&parent != &renderingParent())
+        renderTreePosition().invalidateNextSibling();
+
     m_parentStack.removeLast();
 }
 
@@ -533,6 +536,18 @@ void RenderTreeUpdater::tearDownRenderers(Element& root)
     tearDownRenderers(root, TeardownType::Full, builder);
 }
 
+void RenderTreeUpdater::tearDownRenderersAfterSlotChange(Element& host)
+{
+    ASSERT(host.shadowRoot());
+    if (!host.renderer() && !host.hasDisplayContents())
+        return;
+    auto* view = host.document().renderView();
+    if (!view)
+        return;
+    RenderTreeBuilder builder(*view);
+    tearDownRenderers(host, TeardownType::FullAfterSlotChange, builder);
+}
+
 void RenderTreeUpdater::tearDownRenderer(Text& text)
 {
     auto* view = text.document().renderView();
@@ -558,29 +573,37 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
     auto pop = [&] (unsigned depth) {
         while (teardownStack.size() > depth) {
             auto& element = *teardownStack.takeLast();
+            auto styleable = Styleable::fromElement(element);
 
             // Make sure we don't leave any renderers behind in nodes outside the composed tree.
             if (element.shadowRoot())
                 tearDownLeftoverShadowHostChildren(element, builder);
 
             switch (teardownType) {
+            case TeardownType::FullAfterSlotChange:
+                if (&element == &root) {
+                    // Keep animations going on the host.
+                    if (timeline)
+                        timeline->willChangeRendererForStyleable(styleable);
+                    break;
+                }
+                FALLTHROUGH;
             case TeardownType::Full:
-            case TeardownType::RendererUpdateCancelingAnimations:
                 if (timeline) {
                     if (document.renderTreeBeingDestroyed())
-                        timeline->cancelDeclarativeAnimationsForStyleable(Styleable::fromElement(element), WebAnimation::Silently::Yes);
-                    else if (teardownType == TeardownType::RendererUpdateCancelingAnimations)
-                        timeline->cancelDeclarativeAnimationsForStyleable(Styleable::fromElement(element), WebAnimation::Silently::No);
+                        timeline->cancelDeclarativeAnimationsForStyleable(styleable, WebAnimation::Silently::Yes);
                 }
+                element.clearHoverAndActiveStatusBeforeDetachingRenderer();
+                break;
+            case TeardownType::RendererUpdateCancelingAnimations:
+                if (timeline)
+                    timeline->cancelDeclarativeAnimationsForStyleable(styleable, WebAnimation::Silently::No);
                 break;
             case TeardownType::RendererUpdate:
                 if (timeline)
                     timeline->willChangeRendererForStyleable(Styleable::fromElement(element));
                 break;
             }
-
-            if (teardownType == TeardownType::Full)
-                element.clearHoverAndActiveStatusBeforeDetachingRenderer();
 
             GeneratedContent::removeBeforePseudoElement(element, builder);
             GeneratedContent::removeAfterPseudoElement(element, builder);

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -50,6 +50,7 @@ public:
     void commit(std::unique_ptr<const Style::Update>);
 
     static void tearDownRenderers(Element&);
+    static void tearDownRenderersAfterSlotChange(Element& host);
     static void tearDownRenderer(Text&);
 
 private:
@@ -87,7 +88,8 @@ private:
     void popParent();
     void popParentsToDepth(unsigned depth);
 
-    enum class TeardownType { Full, RendererUpdate, RendererUpdateCancelingAnimations };
+    // FIXME: Use OptionSet.
+    enum class TeardownType { Full, FullAfterSlotChange, RendererUpdate, RendererUpdateCancelingAnimations };
     static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&);
     static void tearDownTextRenderer(Text&, RenderTreeBuilder&);
     static void tearDownLeftoverShadowHostChildren(Element&, RenderTreeBuilder&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/replay/UserInputBridge.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/replay/UserInputBridge.cpp
@@ -55,42 +55,42 @@ bool UserInputBridge::handleContextMenuEvent(const PlatformMouseEvent& mouseEven
 
 bool UserInputBridge::handleMousePressEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return m_page.mainFrame().eventHandler().handleMousePressEvent(mouseEvent);
+    return Ref(m_page.mainFrame())->eventHandler().handleMousePressEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseReleaseEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return m_page.mainFrame().eventHandler().handleMouseReleaseEvent(mouseEvent);
+    return Ref(m_page.mainFrame())->eventHandler().handleMouseReleaseEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseMoveEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return m_page.mainFrame().eventHandler().mouseMoved(mouseEvent);
+    return Ref(m_page.mainFrame())->eventHandler().mouseMoved(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseMoveOnScrollbarEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return m_page.mainFrame().eventHandler().passMouseMovedEventToScrollbars(mouseEvent);
+    return Ref(m_page.mainFrame())->eventHandler().passMouseMovedEventToScrollbars(mouseEvent);
 }
 
 bool UserInputBridge::handleMouseForceEvent(const PlatformMouseEvent& mouseEvent, InputSource)
 {
-    return m_page.mainFrame().eventHandler().handleMouseForceEvent(mouseEvent);
+    return Ref(m_page.mainFrame())->eventHandler().handleMouseForceEvent(mouseEvent);
 }
 
 bool UserInputBridge::handleKeyEvent(const PlatformKeyboardEvent& keyEvent, InputSource)
 {
-    return m_page.focusController().focusedOrMainFrame().eventHandler().keyEvent(keyEvent);
+    return Ref(m_page.focusController().focusedOrMainFrame())->eventHandler().keyEvent(keyEvent);
 }
 
 bool UserInputBridge::handleAccessKeyEvent(const PlatformKeyboardEvent& keyEvent, InputSource)
 {
-    return m_page.focusController().focusedOrMainFrame().eventHandler().handleAccessKey(keyEvent);
+    return Ref(m_page.focusController().focusedOrMainFrame())->eventHandler().handleAccessKey(keyEvent);
 }
 
 bool UserInputBridge::handleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps, InputSource)
 {
-    return m_page.mainFrame().eventHandler().handleWheelEvent(wheelEvent, processingSteps);
+    return Ref(m_page.mainFrame())->eventHandler().handleWheelEvent(wheelEvent, processingSteps);
 }
 
 void UserInputBridge::focusSetActive(bool active, InputSource)
@@ -105,12 +105,12 @@ void UserInputBridge::focusSetFocused(bool focused, InputSource)
 
 bool UserInputBridge::scrollRecursively(ScrollDirection direction, ScrollGranularity granularity, InputSource)
 {
-    return m_page.focusController().focusedOrMainFrame().eventHandler().scrollRecursively(direction, granularity, nullptr);
+    return Ref(m_page.focusController().focusedOrMainFrame())->eventHandler().scrollRecursively(direction, granularity, nullptr);
 }
 
 bool UserInputBridge::logicalScrollRecursively(ScrollLogicalDirection direction, ScrollGranularity granularity, InputSource)
 {
-    return m_page.focusController().focusedOrMainFrame().eventHandler().logicalScrollRecursively(direction, granularity, nullptr);
+    return Ref(m_page.focusController().focusedOrMainFrame())->eventHandler().logicalScrollRecursively(direction, granularity, nullptr);
 }
 
 void UserInputBridge::loadRequest(FrameLoadRequest&& request, InputSource)
@@ -118,7 +118,7 @@ void UserInputBridge::loadRequest(FrameLoadRequest&& request, InputSource)
 #if ENABLE(WEB_AUTHN)
     m_page.authenticatorCoordinator().resetUserGestureRequirement();
 #endif
-    m_page.mainFrame().loader().load(WTFMove(request));
+    Ref(m_page.mainFrame())->loader().load(WTFMove(request));
 }
 
 void UserInputBridge::reloadFrame(Frame& frame, OptionSet<ReloadOption> options, InputSource)
@@ -136,7 +136,7 @@ void UserInputBridge::stopLoadingFrame(Frame& frame, InputSource)
 
 bool UserInputBridge::tryClosePage(InputSource)
 {
-    return m_page.mainFrame().loader().shouldClose();
+    return Ref(m_page.mainFrame())->loader().shouldClose();
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/style/StyleBuilderCustom.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/StyleBuilderCustom.h
@@ -1799,30 +1799,37 @@ inline void BuilderCustom::applyValueGridTemplateAreas(BuilderState& builderStat
     builderState.style().setNamedGridAreaColumnCount(gridTemplateAreasValue.columnCount());
 }
 
+#define SET_TRACKS_DATA_INTERNAL(tracksData, style, parentStyle, TrackType) \
+    ASSERT(tracksData || parentStyle); \
+    style.setGrid##TrackType##s(tracksData ? tracksData->m_trackSizes : parentStyle->grid##TrackType##s()); \
+    style.setNamedGrid##TrackType##Lines(tracksData ? tracksData->m_namedGridLines : parentStyle->namedGrid##TrackType##Lines()); \
+    style.setOrderedNamedGrid##TrackType##Lines(tracksData ? tracksData->m_orderedNamedGridLines : parentStyle->orderedNamedGrid##TrackType##Lines()); \
+    style.setGridAutoRepeat##TrackType##s(tracksData ? tracksData->m_autoRepeatTrackSizes : parentStyle->gridAutoRepeat##TrackType##s()); \
+    style.setGridAutoRepeat##TrackType##sInsertionPoint(tracksData ? tracksData->m_autoRepeatInsertionPoint : parentStyle->gridAutoRepeat##TrackType##sInsertionPoint()); \
+    style.setAutoRepeatNamedGrid##TrackType##Lines(tracksData ? tracksData->m_autoRepeatNamedGridLines : parentStyle->autoRepeatNamedGrid##TrackType##Lines()); \
+    style.setAutoRepeatOrderedNamedGrid##TrackType##Lines(tracksData ? tracksData->m_autoRepeatOrderedNamedGridLines : parentStyle->autoRepeatOrderedNamedGrid##TrackType##Lines()); \
+    style.setGridAutoRepeat##TrackType##sType(tracksData ? tracksData->m_autoRepeatType : parentStyle->gridAutoRepeat##TrackType##sType());
+
+#define SET_INHERIT_TRACKS_DATA(style, parentStyle, TrackType) \
+    BuilderConverter::TracksData* tracksData = nullptr; \
+    const RenderStyle* parentStylePointer = &parentStyle; \
+    SET_TRACKS_DATA_INTERNAL(tracksData, style, parentStylePointer, TrackType)
+
+#define SET_TRACKS_DATA(tracksData, style, TrackType) \
+    BuilderConverter::TracksData* tracksDataPointer = &tracksData; \
+    const RenderStyle* parentStyle = nullptr; \
+    SET_TRACKS_DATA_INTERNAL(tracksDataPointer, style, parentStyle, TrackType)
+
 inline void BuilderCustom::applyInitialGridTemplateColumns(BuilderState& builderState)
 {
-    builderState.style().setGridColumns(RenderStyle::initialGridColumns());
-    builderState.style().setNamedGridColumnLines(RenderStyle::initialNamedGridColumnLines());
-    builderState.style().setOrderedNamedGridColumnLines(RenderStyle::initialOrderedNamedGridColumnLines());
+    BuilderConverter::TracksData initialTracksData;
+    SET_TRACKS_DATA(initialTracksData, builderState.style(), Column);
 }
 
 inline void BuilderCustom::applyInheritGridTemplateColumns(BuilderState& builderState)
 {
-    builderState.style().setGridColumns(builderState.parentStyle().gridColumns());
-    builderState.style().setNamedGridColumnLines(builderState.parentStyle().namedGridColumnLines());
-    builderState.style().setOrderedNamedGridColumnLines(builderState.parentStyle().orderedNamedGridColumnLines());
+    SET_INHERIT_TRACKS_DATA(builderState.style(), builderState.parentStyle(), Column);
 }
-
-#define SET_TRACKS_DATA(tracksData, style, TrackType) \
-    style.setGrid##TrackType##s(tracksData.m_trackSizes); \
-    style.setNamedGrid##TrackType##Lines(tracksData.m_namedGridLines); \
-    style.setOrderedNamedGrid##TrackType##Lines(tracksData.m_orderedNamedGridLines); \
-    style.setGridAutoRepeat##TrackType##s(tracksData.m_autoRepeatTrackSizes); \
-    style.setGridAutoRepeat##TrackType##sInsertionPoint(tracksData.m_autoRepeatInsertionPoint); \
-    style.setAutoRepeatNamedGrid##TrackType##Lines(tracksData.m_autoRepeatNamedGridLines); \
-    style.setAutoRepeatOrderedNamedGrid##TrackType##Lines(tracksData.m_autoRepeatOrderedNamedGridLines); \
-    style.setGridAutoRepeat##TrackType##sType(tracksData.m_autoRepeatType); \
-    style.setGridAutoRepeat##TrackType##sInsertionPoint(tracksData.m_autoRepeatInsertionPoint);
 
 inline void BuilderCustom::applyValueGridTemplateColumns(BuilderState& builderState, CSSValue& value)
 {
@@ -1838,16 +1845,13 @@ inline void BuilderCustom::applyValueGridTemplateColumns(BuilderState& builderSt
 
 inline void BuilderCustom::applyInitialGridTemplateRows(BuilderState& builderState)
 {
-    builderState.style().setGridRows(RenderStyle::initialGridRows());
-    builderState.style().setNamedGridRowLines(RenderStyle::initialNamedGridRowLines());
-    builderState.style().setOrderedNamedGridRowLines(RenderStyle::initialOrderedNamedGridRowLines());
+    BuilderConverter::TracksData initialTracksData;
+    SET_TRACKS_DATA(initialTracksData, builderState.style(), Row);
 }
 
 inline void BuilderCustom::applyInheritGridTemplateRows(BuilderState& builderState)
 {
-    builderState.style().setGridRows(builderState.parentStyle().gridRows());
-    builderState.style().setNamedGridRowLines(builderState.parentStyle().namedGridRowLines());
-    builderState.style().setOrderedNamedGridRowLines(builderState.parentStyle().orderedNamedGridRowLines());
+    SET_INHERIT_TRACKS_DATA(builderState.style(), builderState.parentStyle(), Row);
 }
 
 inline void BuilderCustom::applyValueGridTemplateRows(BuilderState& builderState, CSSValue& value)

--- a/modules/javafx.web/src/main/native/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/StyleTreeResolver.cpp
@@ -205,7 +205,7 @@ ElementUpdates TreeResolver::resolveElement(Element& element)
         return { };
     }
 
-    if (!element.rendererIsEverNeeded())
+    if (!element.rendererIsEverNeeded() && !element.hasDisplayContents())
         return { };
 
     Styleable styleable { element, PseudoId::None };

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -496,7 +496,7 @@ void SVGAnimationElement::currentValuesForValuesAnimation(float percent, float& 
         --index;
     from = m_values[index];
     to = m_values[index + 1];
-    ASSERT_WITH_SECURITY_IMPLICATION(toPercent > fromPercent);
+    ASSERT(toPercent > fromPercent);
     effectivePercent = (percent - fromPercent) / (toPercent - fromPercent);
 
     if (calcMode == CalcMode::Spline) {
@@ -590,37 +590,6 @@ void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)
     calculateAnimatedValue(effectivePercent, repeatCount);
 }
 
-void SVGAnimationElement::computeCSSPropertyValue(SVGElement* element, CSSPropertyID id, String& valueString)
-{
-    ASSERT(element);
-
-    // Don't include any properties resulting from CSS Transitions/Animations or SMIL animations, as we want to retrieve the "base value".
-    element->setUseOverrideComputedStyle(true);
-    RefPtr<CSSValue> value = ComputedStyleExtractor(element).propertyValue(id);
-    valueString = value ? value->cssText() : String();
-    element->setUseOverrideComputedStyle(false);
-}
-
-static bool inheritsFromProperty(SVGElement* targetElement, const QualifiedName& attributeName, const String& value)
-{
-    static MainThreadNeverDestroyed<const AtomString> inherit("inherit", AtomString::ConstructFromLiteral);
-
-    if (value.isEmpty() || value != inherit)
-        return false;
-    return targetElement->isAnimatedStyleAttribute(attributeName);
-}
-
-void SVGAnimationElement::determinePropertyValueTypes(const String& from, const String& to)
-{
-    auto targetElement = makeRefPtr(this->targetElement());
-    ASSERT(targetElement);
-
-    const QualifiedName& attributeName = this->attributeName();
-    if (inheritsFromProperty(targetElement.get(), attributeName, from))
-        m_fromPropertyValueType = InheritValue;
-    if (inheritsFromProperty(targetElement.get(), attributeName, to))
-        m_toPropertyValueType = InheritValue;
-}
 void SVGAnimationElement::resetAnimation()
 {
     m_lastValuesAnimationFrom = String();

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGAnimationElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGAnimationElement.h
@@ -79,9 +79,6 @@ public:
     enum class AttributeType : uint8_t { CSS, XML, Auto };
     AttributeType attributeType() const { return m_attributeType; }
 
-    void computeCSSPropertyValue(SVGElement*, CSSPropertyID, String& value);
-    virtual void determinePropertyValueTypes(const String& from, const String& to);
-
 protected:
     SVGAnimationElement(const QualifiedName&, Document&);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGElement.cpp
@@ -155,8 +155,8 @@ static NEVER_INLINE HashMap<AtomStringImpl*, CSSPropertyID> createAttributeNameT
     return map;
 }
 
-SVGElement::SVGElement(const QualifiedName& tagName, Document& document)
-    : StyledElement(tagName, document, CreateSVGElement)
+SVGElement::SVGElement(const QualifiedName& tagName, Document& document, ConstructionType constructionType)
+    : StyledElement(tagName, document, constructionType)
     , m_propertyAnimatorFactory(makeUnique<SVGPropertyAnimatorFactory>())
 {
     static std::once_flag onceFlag;
@@ -293,6 +293,7 @@ const HashSet<SVGElement*>& SVGElement::instances() const
 
 bool SVGElement::getBoundingBox(FloatRect& rect, SVGLocatable::StyleUpdateStrategy styleUpdateStrategy)
 {
+    // FIXME: should retrieve the value from the associated RenderObject.
     if (is<SVGGraphicsElement>(*this)) {
         rect = downcast<SVGGraphicsElement>(*this).getBBox(styleUpdateStrategy);
         return true;

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGElement.h
@@ -147,7 +147,7 @@ public:
     SVGAnimatedString& classNameAnimated() { return m_className; }
 
 protected:
-    SVGElement(const QualifiedName&, Document&);
+    SVGElement(const QualifiedName&, Document&, ConstructionType = CreateSVGElement);
     virtual ~SVGElement();
 
     bool rendererIsNeeded(const RenderStyle&) override;

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGUnknownElement.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/SVGUnknownElement.h
@@ -45,7 +45,7 @@ public:
 
 private:
     SVGUnknownElement(const QualifiedName& tagName, Document& document)
-        : SVGElement(tagName, document)
+        : SVGElement(tagName, document, CreateSVGElement | NodeFlag::IsUnknownElement)
     {
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimator.h
@@ -56,7 +56,7 @@ public:
 
     void start(SVGElement* targetElement) override
     {
-        String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));
+        String baseValue = computeCSSPropertyValue(*targetElement, cssPropertyID(m_attributeName.localName()));
         m_property->setValue(SVGPropertyTraits<PropertyType>::fromString(baseValue));
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -76,14 +76,14 @@ protected:
         return value == inherit ? computeInheritedCSSPropertyValue(targetElement) : value;
     }
 
-    String computeCSSPropertyValue(SVGElement* targetElement, CSSPropertyID id) const
+    String computeCSSPropertyValue(SVGElement& targetElement, CSSPropertyID id) const
     {
-        ASSERT(targetElement);
+        auto protector = makeRefPtr(targetElement);
 
         // Don't include any properties resulting from CSS Transitions/Animations or SMIL animations, as we want to retrieve the "base value".
-        targetElement->setUseOverrideComputedStyle(true);
-        RefPtr<CSSValue> value = ComputedStyleExtractor(targetElement).propertyValue(id);
-        targetElement->setUseOverrideComputedStyle(false);
+        targetElement.setUseOverrideComputedStyle(true);
+        RefPtr<CSSValue> value = ComputedStyleExtractor(&targetElement).propertyValue(id);
+        targetElement.setUseOverrideComputedStyle(false);
         return value ? value->cssText() : String();
     }
 
@@ -95,7 +95,7 @@ protected:
             return emptyString();
 
         SVGElement& svgParent = downcast<SVGElement>(*parent);
-        return computeCSSPropertyValue(&svgParent, cssPropertyID(m_attributeName.localName()));
+        return computeCSSPropertyValue(svgParent, cssPropertyID(m_attributeName.localName()));
     }
 
     AnimationFunction m_function;

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGValuePropertyAnimatorImpl.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGValuePropertyAnimatorImpl.h
@@ -44,7 +44,7 @@ public:
 
     void start(SVGElement* targetElement) override
     {
-        String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));
+        String baseValue = computeCSSPropertyValue(*targetElement, cssPropertyID(m_attributeName.localName()));
         SVGLengthValue value(SVGLengthMode::Other);
         if (!value.setValueAsString(baseValue).hasException())
             m_property->setValue(value);

--- a/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGValuePropertyListAnimatorImpl.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/svg/properties/SVGValuePropertyListAnimatorImpl.h
@@ -44,7 +44,7 @@ public:
 
     void start(SVGElement* targetElement) override
     {
-        String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));
+        String baseValue = computeCSSPropertyValue(*targetElement, cssPropertyID(m_attributeName.localName()));
         if (!m_list->parse(baseValue))
             m_list->clearItems();
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -507,7 +507,7 @@ void WorkerOrWorkletScriptController::initScriptWithSubclass()
     ASSERT(asObject(m_globalScopeWrapper->getPrototypeDirect(*m_vm))->globalObject() == m_globalScopeWrapper);
 
     m_consoleClient = makeUnique<WorkerConsoleClient>(*m_globalScope);
-    m_globalScopeWrapper->setConsoleClient(m_consoleClient.get());
+    m_globalScopeWrapper->setConsoleClient(makeWeakPtr(*m_consoleClient));
 }
 
 void WorkerOrWorkletScriptController::initScript()


### PR DESCRIPTION
Clean backport to `jfx11u` of WebKit GTK 2.32.4 fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274107](https://bugs.openjdk.java.net/browse/JDK-8274107): Cherry pick GTK WebKit 2.32.4 changes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/54.diff">https://git.openjdk.java.net/jfx11u/pull/54.diff</a>

</details>
