### PR TITLE
8275138: WebView: UserAgent string is empty for first request

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameLoaderClientJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameLoaderClientJava.cpp
@@ -220,6 +220,13 @@ void FrameLoaderClientJava::dispatchDidNavigateWithinPage()
                   1.0 /* progress */);
 }
 
+// Called from twkInit to initialize the client. This will ensure that
+// the page field is initialized before any operation that needs it
+void FrameLoaderClientJava::init()
+{
+    (void)page();
+}
+
 Page* FrameLoaderClientJava::page()
 {
     if (!m_page) {

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameLoaderClientJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/FrameLoaderClientJava.h
@@ -46,6 +46,8 @@ public:
     FrameLoaderClientJava(const JLObject &webPage);
     ~FrameLoaderClientJava();
 
+    void init();
+
     bool hasWebView() const override;
 
     void makeRepresentation(DocumentLoader*) override;

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
@@ -924,8 +924,11 @@ JNIEXPORT void JNICALL Java_com_sun_webkit_WebPage_twkInit
     page->setDeviceScaleFactor(devicePixelScale);
 
     settings.setLinkPrefetchEnabled(true);
-    static_cast<FrameLoaderClientJava&>(page->mainFrame().loader().client())
-                                            .setFrame(&page->mainFrame());
+
+    FrameLoaderClientJava& client =
+        static_cast<FrameLoaderClientJava&>(page->mainFrame().loader().client());
+    client.init();
+    client.setFrame(&page->mainFrame());
 
     page->mainFrame().init();
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -445,6 +445,25 @@ public class MiscellaneousTest extends TestBase {
         }
     }
 
+    private void verifyUserAgentString(String userAgentString) {
+        final String fxVersion = System.getProperty("javafx.runtime.version");
+        final String numericStr = fxVersion.split("[^0-9]")[0];
+        final String fxVersionString = "JavaFX/" + numericStr;
+        assertTrue("UserAgentString does not contain " + fxVersionString, userAgentString.contains(fxVersionString));
+
+        File webkitLicense = new File("src/main/legal/webkit.md");
+        assertTrue("File does not exist: " + webkitLicense, webkitLicense.exists());
+
+        try (final BufferedReader licenseText = new BufferedReader(new FileReader(webkitLicense))) {
+            final String firstLine = licenseText.readLine().trim();
+            final String webkitVersion = firstLine.substring(firstLine.lastIndexOf(" ") + 2);
+            assertTrue("webkitVersion should not be empty", webkitVersion.length() > 0);
+            assertTrue("UserAgentString does not contain: " + webkitVersion, userAgentString.contains(webkitVersion));
+        } catch (IOException ex){
+            throw new AssertionError(ex);
+        }
+    }
+
     /**
      * @test
      * @bug 8193207
@@ -453,22 +472,24 @@ public class MiscellaneousTest extends TestBase {
     @Test public void testUserAgentString() {
         submit(() -> {
             final String userAgentString = getEngine().getUserAgent();
-            final String fxVersion = System.getProperty("javafx.runtime.version");
-            final String numericStr = fxVersion.split("[^0-9]")[0];
-            final String fxVersionString = "JavaFX/" + numericStr;
-            assertTrue("UserAgentString does not contain " + fxVersionString, userAgentString.contains(fxVersionString));
+            verifyUserAgentString(userAgentString);
+        });
+    }
 
-            File webkitLicense = new File("src/main/legal/webkit.md");
-            assertTrue("File does not exist: " + webkitLicense, webkitLicense.exists());
-
-            try (final BufferedReader licenseText = new BufferedReader(new FileReader(webkitLicense))) {
-                final String firstLine = licenseText.readLine().trim();
-                final String webkitVersion = firstLine.substring(firstLine.lastIndexOf(" ") + 2);
-                assertTrue("webkitVersion should not be empty", webkitVersion.length() > 0);
-                assertTrue("UserAgentString does not contain: " + webkitVersion, userAgentString.contains(webkitVersion));
-            } catch (IOException ex){
-                throw new AssertionError(ex);
-            }
+    /**
+     * @test
+     * @bug 8275138
+     * Check UserAgentString from JavaScript for javafx runtime version and webkit version
+     */
+    @Test public void testUserAgentStringJS() {
+        final WebEngine webEngine = createWebEngine();
+        submit(() -> {
+            final JSObject window = (JSObject) webEngine.executeScript("window");
+            assertNotNull(window);
+            webEngine.executeScript("var userAgent = navigator.userAgent");
+            String userAgentString = (String)window.getMember("userAgent");
+            assertNotNull(userAgentString);
+            verifyUserAgentString(userAgentString);
         });
     }
 


### PR DESCRIPTION
Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275138](https://bugs.openjdk.java.net/browse/JDK-8275138): WebView: UserAgent string is empty for first request


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/57.diff">https://git.openjdk.java.net/jfx11u/pull/57.diff</a>

</details>
