### PR TITLE
8279396: Define version in .jcheck/conf

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,6 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
+version=openjfx11.0.14
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -1,0 +1,40 @@
+# Updating the JavaFX Release Version
+
+Here are the instructions for updating the JavaFX release version number
+for a feature release or security (dot-dot) release.
+See [JDK-8226365](https://bugs.openjdk.java.net/browse/JDK-8226365)
+for a recent example.
+
+## Incrementing the feature version
+
+Here are the steps to increment the JavaFX release version number to a new
+feature version (for example, from 13 to 14).
+
+* In `.jcheck/conf`, modify the `version` property in the `[general]`
+section to increment the version number from `openjfx$N` to `openjfx$N+1`.
+
+* In `build.properties`, modify the following properties to increment the
+feature version number from `N` to `N+1`:
+
+```
+    jfx.release.major.version
+    javadoc.title
+    javadoc.header
+```
+
+* In
+`modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java`,
+modify the testMajorVersion method to increment the feature version number
+from `N` to `N+1`.
+
+## Incrementing the security version
+
+Here are the steps to increment the JavaFX release version number to a new
+security version (for example, from 13 to 13.0.1).
+
+* In `.jcheck/conf`, modify the `version` property in the `[general]`
+section to increment the version number from `openjfx$N` to `openjfx$N.0.1`
+or from `openjfx$N.0.M` to `openjfx$N.0.$M+1`.
+
+* In `build.properties`, modify the `jfx.release.security.version` property
+to increment the security version number from `M` to `M+1`.


### PR DESCRIPTION
Backport fix to add `version` property to `.jcheck/conf`. This is needed in support of a Skara bot config change to take the fix version from the repo.

NOTE: the `UPDATING-version.md` file was not present in the repo. I copied it from mainline, since the instructions are identical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396): Define version in .jcheck/conf


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/68.diff">https://git.openjdk.java.net/jfx11u/pull/68.diff</a>

</details>
