### PR TITLE
8160597: IllegalArgumentException when we initiate drag on Image

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -568,7 +568,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_sun_glass_ui_mac_MacPasteboard__1getItemAs
                 }
 #endif
 
-                if (image != nil)
+                if (image != nil && image.size.width > 0 && image.size.height > 0)
                 {
                     CGImageRef cgImage = [image CGImageForProposedRect:NULL context:nil hints:nil];
 

--- a/tests/system/src/test/addExports
+++ b/tests/system/src/test/addExports
@@ -4,6 +4,7 @@
 --add-exports java.desktop/sun.awt.datatransfer=ALL-UNNAMED
 #
 --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.glass.ui.mac=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.animation=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED


### PR DESCRIPTION
clean backport from 18 to 11u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597): IllegalArgumentException when we initiate drag on Image


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/62.diff">https://git.openjdk.java.net/jfx11u/pull/62.diff</a>

</details>
