### PR TITLE
8242505: Some WebKit tests might fail because Microsoft libraries are not loaded

### DIFF
--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/SharedBufferTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/SharedBufferTest.java
@@ -25,6 +25,8 @@
 
 package test.com.sun.webkit;
 
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.SharedBuffer;
 import com.sun.webkit.SharedBufferShim;
 import com.sun.webkit.WebPage;
@@ -50,6 +52,10 @@ public class SharedBufferTest {
 
     @BeforeClass
     public static void beforeClass() throws ClassNotFoundException {
+        if (PlatformUtil.isWindows()) {
+            // Must load Microsoft libs before loading jfxwebkit.dll
+            Toolkit.loadMSWindowsLibraries();
+        }
         Class.forName(WebPage.class.getName());
     }
 

--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/SimpleSharedBufferInputStreamTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/SimpleSharedBufferInputStreamTest.java
@@ -25,6 +25,8 @@
 
 package test.com.sun.webkit;
 
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.SharedBuffer;
 import com.sun.webkit.SharedBufferShim;
 import com.sun.webkit.SimpleSharedBufferInputStream;
@@ -52,6 +54,10 @@ public class SimpleSharedBufferInputStreamTest {
 
     @BeforeClass
     public static void beforeClass() throws ClassNotFoundException {
+        if (PlatformUtil.isWindows()) {
+            // Must load Microsoft libs before loading jfxwebkit.dll
+            Toolkit.loadMSWindowsLibraries();
+        }
         Class.forName(WebPage.class.getName());
     }
 


### PR DESCRIPTION
Clean backport of this test-only fix to `jfx11u`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8242505](https://bugs.openjdk.java.net/browse/JDK-8242505): Some WebKit tests might fail because Microsoft libraries are not loaded


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/73.diff">https://git.openjdk.java.net/jfx11u/pull/73.diff</a>

</details>
