### PR TITLE
8265399: Update to Visual Studio 2019 version 16.9.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=6.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.3.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2017-15.9.24+1.0
+jfx.build.windows.msvc.version=VS2019-16.9.3+1.0
 jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools


### PR DESCRIPTION
Update `jfx11u` to the same version of VS2019 (16.9.3) that is used in mainline jfx. I tested this along with the other VS 2019 and WebKit 613.1 fixes together in the `test-kcr-11.0.15` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265399](https://bugs.openjdk.java.net/browse/JDK-8265399): Update to Visual Studio 2019 version 16.9.3


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/76.diff">https://git.openjdk.java.net/jfx11u/pull/76.diff</a>

</details>
