### PR TITLE
8284184: Crash in GraphicsContextJava::drawLinesForText on https://us.yahoo.com/

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
@@ -343,6 +343,9 @@ void GraphicsContextJava::drawLinesForText(const FloatPoint& origin, float thick
     if (paintingDisabled())
         return;
 
+    if (widths.size() == 0)
+        return;
+
     // This is a workaround for http://bugs.webkit.org/show_bug.cgi?id=15659
     StrokeStyle savedStrokeStyle = strokeStyle();
     setStrokeStyle(stroke);


### PR DESCRIPTION
Reviewed-by: kcr, arapte

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284184](https://bugs.openjdk.java.net/browse/JDK-8284184): Crash in GraphicsContextJava::drawLinesForText on https://us.yahoo.com/


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/92.diff">https://git.openjdk.java.net/jfx11u/pull/92.diff</a>

</details>
