### PR TITLE
8280840: Update libFFI to 3.4.2

### DIFF
--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -1,9 +1,9 @@
-## LibFFI v3.3
+## LibFFI v3.4.2
 
 ### LibFFI License
 ```
 
-libffi - Copyright (c) 1996-2019  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2021  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
@@ -1,4 +1,4 @@
-libffi - Copyright (c) 1996-2019  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2021  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_cfi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_cfi.h
@@ -2,6 +2,27 @@
    ffi_cfi.h - Copyright (c) 2014  Red Hat, Inc.
 
    Conditionally assemble cfi directives. Only necessary for building libffi.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the ``Software''), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
    ----------------------------------------------------------------------- */
 
 #ifndef FFI_CFI_H
@@ -9,8 +30,8 @@
 
 #ifdef HAVE_AS_CFI_PSEUDO_OP
 
-# define cfi_startproc          .cfi_startproc
-# define cfi_endproc            .cfi_endproc
+# define cfi_startproc              .cfi_startproc
+# define cfi_endproc                .cfi_endproc
 # define cfi_def_cfa(reg, off)      .cfi_def_cfa reg, off
 # define cfi_def_cfa_register(reg)  .cfi_def_cfa_register reg
 # define cfi_def_cfa_offset(off)    .cfi_def_cfa_offset off
@@ -19,15 +40,15 @@
 # define cfi_rel_offset(reg, off)   .cfi_rel_offset reg, off
 # define cfi_register(r1, r2)       .cfi_register r1, r2
 # define cfi_return_column(reg)     .cfi_return_column reg
-# define cfi_restore(reg)       .cfi_restore reg
+# define cfi_restore(reg)           .cfi_restore reg
 # define cfi_same_value(reg)        .cfi_same_value reg
-# define cfi_undefined(reg)     .cfi_undefined reg
-# define cfi_remember_state     .cfi_remember_state
-# define cfi_restore_state      .cfi_restore_state
-# define cfi_window_save        .cfi_window_save
+# define cfi_undefined(reg)         .cfi_undefined reg
+# define cfi_remember_state         .cfi_remember_state
+# define cfi_restore_state          .cfi_restore_state
+# define cfi_window_save            .cfi_window_save
 # define cfi_personality(enc, exp)  .cfi_personality enc, exp
-# define cfi_lsda(enc, exp)     .cfi_lsda enc, exp
-# define cfi_escape(...)        .cfi_escape __VA_ARGS__
+# define cfi_lsda(enc, exp)         .cfi_lsda enc, exp
+# define cfi_escape(...)            .cfi_escape __VA_ARGS__
 
 #else
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_common.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_common.h
@@ -5,6 +5,27 @@
 
    Common internal definitions and macros. Only necessary for building
    libffi.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the ``Software''), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
    ----------------------------------------------------------------------- */
 
 #ifndef FFI_COMMON_H
@@ -102,6 +123,10 @@ ffi_status ffi_prep_cif_core(ffi_cif *cif,
 /* Translate a data pointer to a code pointer.  Needed for closures on
    some targets.  */
 void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
+
+/* The arch code calls this to determine if a given closure has a
+   static trampoline. */
+int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
 
 /* Extended cif, used in callback from assembly routine */
 typedef struct

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
@@ -18,6 +18,9 @@
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
 
+/* Define this if you want statically defined trampolines */
+/* #undef FFI_EXEC_STATIC_TRAMP */
+
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 #define FFI_EXEC_TRAMPOLINE_TABLE 1
 
@@ -77,11 +80,17 @@
 /* Define to 1 if you have the `memcpy' function. */
 #define HAVE_MEMCPY 1
 
+/* Define to 1 if you have the `memfd_create' function. */
+/* #undef HAVE_MEMFD_CREATE */
+
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mkostemp' function. */
 #define HAVE_MKOSTEMP 1
+
+/* Define to 1 if you have the `mkstemp' function. */
+/* #undef HAVE_MKSTEMP */
 
 /* Define to 1 if you have the `mmap' function. */
 #define HAVE_MMAP 1
@@ -94,6 +103,9 @@
 
 /* Define if read-only mmap of a plain file works. */
 #define HAVE_MMAP_FILE 1
+
+/* Define if your compiler supports pointer authentication. */
+/* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
 /* #undef HAVE_RO_EH_FRAME */
@@ -109,6 +121,9 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/memfd.h> header file. */
+/* #undef HAVE_SYS_MEMFD_H */
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -138,7 +153,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.3"
+#define PACKAGE_STRING "libffi 3.4.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -147,7 +162,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.3"
+#define PACKAGE_VERSION "3.4.2"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -177,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.3"
+#define VERSION "3.4.2"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
@@ -18,6 +18,9 @@
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
 
+/* Define this if you want statically defined trampolines */
+/* #undef FFI_EXEC_STATIC_TRAMP */
+
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
@@ -77,11 +80,17 @@
 /* Define to 1 if you have the `memcpy' function. */
 #define HAVE_MEMCPY 1
 
+/* Define to 1 if you have the `memfd_create' function. */
+/* #undef HAVE_MEMFD_CREATE */
+
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mkostemp' function. */
 #define HAVE_MKOSTEMP 1
+
+/* Define to 1 if you have the `mkstemp' function. */
+/* #undef HAVE_MKSTEMP */
 
 /* Define to 1 if you have the `mmap' function. */
 #define HAVE_MMAP 1
@@ -94,6 +103,9 @@
 
 /* Define if read-only mmap of a plain file works. */
 #define HAVE_MMAP_FILE 1
+
+/* Define if your compiler supports pointer authentication. */
+/* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
 /* #undef HAVE_RO_EH_FRAME */
@@ -109,6 +121,9 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/memfd.h> header file. */
+/* #undef HAVE_SYS_MEMFD_H */
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 #define HAVE_SYS_MMAN_H 1
@@ -138,7 +153,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.3"
+#define PACKAGE_STRING "libffi 3.4.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -147,7 +162,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.3"
+#define PACKAGE_VERSION "3.4.2"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -177,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.3"
+#define VERSION "3.4.2"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/tramp.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/tramp.h
@@ -1,0 +1,45 @@
+/* -----------------------------------------------------------------------
+   ffi_tramp.h - Copyright (C) 2021  Microsoft, Inc.
+
+   Static trampoline definitions.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the ``Software''), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+   ----------------------------------------------------------------------- */
+
+#ifndef FFI_TRAMP_H
+#define FFI_TRAMP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ffi_tramp_is_supported(void);
+void *ffi_tramp_alloc (int flags);
+void ffi_tramp_set_parms (void *tramp, void *data, void *code);
+void *ffi_tramp_get_addr (void *tramp);
+void ffi_tramp_free (void *tramp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FFI_TRAMP_H */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
@@ -18,6 +18,9 @@
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
 
+/* Define this if you want statically defined trampolines */
+/* #undef FFI_EXEC_STATIC_TRAMP */
+
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
@@ -77,11 +80,17 @@
 /* Define to 1 if you have the `memcpy' function. */
 #define HAVE_MEMCPY 1
 
+/* Define to 1 if you have the `memfd_create' function. */
+/* #undef HAVE_MEMFD_CREATE */
+
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mkostemp' function. */
 /* #undef HAVE_MKOSTEMP */
+
+/* Define to 1 if you have the `mkstemp' function. */
+/* #undef HAVE_MKSTEMP */
 
 /* Define to 1 if you have the `mmap' function. */
 /* #undef HAVE_MMAP */
@@ -94,6 +103,9 @@
 
 /* Define if read-only mmap of a plain file works. */
 /* #undef HAVE_MMAP_FILE */
+
+/* Define if your compiler supports pointer authentication. */
+/* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
 /* #undef HAVE_RO_EH_FRAME */
@@ -109,6 +121,9 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/memfd.h> header file. */
+/* #undef HAVE_SYS_MEMFD_H */
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 /* #undef HAVE_SYS_MMAN_H */
@@ -138,7 +153,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.3"
+#define PACKAGE_STRING "libffi 3.4.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -147,7 +162,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.3"
+#define PACKAGE_VERSION "3.4.2"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -177,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.3"
+#define VERSION "3.4.2"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
@@ -18,6 +18,9 @@
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
 
+/* Define this if you want statically defined trampolines */
+/* #undef FFI_EXEC_STATIC_TRAMP */
+
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
@@ -77,11 +80,17 @@
 /* Define to 1 if you have the `memcpy' function. */
 #define HAVE_MEMCPY 1
 
+/* Define to 1 if you have the `memfd_create' function. */
+/* #undef HAVE_MEMFD_CREATE */
+
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mkostemp' function. */
 /* #undef HAVE_MKOSTEMP */
+
+/* Define to 1 if you have the `mkstemp' function. */
+/* #undef HAVE_MKSTEMP */
 
 /* Define to 1 if you have the `mmap' function. */
 /* #undef HAVE_MMAP */
@@ -94,6 +103,9 @@
 
 /* Define if read-only mmap of a plain file works. */
 /* #undef HAVE_MMAP_FILE */
+
+/* Define if your compiler supports pointer authentication. */
+/* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
 /* #undef HAVE_RO_EH_FRAME */
@@ -109,6 +121,9 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/memfd.h> header file. */
+/* #undef HAVE_SYS_MEMFD_H */
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
 /* #undef HAVE_SYS_MMAN_H */
@@ -138,7 +153,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.3"
+#define PACKAGE_STRING "libffi 3.4.2"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -147,7 +162,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.3"
+#define PACKAGE_VERSION "3.4.2"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -177,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.3"
+#define VERSION "3.4.2"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
@@ -27,9 +27,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include <ffi.h>
 #include <ffi_common.h>
 #include "internal.h"
-#ifdef _M_ARM64
+#ifdef _WIN32
 #include <windows.h> /* FlushInstructionCache */
 #endif
+#include <tramp.h>
 
 /* Force FFI_TYPE_LONGDOUBLE to be different than FFI_TYPE_DOUBLE;
    all further uses in this file will refer to the 128-bit type.  */
@@ -62,6 +63,9 @@ struct call_context
 #if FFI_EXEC_TRAMPOLINE_TABLE
 
 #ifdef __MACH__
+#ifdef HAVE_PTRAUTH
+#include <ptrauth.h>
+#endif
 #include <mach/vm_param.h>
 #endif
 
@@ -78,7 +82,7 @@ ffi_clear_cache (void *start, void *end)
   sys_icache_invalidate (start, (char *)end - (char *)start);
 #elif defined (__GNUC__)
   __builtin___clear_cache (start, end);
-#elif defined (_M_ARM64)
+#elif defined (_WIN32)
   FlushInstructionCache(GetCurrentProcess(), start, (char*)end - (char*)start);
 #else
 #error "Missing builtin to flush instruction cache"
@@ -331,48 +335,48 @@ extend_hfa_type (void *dest, void *src, int h)
   void *x0;
 
   asm volatile (
-    "adr    %0, 0f\n"
-"   add %0, %0, %1\n"
-"   br  %0\n"
-"0: ldp s16, s17, [%3]\n"   /* S4 */
-"   ldp s18, s19, [%3, #8]\n"
-"   b   4f\n"
-"   ldp s16, s17, [%3]\n"   /* S3 */
-"   ldr s18, [%3, #8]\n"
-"   b   3f\n"
-"   ldp s16, s17, [%3]\n"   /* S2 */
-"   b   2f\n"
-"   nop\n"
-"   ldr s16, [%3]\n"        /* S1 */
-"   b   1f\n"
-"   nop\n"
-"   ldp d16, d17, [%3]\n"   /* D4 */
-"   ldp d18, d19, [%3, #16]\n"
-"   b   4f\n"
-"   ldp d16, d17, [%3]\n"   /* D3 */
-"   ldr d18, [%3, #16]\n"
-"   b   3f\n"
-"   ldp d16, d17, [%3]\n"   /* D2 */
-"   b   2f\n"
-"   nop\n"
-"   ldr d16, [%3]\n"        /* D1 */
-"   b   1f\n"
-"   nop\n"
-"   ldp q16, q17, [%3]\n"   /* Q4 */
-"   ldp q18, q19, [%3, #32]\n"
-"   b   4f\n"
-"   ldp q16, q17, [%3]\n"   /* Q3 */
-"   ldr q18, [%3, #32]\n"
-"   b   3f\n"
-"   ldp q16, q17, [%3]\n"   /* Q2 */
-"   b   2f\n"
-"   nop\n"
-"   ldr q16, [%3]\n"        /* Q1 */
-"   b   1f\n"
-"4: str q19, [%2, #48]\n"
-"3: str q18, [%2, #32]\n"
-"2: str q17, [%2, #16]\n"
-"1: str q16, [%2]"
+"adr    %0, 0f\n"
+"       add     %0, %0, %1\n"
+"       br      %0\n"
+"0:     ldp     s16, s17, [%3]\n"       /* S4 */
+"       ldp     s18, s19, [%3, #8]\n"
+"       b       4f\n"
+"       ldp     s16, s17, [%3]\n"       /* S3 */
+"       ldr     s18, [%3, #8]\n"
+"       b       3f\n"
+"       ldp     s16, s17, [%3]\n"       /* S2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     s16, [%3]\n"            /* S1 */
+"       b       1f\n"
+"       nop\n"
+"       ldp     d16, d17, [%3]\n"       /* D4 */
+"       ldp     d18, d19, [%3, #16]\n"
+"       b       4f\n"
+"       ldp     d16, d17, [%3]\n"       /* D3 */
+"       ldr     d18, [%3, #16]\n"
+"       b       3f\n"
+"       ldp     d16, d17, [%3]\n"       /* D2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     d16, [%3]\n"            /* D1 */
+"       b       1f\n"
+"       nop\n"
+"       ldp     q16, q17, [%3]\n"       /* Q4 */
+"       ldp     q18, q19, [%3, #32]\n"
+"       b       4f\n"
+"       ldp     q16, q17, [%3]\n"       /* Q3 */
+"       ldr     q18, [%3, #32]\n"
+"       b       3f\n"
+"       ldp     q16, q17, [%3]\n"       /* Q2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     q16, [%3]\n"            /* Q1 */
+"       b       1f\n"
+"4:     str     q19, [%2, #48]\n"
+"3:     str     q18, [%2, #32]\n"
+"2:     str     q17, [%2, #16]\n"
+"1:     str     q16, [%2]"
     : "=&r"(x0)
     : "r"(f * 12), "r"(dest), "r"(src)
     : "memory", "v16", "v17", "v18", "v19");
@@ -561,6 +565,14 @@ ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned int nfixedargs,
   cif->aarch64_nfixedargs = nfixedargs;
   return status;
 }
+#else
+ffi_status FFI_HIDDEN
+ffi_prep_cif_machdep_var(ffi_cif *cif, unsigned int nfixedargs, unsigned int ntotalargs)
+{
+  ffi_status status = ffi_prep_cif_machdep (cif);
+  cif->flags |= AARCH64_FLAG_VARARG;
+  return status;
+}
 #endif /* __APPLE__ */
 
 extern void ffi_call_SYSV (struct call_context *context, void *frame,
@@ -577,13 +589,19 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
   void *stack, *frame, *rvalue;
   struct arg_state state;
   size_t stack_bytes, rtype_size, rsize;
-  int i, nargs, flags;
+  int i, nargs, flags, isvariadic = 0;
   ffi_type *rtype;
 
   flags = cif->flags;
   rtype = cif->rtype;
   rtype_size = rtype->size;
   stack_bytes = cif->bytes;
+
+  if (flags & AARCH64_FLAG_VARARG)
+  {
+    isvariadic = 1;
+    flags &= ~AARCH64_FLAG_VARARG;
+  }
 
   /* If the target function returns a structure via hidden pointer,
      then we cannot allow a null rvalue.  Otherwise, mash a null
@@ -599,11 +617,12 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
   else if (flags & AARCH64_RET_NEED_COPY)
     rsize = 16;
 
-  /* Allocate consectutive stack for everything we'll need.  */
-  context = alloca (sizeof(struct call_context) + stack_bytes + 32 + rsize);
+  /* Allocate consectutive stack for everything we'll need.
+     The frame uses 40 bytes for: lr, fp, rvalue, flags, sp */
+  context = alloca (sizeof(struct call_context) + stack_bytes + 40 + rsize);
   stack = context + 1;
   frame = (void*)((uintptr_t)stack + (uintptr_t)stack_bytes);
-  rvalue = (rsize ? (void*)((uintptr_t)frame + 32) : orig_rvalue);
+  rvalue = (rsize ? (void*)((uintptr_t)frame + 40) : orig_rvalue);
 
   arg_init (&state);
   for (i = 0, nargs = cif->nargs; i < nargs; i++)
@@ -665,8 +684,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
         if (h)
           {
               int elems = 4 - (h & 3);
-#ifdef _M_ARM64 /* for handling armasm calling convention */
-                if (cif->is_variadic)
+              if (cif->abi == FFI_WIN64 && isvariadic)
               {
                 if (state.ngrn + elems <= N_X_ARG_REG)
                 {
@@ -680,7 +698,6 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
               }
               else
               {
-#endif /* for handling armasm calling convention */
                 if (state.nsrn + elems <= N_V_ARG_REG)
                 {
                   dest = &context->v[state.nsrn];
@@ -690,9 +707,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
                 }
                 state.nsrn = N_V_ARG_REG;
                 dest = allocate_to_stack (&state, stack, ty->alignment, s);
-#ifdef _M_ARM64 /* for handling armasm calling convention */
               }
-#endif /* for handling armasm calling convention */
           }
         else if (s > 16)
           {
@@ -756,6 +771,8 @@ ffi_call (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue)
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
 
+#if FFI_CLOSURES
+
 #ifdef FFI_GO_CLOSURES
 void
 ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
@@ -769,6 +786,10 @@ ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
 
 extern void ffi_closure_SYSV (void) FFI_HIDDEN;
 extern void ffi_closure_SYSV_V (void) FFI_HIDDEN;
+#if defined(FFI_EXEC_STATIC_TRAMP)
+extern void ffi_closure_SYSV_alt (void) FFI_HIDDEN;
+extern void ffi_closure_SYSV_V_alt (void) FFI_HIDDEN;
+#endif
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure *closure,
@@ -777,7 +798,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
                       void *user_data,
                       void *codeloc)
 {
-  if (cif->abi != FFI_SYSV)
+  if (cif->abi != FFI_SYSV && cif->abi != FFI_WIN64)
     return FFI_BAD_ABI;
 
   void (*start)(void);
@@ -789,18 +810,35 @@ ffi_prep_closure_loc (ffi_closure *closure,
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 #ifdef __MACH__
+#ifdef HAVE_PTRAUTH
+  codeloc = ptrauth_auth_data(codeloc, ptrauth_key_function_pointer, 0);
+#endif
   void **config = (void **)((uint8_t *)codeloc - PAGE_MAX_SIZE);
   config[0] = closure;
   config[1] = start;
 #endif
 #else
   static const unsigned char trampoline[16] = {
-    0x90, 0x00, 0x00, 0x58, /* ldr  x16, tramp+16   */
-    0xf1, 0xff, 0xff, 0x10, /* adr  x17, tramp+0    */
-    0x00, 0x02, 0x1f, 0xd6  /* br   x16     */
+    0x90, 0x00, 0x00, 0x58,     /* ldr  x16, tramp+16   */
+    0xf1, 0xff, 0xff, 0x10,     /* adr  x17, tramp+0    */
+    0x00, 0x02, 0x1f, 0xd6      /* br   x16             */
   };
   char *tramp = closure->tramp;
 
+#if defined(FFI_EXEC_STATIC_TRAMP)
+  if (ffi_tramp_is_present(closure))
+    {
+      /* Initialize the static trampoline's parameters. */
+      if (start == ffi_closure_SYSV_V)
+          start = ffi_closure_SYSV_V_alt;
+      else
+          start = ffi_closure_SYSV_alt;
+      ffi_tramp_set_parms (closure->ftramp, start, closure);
+      goto out;
+    }
+#endif
+
+  /* Initialize the dynamic trampoline. */
   memcpy (tramp, trampoline, sizeof(trampoline));
 
   *(UINT64 *)(tramp + 16) = (uintptr_t)start;
@@ -808,7 +846,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
   ffi_clear_cache(tramp, tramp + FFI_TRAMPOLINE_SIZE);
 
   /* Also flush the cache for code mapping.  */
-#ifdef _M_ARM64
+#ifdef _WIN32
   // Not using dlmalloc.c for Windows ARM64 builds
   // so calling ffi_data_to_code_pointer() isn't necessary
   unsigned char *tramp_code = tramp;
@@ -816,6 +854,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
   unsigned char *tramp_code = ffi_data_to_code_pointer (tramp);
   #endif
   ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
+out:
 #endif
 
   closure->cif = cif;
@@ -835,7 +874,7 @@ ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif* cif,
 {
   void (*start)(void);
 
-  if (cif->abi != FFI_SYSV)
+  if (cif->abi != FFI_SYSV && cif->abi != FFI_WIN64)
     return FFI_BAD_ABI;
 
   if (cif->flags & AARCH64_FLAG_ARG_V)
@@ -875,10 +914,17 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
             void *stack, void *rvalue, void *struct_rvalue)
 {
   void **avalue = (void**) alloca (cif->nargs * sizeof (void*));
-  int i, h, nargs, flags;
+  int i, h, nargs, flags, isvariadic = 0;
   struct arg_state state;
 
   arg_init (&state);
+
+  flags = cif->flags;
+  if (flags & AARCH64_FLAG_VARARG)
+  {
+    isvariadic = 1;
+    flags &= ~AARCH64_FLAG_VARARG;
+  }
 
   for (i = 0, nargs = cif->nargs; i < nargs; i++)
     {
@@ -914,8 +960,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
       if (h)
         {
           n = 4 - (h & 3);
-#ifdef _M_ARM64  /* for handling armasm calling convention */
-              if (cif->is_variadic)
+              if (cif->abi == FFI_WIN64 && isvariadic)
                 {
                   if (state.ngrn + n <= N_X_ARG_REG)
                     {
@@ -941,7 +986,6 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
                 }
               else
                 {
-#endif  /* for handling armasm calling convention */
                   if (state.nsrn + n <= N_V_ARG_REG)
                     {
                       void *reg = &context->v[state.nsrn];
@@ -954,9 +998,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
                       avalue[i] = allocate_to_stack(&state, stack,
                                                    ty->alignment, s);
                     }
-#ifdef _M_ARM64  /* for handling armasm calling convention */
                 }
-#endif  /* for handling armasm calling convention */
             }
           else if (s > 16)
             {
@@ -997,7 +1039,6 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 #endif
     }
 
-  flags = cif->flags;
   if (flags & AARCH64_RET_IN_MEM)
     rvalue = struct_rvalue;
 
@@ -1005,5 +1046,19 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
 
   return flags;
 }
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+void *
+ffi_tramp_arch (size_t *tramp_size, size_t *map_size)
+{
+  extern void *trampoline_code_table;
+
+  *tramp_size = AARCH64_TRAMP_SIZE;
+  *map_size = AARCH64_TRAMP_MAP_SIZE;
+  return &trampoline_code_table;
+}
+#endif
+
+#endif /* FFI_CLOSURES */
 
 #endif /* (__aarch64__) || defined(__arm64__)|| defined (_M_ARM64)*/

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffitarget.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffitarget.h
@@ -1,31 +1,23 @@
-/* -----------------------------------------------------------------*-C-*-
-   ffitarget.h - Copyright (c) 2012  Anthony Green
-                 Copyright (c) 2010  CodeSourcery
-                 Copyright (c) 1996-2003  Red Hat, Inc.
+/* Copyright (c) 2009, 2010, 2011, 2012 ARM Ltd.
 
-   Target configuration macros for ARM.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-   Permission is hereby granted, free of charge, to any person obtaining
-   a copy of this software and associated documentation files (the
-   ``Software''), to deal in the Software without restriction, including
-   without limitation the rights to use, copy, modify, merge, publish,
-   distribute, sublicense, and/or sell copies of the Software, and to
-   permit persons to whom the Software is furnished to do so, subject to
-   the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-   The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
-   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-   DEALINGS IN THE SOFTWARE.
-
-   ----------------------------------------------------------------------- */
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #ifndef LIBFFI_TARGET_H
 #define LIBFFI_TARGET_H
@@ -35,58 +27,57 @@
 #endif
 
 #ifndef LIBFFI_ASM
-typedef unsigned long          ffi_arg;
-typedef signed long            ffi_sarg;
+#ifdef __ILP32__
+#define FFI_SIZEOF_ARG 8
+#define FFI_SIZEOF_JAVA_RAW  4
+typedef unsigned long long ffi_arg;
+typedef signed long long ffi_sarg;
+#elif defined(_WIN32)
+#define FFI_SIZEOF_ARG 8
+typedef unsigned long long ffi_arg;
+typedef signed long long ffi_sarg;
+#else
+typedef unsigned long ffi_arg;
+typedef signed long ffi_sarg;
+#endif
 
-typedef enum ffi_abi {
+typedef enum ffi_abi
+  {
   FFI_FIRST_ABI = 0,
   FFI_SYSV,
-  FFI_VFP,
+    FFI_WIN64,
   FFI_LAST_ABI,
-#if defined(__ARM_PCS_VFP) || defined(_M_ARM)
-  FFI_DEFAULT_ABI = FFI_VFP,
+#if defined(_WIN32)
+    FFI_DEFAULT_ABI = FFI_WIN64
 #else
-  FFI_DEFAULT_ABI = FFI_SYSV,
+    FFI_DEFAULT_ABI = FFI_SYSV
 #endif
 } ffi_abi;
-#endif
-
-#define FFI_EXTRA_CIF_FIELDS            \
-  int vfp_used;                 \
-  unsigned short vfp_reg_free, vfp_nargs;   \
-  signed char vfp_args[16]          \
-
-#define FFI_TARGET_SPECIFIC_VARIADIC
-#ifndef _M_ARM
-#define FFI_TARGET_HAS_COMPLEX_TYPE
 #endif
 
 /* ---- Definitions for closures ----------------------------------------- */
 
 #define FFI_CLOSURES 1
-#define FFI_GO_CLOSURES 1
 #define FFI_NATIVE_RAW_API 0
 
 #if defined (FFI_EXEC_TRAMPOLINE_TABLE) && FFI_EXEC_TRAMPOLINE_TABLE
 
 #ifdef __MACH__
-#define FFI_TRAMPOLINE_SIZE 12
-#define FFI_TRAMPOLINE_CLOSURE_OFFSET 8
+#define FFI_TRAMPOLINE_SIZE 16
+#define FFI_TRAMPOLINE_CLOSURE_OFFSET 16
 #else
 #error "No trampoline table implementation"
 #endif
 
 #else
-#ifdef _MSC_VER
-#define FFI_TRAMPOLINE_SIZE 16
-#define FFI_TRAMPOLINE_CLOSURE_FUNCTION 12
-#else
-#define FFI_TRAMPOLINE_SIZE 12
-#endif
+#define FFI_TRAMPOLINE_SIZE 24
 #define FFI_TRAMPOLINE_CLOSURE_OFFSET FFI_TRAMPOLINE_SIZE
 #endif
 
+#ifdef _WIN32
+#define FFI_EXTRA_CIF_FIELDS unsigned is_variadic
 #endif
+#define FFI_TARGET_SPECIFIC_VARIADIC
 
 /* ---- Internal ---- */
 
@@ -101,4 +92,6 @@ typedef enum ffi_abi {
 #ifndef _WIN32
 /* No complex type on Windows */
 #define FFI_TARGET_HAS_COMPLEX_TYPE
+#endif
+
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/internal.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/internal.h
@@ -18,50 +18,83 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#define AARCH64_RET_VOID    0
-#define AARCH64_RET_INT64   1
-#define AARCH64_RET_INT128  2
+#define AARCH64_RET_VOID        0
+#define AARCH64_RET_INT64       1
+#define AARCH64_RET_INT128      2
 
-#define AARCH64_RET_UNUSED3 3
-#define AARCH64_RET_UNUSED4 4
-#define AARCH64_RET_UNUSED5 5
-#define AARCH64_RET_UNUSED6 6
-#define AARCH64_RET_UNUSED7 7
+#define AARCH64_RET_UNUSED3     3
+#define AARCH64_RET_UNUSED4     4
+#define AARCH64_RET_UNUSED5     5
+#define AARCH64_RET_UNUSED6     6
+#define AARCH64_RET_UNUSED7     7
 
 /* Note that FFI_TYPE_FLOAT == 2, _DOUBLE == 3, _LONGDOUBLE == 4,
    so _S4 through _Q1 are layed out as (TYPE * 4) + (4 - COUNT).  */
-#define AARCH64_RET_S4      8
-#define AARCH64_RET_S3      9
-#define AARCH64_RET_S2      10
-#define AARCH64_RET_S1      11
+#define AARCH64_RET_S4          8
+#define AARCH64_RET_S3          9
+#define AARCH64_RET_S2          10
+#define AARCH64_RET_S1          11
 
-#define AARCH64_RET_D4      12
-#define AARCH64_RET_D3      13
-#define AARCH64_RET_D2      14
-#define AARCH64_RET_D1      15
+#define AARCH64_RET_D4          12
+#define AARCH64_RET_D3          13
+#define AARCH64_RET_D2          14
+#define AARCH64_RET_D1          15
 
-#define AARCH64_RET_Q4      16
-#define AARCH64_RET_Q3      17
-#define AARCH64_RET_Q2      18
-#define AARCH64_RET_Q1      19
+#define AARCH64_RET_Q4          16
+#define AARCH64_RET_Q3          17
+#define AARCH64_RET_Q2          18
+#define AARCH64_RET_Q1          19
 
 /* Note that each of the sub-64-bit integers gets two entries.  */
-#define AARCH64_RET_UINT8   20
-#define AARCH64_RET_UINT16  22
-#define AARCH64_RET_UINT32  24
+#define AARCH64_RET_UINT8       20
+#define AARCH64_RET_UINT16      22
+#define AARCH64_RET_UINT32      24
 
-#define AARCH64_RET_SINT8   26
-#define AARCH64_RET_SINT16  28
-#define AARCH64_RET_SINT32  30
+#define AARCH64_RET_SINT8       26
+#define AARCH64_RET_SINT16      28
+#define AARCH64_RET_SINT32      30
 
-#define AARCH64_RET_MASK    31
+#define AARCH64_RET_MASK        31
 
-#define AARCH64_RET_IN_MEM  (1 << 5)
+#define AARCH64_RET_IN_MEM      (1 << 5)
 #define AARCH64_RET_NEED_COPY   (1 << 6)
 
 #define AARCH64_FLAG_ARG_V_BIT  7
-#define AARCH64_FLAG_ARG_V  (1 << AARCH64_FLAG_ARG_V_BIT)
+#define AARCH64_FLAG_ARG_V      (1 << AARCH64_FLAG_ARG_V_BIT)
+#define AARCH64_FLAG_VARARG     (1 << 8)
 
-#define N_X_ARG_REG     8
-#define N_V_ARG_REG     8
-#define CALL_CONTEXT_SIZE   (N_V_ARG_REG * 16 + N_X_ARG_REG * 8)
+#define N_X_ARG_REG             8
+#define N_V_ARG_REG             8
+#define CALL_CONTEXT_SIZE       (N_V_ARG_REG * 16 + N_X_ARG_REG * 8)
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 16K is chosen to
+ * cover the base page sizes of 4K and 16K.
+ */
+#define AARCH64_TRAMP_MAP_SHIFT 14
+#define AARCH64_TRAMP_MAP_SIZE  (1 << AARCH64_TRAMP_MAP_SHIFT)
+#define AARCH64_TRAMP_SIZE      32
+
+#endif
+
+/* Helpers for writing assembly compatible with arm ptr auth */
+#ifdef LIBFFI_ASM
+
+#ifdef HAVE_PTRAUTH
+#define SIGN_LR pacibsp
+#define SIGN_LR_WITH_REG(x) pacib lr, x
+#define AUTH_LR_AND_RET retab
+#define AUTH_LR_WITH_REG(x) autib lr, x
+#define BRANCH_AND_LINK_TO_REG blraaz
+#define BRANCH_TO_REG braaz
+#else
+#define SIGN_LR
+#define SIGN_LR_WITH_REG(x)
+#define AUTH_LR_AND_RET ret
+#define AUTH_LR_WITH_REG(x)
+#define BRANCH_AND_LINK_TO_REG blr
+#define BRANCH_TO_REG br
+#endif
+
+#endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/sysv.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/sysv.S
@@ -41,9 +41,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #endif
 
 #ifdef __AARCH64EB__
-# define BE(X)	X
+# define BE(X)  X
 #else
-# define BE(X)	0
+# define BE(X)  0
 #endif
 
 #ifdef __ILP32__
@@ -53,18 +53,18 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #endif
 
 #ifdef __ILP32__
-#define PTR_SIZE	4
+#define PTR_SIZE        4
 #else
-#define PTR_SIZE	8
+#define PTR_SIZE        8
 #endif
 
-	.text
-	.align 4
+        .text
+        .align 4
 
 /* ffi_call_SYSV
    extern void ffi_call_SYSV (void *stack, void *frame,
-			      void (*fn)(void), void *rvalue,
-			      int flags, void *closure);
+                              void (*fn)(void), void *rvalue,
+                              int flags, void *closure);
 
    Therefore on entry we have:
 
@@ -76,134 +76,156 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
    x5 closure
 */
 
-	cfi_startproc
+        cfi_startproc
 CNAME(ffi_call_SYSV):
-	/* Use a stack frame allocated by our caller.  */
-	cfi_def_cfa(x1, 32);
-	stp	x29, x30, [x1]
-	mov	x29, x1
-	mov	sp, x0
-	cfi_def_cfa_register(x29)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+        /* Sign the lr with x1 since that is where it will be stored */
+        SIGN_LR_WITH_REG(x1)
 
-	mov	x9, x2			/* save fn */
-	mov	x8, x3			/* install structure return */
+        /* Use a stack frame allocated by our caller.  */
+#if defined(HAVE_PTRAUTH) && defined(__APPLE__)
+        /* darwin's libunwind assumes that the cfa is the sp and that's the data
+         * used to sign the lr.  In order to allow unwinding through this
+         * function it is necessary to point the cfa at the signing register.
+         */
+        cfi_def_cfa(x1, 0);
+#else
+        cfi_def_cfa(x1, 40);
+#endif
+        stp     x29, x30, [x1]
+        mov     x9, sp
+        str     x9, [x1, #32]
+        mov     x29, x1
+        mov     sp, x0
+        cfi_def_cfa_register(x29)
+        cfi_rel_offset (x29, 0)
+        cfi_rel_offset (x30, 8)
+
+        mov     x9, x2                  /* save fn */
+        mov     x8, x3                  /* install structure return */
 #ifdef FFI_GO_CLOSURES
-	mov	x18, x5			/* install static chain */
+        mov     x18, x5                 /* install static chain */
 #endif
-	stp	x3, x4, [x29, #16]	/* save rvalue and flags */
+        stp     x3, x4, [x29, #16]      /* save rvalue and flags */
 
-	/* Load the vector argument passing registers, if necessary.  */
-	tbz	w4, #AARCH64_FLAG_ARG_V_BIT, 1f
-	ldp     q0, q1, [sp, #0]
-	ldp     q2, q3, [sp, #32]
-	ldp     q4, q5, [sp, #64]
-	ldp     q6, q7, [sp, #96]
+        /* Load the vector argument passing registers, if necessary.  */
+        tbz     w4, #AARCH64_FLAG_ARG_V_BIT, 1f
+        ldp     q0, q1, [sp, #0]
+        ldp     q2, q3, [sp, #32]
+        ldp     q4, q5, [sp, #64]
+        ldp     q6, q7, [sp, #96]
 1:
-	/* Load the core argument passing registers, including
-	   the structure return pointer.  */
-	ldp     x0, x1, [sp, #16*N_V_ARG_REG + 0]
-	ldp     x2, x3, [sp, #16*N_V_ARG_REG + 16]
-	ldp     x4, x5, [sp, #16*N_V_ARG_REG + 32]
-	ldp     x6, x7, [sp, #16*N_V_ARG_REG + 48]
+        /* Load the core argument passing registers, including
+           the structure return pointer.  */
+        ldp     x0, x1, [sp, #16*N_V_ARG_REG + 0]
+        ldp     x2, x3, [sp, #16*N_V_ARG_REG + 16]
+        ldp     x4, x5, [sp, #16*N_V_ARG_REG + 32]
+        ldp     x6, x7, [sp, #16*N_V_ARG_REG + 48]
 
-	/* Deallocate the context, leaving the stacked arguments.  */
-	add	sp, sp, #CALL_CONTEXT_SIZE
+        /* Deallocate the context, leaving the stacked arguments.  */
+        add     sp, sp, #CALL_CONTEXT_SIZE
 
-	blr     x9			/* call fn */
+        BRANCH_AND_LINK_TO_REG     x9   /* call fn */
 
-	ldp	x3, x4, [x29, #16]	/* reload rvalue and flags */
+        ldp     x3, x4, [x29, #16]      /* reload rvalue and flags */
 
-	/* Partially deconstruct the stack frame.  */
-	mov     sp, x29
-	cfi_def_cfa_register (sp)
-	ldp     x29, x30, [x29]
+        /* Partially deconstruct the stack frame.  */
+        ldr     x9, [x29, #32]
+        mov     sp, x9
+        cfi_def_cfa_register (sp)
+        mov     x2, x29                 /* Preserve for auth */
+        ldp     x29, x30, [x29]
 
-	/* Save the return value as directed.  */
-	adr	x5, 0f
-	and	w4, w4, #AARCH64_RET_MASK
-	add	x5, x5, x4, lsl #3
-	br	x5
+        /* Save the return value as directed.  */
+        adr     x5, 0f
+        and     w4, w4, #AARCH64_RET_MASK
+        add     x5, x5, x4, lsl #3
+        br      x5
 
-	/* Note that each table entry is 2 insns, and thus 8 bytes.
-	   For integer data, note that we're storing into ffi_arg
-	   and therefore we want to extend to 64 bits; these types
-	   have two consecutive entries allocated for them.  */
-	.align	4
-0:	ret				/* VOID */
-	nop
-1:	str	x0, [x3]		/* INT64 */
-	ret
-2:	stp	x0, x1, [x3]		/* INT128 */
-	ret
-3:	brk	#1000			/* UNUSED */
-	ret
-4:	brk	#1000			/* UNUSED */
-	ret
-5:	brk	#1000			/* UNUSED */
-	ret
-6:	brk	#1000			/* UNUSED */
-	ret
-7:	brk	#1000			/* UNUSED */
-	ret
-8:	st4	{ v0.s, v1.s, v2.s, v3.s }[0], [x3]	/* S4 */
-	ret
-9:	st3	{ v0.s, v1.s, v2.s }[0], [x3]	/* S3 */
-	ret
-10:	stp	s0, s1, [x3]		/* S2 */
-	ret
-11:	str	s0, [x3]		/* S1 */
-	ret
-12:	st4	{ v0.d, v1.d, v2.d, v3.d }[0], [x3]	/* D4 */
-	ret
-13:	st3	{ v0.d, v1.d, v2.d }[0], [x3]	/* D3 */
-	ret
-14:	stp	d0, d1, [x3]		/* D2 */
-	ret
-15:	str	d0, [x3]		/* D1 */
-	ret
-16:	str	q3, [x3, #48]		/* Q4 */
-	nop
-17:	str	q2, [x3, #32]		/* Q3 */
-	nop
-18:	stp	q0, q1, [x3]		/* Q2 */
-	ret
-19:	str	q0, [x3]		/* Q1 */
-	ret
-20:	uxtb	w0, w0			/* UINT8 */
-	str	x0, [x3]
-21:	ret				/* reserved */
-	nop
-22:	uxth	w0, w0			/* UINT16 */
-	str	x0, [x3]
-23:	ret				/* reserved */
-	nop
-24:	mov	w0, w0			/* UINT32 */
-	str	x0, [x3]
-25:	ret				/* reserved */
-	nop
-26:	sxtb	x0, w0			/* SINT8 */
-	str	x0, [x3]
-27:	ret				/* reserved */
-	nop
-28:	sxth	x0, w0			/* SINT16 */
-	str	x0, [x3]
-29:	ret				/* reserved */
-	nop
-30:	sxtw	x0, w0			/* SINT32 */
-	str	x0, [x3]
-31:	ret				/* reserved */
-	nop
+        /* Note that each table entry is 2 insns, and thus 8 bytes.
+           For integer data, note that we're storing into ffi_arg
+           and therefore we want to extend to 64 bits; these types
+           have two consecutive entries allocated for them.  */
+        .align  4
+0:      b 99f                           /* VOID */
+        nop
+1:      str     x0, [x3]                /* INT64 */
+        b 99f
+2:      stp     x0, x1, [x3]            /* INT128 */
+        b 99f
+3:      brk     #1000                   /* UNUSED */
+        b 99f
+4:      brk     #1000                   /* UNUSED */
+        b 99f
+5:      brk     #1000                   /* UNUSED */
+        b 99f
+6:      brk     #1000                   /* UNUSED */
+        b 99f
+7:      brk     #1000                   /* UNUSED */
+        b 99f
+8:      st4     { v0.s, v1.s, v2.s, v3.s }[0], [x3]  /* S4 */
+        b 99f
+9:      st3     { v0.s, v1.s, v2.s }[0], [x3]        /* S3 */
+        b 99f
+10:     stp     s0, s1, [x3]                         /* S2 */
+        b 99f
+11:     str     s0, [x3]                             /* S1 */
+        b 99f
+12:     st4     { v0.d, v1.d, v2.d, v3.d }[0], [x3]  /* D4 */
+        b 99f
+13:     st3     { v0.d, v1.d, v2.d }[0], [x3]        /* D3 */
+        b 99f
+14:     stp     d0, d1, [x3]                         /* D2 */
+        b 99f
+15:     str     d0, [x3]                             /* D1 */
+        b 99f
+16:     str     q3, [x3, #48]                        /* Q4 */
+        nop
+17:     str     q2, [x3, #32]                        /* Q3 */
+        nop
+18:     stp     q0, q1, [x3]                         /* Q2 */
+        b 99f
+19:     str     q0, [x3]                             /* Q1 */
+        b 99f
+20:     uxtb    w0, w0                               /* UINT8 */
+        str     x0, [x3]
+21:     b 99f                                        /* reserved */
+        nop
+22:     uxth    w0, w0                               /* UINT16 */
+        str     x0, [x3]
+23:     b 99f                                        /* reserved */
+        nop
+24:     mov     w0, w0                               /* UINT32 */
+        str     x0, [x3]
+25:     b 99f                                        /* reserved */
+        nop
+26:     sxtb    x0, w0                               /* SINT8 */
+        str     x0, [x3]
+27:     b 99f                                        /* reserved */
+        nop
+28:     sxth    x0, w0                               /* SINT16 */
+        str     x0, [x3]
+29:     b 99f                                        /* reserved */
+        nop
+30:     sxtw    x0, w0                               /* SINT32 */
+        str     x0, [x3]
+31:     b 99f                                        /* reserved */
+        nop
 
-	cfi_endproc
+        /* Return now that result has been populated. */
+99:
+        AUTH_LR_WITH_REG(x2)
+        ret
 
-	.globl	CNAME(ffi_call_SYSV)
-	FFI_HIDDEN(CNAME(ffi_call_SYSV))
+        cfi_endproc
+
+        .globl  CNAME(ffi_call_SYSV)
+        FFI_HIDDEN(CNAME(ffi_call_SYSV))
 #ifdef __ELF__
-	.type	CNAME(ffi_call_SYSV), #function
-	.size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
+        .type CNAME(ffi_call_SYSV), #function
+        .size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
 #endif
+
+#if FFI_CLOSURES
 
 /* ffi_closure_SYSV
 
@@ -221,140 +243,214 @@ CNAME(ffi_call_SYSV):
 
 #define ffi_closure_SYSV_FS (8*2 + CALL_CONTEXT_SIZE + 64)
 
-	.align 4
+        .align 4
 CNAME(ffi_closure_SYSV_V):
-	cfi_startproc
-	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+        cfi_startproc
+        SIGN_LR
+        stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+        cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+        cfi_rel_offset (x29, 0)
+        cfi_rel_offset (x30, 8)
 
-	/* Save the argument passing vector registers.  */
-	stp     q0, q1, [sp, #16 + 0]
-	stp     q2, q3, [sp, #16 + 32]
-	stp     q4, q5, [sp, #16 + 64]
-	stp     q6, q7, [sp, #16 + 96]
-	b	0f
-	cfi_endproc
+        /* Save the argument passing vector registers.  */
+        stp     q0, q1, [sp, #16 + 0]
+        stp     q2, q3, [sp, #16 + 32]
+        stp     q4, q5, [sp, #16 + 64]
+        stp     q6, q7, [sp, #16 + 96]
+        b       0f
+        cfi_endproc
 
-	.globl	CNAME(ffi_closure_SYSV_V)
-	FFI_HIDDEN(CNAME(ffi_closure_SYSV_V))
+        .globl  CNAME(ffi_closure_SYSV_V)
+        FFI_HIDDEN(CNAME(ffi_closure_SYSV_V))
 #ifdef __ELF__
-	.type	CNAME(ffi_closure_SYSV_V), #function
-	.size	CNAME(ffi_closure_SYSV_V), . - CNAME(ffi_closure_SYSV_V)
+        .type   CNAME(ffi_closure_SYSV_V), #function
+        .size   CNAME(ffi_closure_SYSV_V), . - CNAME(ffi_closure_SYSV_V)
 #endif
 
-	.align	4
-	cfi_startproc
+        .align  4
+        cfi_startproc
 CNAME(ffi_closure_SYSV):
-	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+        SIGN_LR
+        stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+        cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+        cfi_rel_offset (x29, 0)
+        cfi_rel_offset (x30, 8)
 0:
-	mov     x29, sp
+        mov     x29, sp
 
-	/* Save the argument passing core registers.  */
-	stp     x0, x1, [sp, #16 + 16*N_V_ARG_REG + 0]
-	stp     x2, x3, [sp, #16 + 16*N_V_ARG_REG + 16]
-	stp     x4, x5, [sp, #16 + 16*N_V_ARG_REG + 32]
-	stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
+        /* Save the argument passing core registers.  */
+        stp     x0, x1, [sp, #16 + 16*N_V_ARG_REG + 0]
+        stp     x2, x3, [sp, #16 + 16*N_V_ARG_REG + 16]
+        stp     x4, x5, [sp, #16 + 16*N_V_ARG_REG + 32]
+        stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
 
-	/* Load ffi_closure_inner arguments.  */
-	ldp	PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]	/* load cif, fn */
-	ldr	PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]	/* load user_data */
+        /* Load ffi_closure_inner arguments.  */
+        ldp     PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]   /* load cif, fn */
+        ldr     PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]    /* load user_data */
+#ifdef FFI_GO_CLOSURES
 .Ldo_closure:
-	add	x3, sp, #16				/* load context */
-	add	x4, sp, #ffi_closure_SYSV_FS		/* load stack */
-	add	x5, sp, #16+CALL_CONTEXT_SIZE		/* load rvalue */
-	mov	x6, x8					/* load struct_rval */
-	bl      CNAME(ffi_closure_SYSV_inner)
-
-	/* Load the return value as directed.  */
-	adr	x1, 0f
-	and	w0, w0, #AARCH64_RET_MASK
-	add	x1, x1, x0, lsl #3
-	add	x3, sp, #16+CALL_CONTEXT_SIZE
-	br	x1
-
-	/* Note that each table entry is 2 insns, and thus 8 bytes.  */
-	.align	4
-0:	b	99f			/* VOID */
-	nop
-1:	ldr	x0, [x3]		/* INT64 */
-	b	99f
-2:	ldp	x0, x1, [x3]		/* INT128 */
-	b	99f
-3:	brk	#1000			/* UNUSED */
-	nop
-4:	brk	#1000			/* UNUSED */
-	nop
-5:	brk	#1000			/* UNUSED */
-	nop
-6:	brk	#1000			/* UNUSED */
-	nop
-7:	brk	#1000			/* UNUSED */
-	nop
-8:	ldr	s3, [x3, #12]		/* S4 */
-	nop
-9:	ldr	s2, [x3, #8]		/* S3 */
-	nop
-10:	ldp	s0, s1, [x3]		/* S2 */
-	b	99f
-11:	ldr	s0, [x3]		/* S1 */
-	b	99f
-12:	ldr	d3, [x3, #24]		/* D4 */
-	nop
-13:	ldr	d2, [x3, #16]		/* D3 */
-	nop
-14:	ldp	d0, d1, [x3]		/* D2 */
-	b	99f
-15:	ldr	d0, [x3]		/* D1 */
-	b	99f
-16:	ldr	q3, [x3, #48]		/* Q4 */
-	nop
-17:	ldr	q2, [x3, #32]		/* Q3 */
-	nop
-18:	ldp	q0, q1, [x3]		/* Q2 */
-	b	99f
-19:	ldr	q0, [x3]		/* Q1 */
-	b	99f
-20:	ldrb	w0, [x3, #BE(7)]	/* UINT8 */
-	b	99f
-21:	brk	#1000			/* reserved */
-	nop
-22:	ldrh	w0, [x3, #BE(6)]	/* UINT16 */
-	b	99f
-23:	brk	#1000			/* reserved */
-	nop
-24:	ldr	w0, [x3, #BE(4)]	/* UINT32 */
-	b	99f
-25:	brk	#1000			/* reserved */
-	nop
-26:	ldrsb	x0, [x3, #BE(7)]	/* SINT8 */
-	b	99f
-27:	brk	#1000			/* reserved */
-	nop
-28:	ldrsh	x0, [x3, #BE(6)]	/* SINT16 */
-	b	99f
-29:	brk	#1000			/* reserved */
-	nop
-30:	ldrsw	x0, [x3, #BE(4)]	/* SINT32 */
-	nop
-31:					/* reserved */
-99:	ldp     x29, x30, [sp], #ffi_closure_SYSV_FS
-	cfi_adjust_cfa_offset (-ffi_closure_SYSV_FS)
-	cfi_restore (x29)
-	cfi_restore (x30)
-	ret
-	cfi_endproc
-
-	.globl	CNAME(ffi_closure_SYSV)
-	FFI_HIDDEN(CNAME(ffi_closure_SYSV))
-#ifdef __ELF__
-	.type	CNAME(ffi_closure_SYSV), #function
-	.size	CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
 #endif
+        add     x3, sp, #16                             /* load context */
+        add     x4, sp, #ffi_closure_SYSV_FS            /* load stack */
+        add     x5, sp, #16+CALL_CONTEXT_SIZE           /* load rvalue */
+        mov     x6, x8                                  /* load struct_rval */
+        bl      CNAME(ffi_closure_SYSV_inner)
+
+        /* Load the return value as directed.  */
+        adr     x1, 0f
+        and     w0, w0, #AARCH64_RET_MASK
+        add     x1, x1, x0, lsl #3
+        add     x3, sp, #16+CALL_CONTEXT_SIZE
+        br      x1
+
+        /* Note that each table entry is 2 insns, and thus 8 bytes.  */
+        .align  4
+0:      b       99f                     /* VOID */
+        nop
+1:      ldr     x0, [x3]                /* INT64 */
+        b       99f
+2:      ldp     x0, x1, [x3]            /* INT128 */
+        b       99f
+3:      brk     #1000                   /* UNUSED */
+        nop
+4:      brk     #1000                   /* UNUSED */
+        nop
+5:      brk     #1000                   /* UNUSED */
+        nop
+6:      brk     #1000                   /* UNUSED */
+        nop
+7:      brk     #1000                   /* UNUSED */
+        nop
+8:      ldr     s3, [x3, #12]           /* S4 */
+        nop
+9:      ldr     s2, [x3, #8]            /* S3 */
+        nop
+10:     ldp     s0, s1, [x3]            /* S2 */
+        b       99f
+11:     ldr     s0, [x3]                /* S1 */
+        b       99f
+12:     ldr     d3, [x3, #24]           /* D4 */
+        nop
+13:     ldr     d2, [x3, #16]           /* D3 */
+        nop
+14:     ldp     d0, d1, [x3]            /* D2 */
+        b       99f
+15:     ldr     d0, [x3]                /* D1 */
+        b       99f
+16:     ldr     q3, [x3, #48]           /* Q4 */
+        nop
+17:     ldr     q2, [x3, #32]           /* Q3 */
+        nop
+18:     ldp     q0, q1, [x3]            /* Q2 */
+        b       99f
+19:     ldr     q0, [x3]                /* Q1 */
+        b       99f
+20:     ldrb    w0, [x3, #BE(7)]        /* UINT8 */
+        b       99f
+21:     brk     #1000                   /* reserved */
+        nop
+22:     ldrh    w0, [x3, #BE(6)]        /* UINT16 */
+        b       99f
+23:     brk     #1000                   /* reserved */
+        nop
+24:     ldr     w0, [x3, #BE(4)]        /* UINT32 */
+        b       99f
+25:     brk     #1000                   /* reserved */
+        nop
+26:     ldrsb   x0, [x3, #BE(7)]        /* SINT8 */
+        b       99f
+27:     brk     #1000                   /* reserved */
+        nop
+28:     ldrsh   x0, [x3, #BE(6)]        /* SINT16 */
+        b       99f
+29:     brk     #1000                   /* reserved */
+        nop
+30:     ldrsw   x0, [x3, #BE(4)]        /* SINT32 */
+        nop
+31:                                     /* reserved */
+99:     ldp     x29, x30, [sp], #ffi_closure_SYSV_FS
+        cfi_adjust_cfa_offset (-ffi_closure_SYSV_FS)
+        cfi_restore (x29)
+        cfi_restore (x30)
+        AUTH_LR_AND_RET
+        cfi_endproc
+
+        .globl  CNAME(ffi_closure_SYSV)
+        FFI_HIDDEN(CNAME(ffi_closure_SYSV))
+#ifdef __ELF__
+        .type   CNAME(ffi_closure_SYSV), #function
+        .size   CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
+#endif
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+        .align 4
+CNAME(ffi_closure_SYSV_V_alt):
+        /* See the comments above trampoline_code_table. */
+        ldr     x17, [sp, #8]                   /* Load closure in x17 */
+        add     sp, sp, #16                     /* Restore the stack */
+        b       CNAME(ffi_closure_SYSV_V)
+
+        .globl  CNAME(ffi_closure_SYSV_V_alt)
+        FFI_HIDDEN(CNAME(ffi_closure_SYSV_V_alt))
+#ifdef __ELF__
+        .type   CNAME(ffi_closure_SYSV_V_alt), #function
+        .size   CNAME(ffi_closure_SYSV_V_alt), . - CNAME(ffi_closure_SYSV_V_alt)
+#endif
+
+        .align 4
+CNAME(ffi_closure_SYSV_alt):
+        /* See the comments above trampoline_code_table. */
+        ldr     x17, [sp, #8]                   /* Load closure in x17 */
+        add     sp, sp, #16                     /* Restore the stack */
+        b       CNAME(ffi_closure_SYSV)
+
+        .globl  CNAME(ffi_closure_SYSV_alt)
+        FFI_HIDDEN(CNAME(ffi_closure_SYSV_alt))
+#ifdef __ELF__
+        .type   CNAME(ffi_closure_SYSV_alt), #function
+        .size   CNAME(ffi_closure_SYSV_alt), . - CNAME(ffi_closure_SYSV_alt)
+#endif
+
+/*
+ * Below is the definition of the trampoline code table. Each element in
+ * the code table is a trampoline.
+ */
+/*
+ * The trampoline uses register x17. It saves the original value of x17 on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of x17
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+        .align  AARCH64_TRAMP_MAP_SHIFT
+CNAME(trampoline_code_table):
+        .rept   AARCH64_TRAMP_MAP_SIZE / AARCH64_TRAMP_SIZE
+        sub     sp, sp, #16             /* Make space on the stack */
+        str     x17, [sp]               /* Save x17 on stack */
+        adr     x17, #16376             /* Get data address */
+        ldr     x17, [x17]              /* Copy data into x17 */
+        str     x17, [sp, #8]           /* Save data on stack */
+        adr     x17, #16372             /* Get code address */
+        ldr     x17, [x17]              /* Load code address into x17 */
+        br      x17                     /* Jump to code */
+        .endr
+
+        .globl CNAME(trampoline_code_table)
+        FFI_HIDDEN(CNAME(trampoline_code_table))
+#ifdef __ELF__
+        .type   CNAME(trampoline_code_table), #function
+        .size   CNAME(trampoline_code_table), . - CNAME(trampoline_code_table)
+#endif
+        .align  AARCH64_TRAMP_MAP_SHIFT
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 
@@ -366,75 +462,76 @@ CNAME(ffi_closure_trampoline_table_page):
     adr x16, -PAGE_MAX_SIZE
     ldp x17, x16, [x16]
     br x16
-	nop		/* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller that 16 bytes */
+        nop           /* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller than 16 bytes */
     .endr
 
     .globl CNAME(ffi_closure_trampoline_table_page)
     FFI_HIDDEN(CNAME(ffi_closure_trampoline_table_page))
     #ifdef __ELF__
-    	.type	CNAME(ffi_closure_trampoline_table_page), #function
-    	.size	CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
+        .type   CNAME(ffi_closure_trampoline_table_page), #function
+        .size   CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
     #endif
 #endif
 
 #endif /* FFI_EXEC_TRAMPOLINE_TABLE */
 
 #ifdef FFI_GO_CLOSURES
-	.align 4
+        .align 4
 CNAME(ffi_go_closure_SYSV_V):
-	cfi_startproc
-	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+        cfi_startproc
+        stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+        cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+        cfi_rel_offset (x29, 0)
+        cfi_rel_offset (x30, 8)
 
-	/* Save the argument passing vector registers.  */
-	stp     q0, q1, [sp, #16 + 0]
-	stp     q2, q3, [sp, #16 + 32]
-	stp     q4, q5, [sp, #16 + 64]
-	stp     q6, q7, [sp, #16 + 96]
-	b	0f
-	cfi_endproc
+        /* Save the argument passing vector registers.  */
+        stp     q0, q1, [sp, #16 + 0]
+        stp     q2, q3, [sp, #16 + 32]
+        stp     q4, q5, [sp, #16 + 64]
+        stp     q6, q7, [sp, #16 + 96]
+        b       0f
+        cfi_endproc
 
-	.globl	CNAME(ffi_go_closure_SYSV_V)
-	FFI_HIDDEN(CNAME(ffi_go_closure_SYSV_V))
+        .globl  CNAME(ffi_go_closure_SYSV_V)
+        FFI_HIDDEN(CNAME(ffi_go_closure_SYSV_V))
 #ifdef __ELF__
-	.type	CNAME(ffi_go_closure_SYSV_V), #function
-	.size	CNAME(ffi_go_closure_SYSV_V), . - CNAME(ffi_go_closure_SYSV_V)
+        .type   CNAME(ffi_go_closure_SYSV_V), #function
+        .size   CNAME(ffi_go_closure_SYSV_V), . - CNAME(ffi_go_closure_SYSV_V)
 #endif
 
-	.align	4
-	cfi_startproc
+        .align  4
+        cfi_startproc
 CNAME(ffi_go_closure_SYSV):
-	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
-	cfi_rel_offset (x29, 0)
-	cfi_rel_offset (x30, 8)
+        stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
+        cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
+        cfi_rel_offset (x29, 0)
+        cfi_rel_offset (x30, 8)
 0:
-	mov     x29, sp
+        mov     x29, sp
 
-	/* Save the argument passing core registers.  */
-	stp     x0, x1, [sp, #16 + 16*N_V_ARG_REG + 0]
-	stp     x2, x3, [sp, #16 + 16*N_V_ARG_REG + 16]
-	stp     x4, x5, [sp, #16 + 16*N_V_ARG_REG + 32]
-	stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
+        /* Save the argument passing core registers.  */
+        stp     x0, x1, [sp, #16 + 16*N_V_ARG_REG + 0]
+        stp     x2, x3, [sp, #16 + 16*N_V_ARG_REG + 16]
+        stp     x4, x5, [sp, #16 + 16*N_V_ARG_REG + 32]
+        stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
 
-	/* Load ffi_closure_inner arguments.  */
-	ldp	PTR_REG(0), PTR_REG(1), [x18, #PTR_SIZE]/* load cif, fn */
-	mov	x2, x18					/* load user_data */
-	b	.Ldo_closure
-	cfi_endproc
+        /* Load ffi_closure_inner arguments.  */
+        ldp     PTR_REG(0), PTR_REG(1), [x18, #PTR_SIZE]/* load cif, fn */
+        mov     x2, x18                                 /* load user_data */
+        b       .Ldo_closure
+        cfi_endproc
 
-	.globl	CNAME(ffi_go_closure_SYSV)
-	FFI_HIDDEN(CNAME(ffi_go_closure_SYSV))
+        .globl  CNAME(ffi_go_closure_SYSV)
+        FFI_HIDDEN(CNAME(ffi_go_closure_SYSV))
 #ifdef __ELF__
-	.type	CNAME(ffi_go_closure_SYSV), #function
-	.size	CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
+        .type   CNAME(ffi_go_closure_SYSV), #function
+        .size   CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */
+#endif /* FFI_CLOSURES */
 #endif /* __arm64__ */
 
 #if defined __ELF__ && defined __linux__
-	.section .note.GNU-stack,"",%progbits
+        .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
@@ -1959,11 +1959,11 @@ struct malloc_segment {
 
 # define get_segment_flags(S)   (IS_MMAPPED_BIT)
 # define set_segment_flags(S,v) \
-  (((v) != IS_MMAPPED_BIT) ? (ABORT, (v)) :             \
-   (((S)->exec_offset =                         \
-     mmap_exec_offset((S)->base, (S)->size)),               \
-    (mmap_exec_offset((S)->base + (S)->exec_offset, (S)->size) !=   \
-     (S)->exec_offset) ? (ABORT, (v)) :                 \
+  (((v) != IS_MMAPPED_BIT) ? (ABORT, (v)) :                             \
+   (((S)->exec_offset =                                                 \
+     mmap_exec_offset((S)->base, (S)->size)),                           \
+    (mmap_exec_offset((S)->base + (S)->exec_offset, (S)->size) !=       \
+     (S)->exec_offset) ? (ABORT, (v)) :                                 \
    (mmap_exec_offset((S)->base, (S)->size) = 0), (v)))
 
   /* We use an offset here, instead of a pointer, because then, when
@@ -2371,7 +2371,7 @@ static size_t traverse_and_check(mstate m);
 
 #else /* GNUC */
 #if  USE_BUILTIN_FFS
-#define compute_bit2idx(X, I) I = ffs(X)-1
+#define compute_bit2idx(X, I) I = __builtin_ffs(X)-1
 
 #else /* USE_BUILTIN_FFS */
 #define compute_bit2idx(X, I)\

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/java_raw_api.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/java_raw_api.c
@@ -29,11 +29,11 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
-/* This defines a Java- and 64-bit specific variant of the raw API. */
-/* It assumes that "raw" argument blocks look like Java stacks on a */
-/* 64-bit machine.  Arguments that can be stored in a single stack  */
-/* stack slots (longs, doubles) occupy 128 bits, but only the first */
-/* 64 bits are actually used.                       */
+/* This defines a Java- and 64-bit specific variant of the raw API.     */
+/* It assumes that "raw" argument blocks look like Java stacks on a     */
+/* 64-bit machine.  Arguments that can be stored in a single stack      */
+/* stack slots (longs, doubles) occupy 128 bits, but only the first     */
+/* 64 bits are actually used.                                           */
 
 #include <ffi.h>
 #include <ffi_common.h>
@@ -58,7 +58,7 @@ ffi_java_raw_size (ffi_cif *cif)
       result += 2 * FFI_SIZEOF_JAVA_RAW;
       break;
     case FFI_TYPE_STRUCT:
-      /* No structure parameters in Java.   */
+      /* No structure parameters in Java.  */
       abort();
     case FFI_TYPE_COMPLEX:
       /* Not supported yet.  */
@@ -319,7 +319,7 @@ void ffi_java_raw_call (ffi_cif *cif, void (*fn)(void), void *rvalue,
   ffi_java_rvalue_to_raw (cif, rvalue);
 }
 
-#if FFI_CLOSURES        /* base system provides closures */
+#if FFI_CLOSURES           /* base system provides closures */
 
 static void
 ffi_java_translate_args (ffi_cif *cif, void *rvalue,

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------
-   prep_cif.c - Copyright (c) 2011, 2012  Anthony Green
+   prep_cif.c - Copyright (c) 2011, 2012, 2021  Anthony Green
                 Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining
@@ -129,7 +129,7 @@ ffi_status FFI_HIDDEN ffi_prep_cif_core(ffi_cif *cif, ffi_abi abi,
   cif->rtype = rtype;
 
   cif->flags = 0;
-#ifdef _M_ARM64
+#if (defined(_M_ARM64) || defined(__aarch64__)) && defined(_WIN32)
   cif->is_variadic = isvariadic;
 #endif
 #if HAVE_LONG_DOUBLE_VARIANT
@@ -231,7 +231,26 @@ ffi_status ffi_prep_cif_var(ffi_cif *cif,
                             ffi_type *rtype,
                             ffi_type **atypes)
 {
-  return ffi_prep_cif_core(cif, abi, 1, nfixedargs, ntotalargs, rtype, atypes);
+  ffi_status rc;
+  size_t int_size = ffi_type_sint.size;
+  int i;
+
+  rc = ffi_prep_cif_core(cif, abi, 1, nfixedargs, ntotalargs, rtype, atypes);
+
+  if (rc != FFI_OK)
+    return rc;
+
+  for (i = 1; i < ntotalargs; i++)
+    {
+      ffi_type *arg_type = atypes[i];
+      if (arg_type == &ffi_type_float
+          || ((arg_type->type != FFI_TYPE_STRUCT
+               && arg_type->type != FFI_TYPE_COMPLEX)
+              && arg_type->size < int_size))
+        return FFI_BAD_ARGTYPE;
+}
+
+  return FFI_OK;
 }
 
 #if FFI_CLOSURES

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/raw_api.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/raw_api.c
@@ -212,7 +212,7 @@ void ffi_raw_call (ffi_cif *cif, void (*fn)(void), void *rvalue, ffi_raw *raw)
   ffi_call (cif, fn, rvalue, avalue);
 }
 
-#if FFI_CLOSURES        /* base system provides closures */
+#if FFI_CLOSURES            /* base system provides closures */
 
 static void
 ffi_translate_args (ffi_cif *cif, void *rvalue,

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/types.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/types.c
@@ -34,31 +34,31 @@
 /* Type definitions */
 
 #define FFI_TYPEDEF(name, type, id, maybe_const)\
-struct struct_align_##name {            \
-  char c;                   \
-  type x;                   \
-};                      \
-FFI_EXTERN                  \
-maybe_const ffi_type ffi_type_##name = {    \
-  sizeof(type),                 \
-  offsetof(struct struct_align_##name, x),  \
-  id, NULL                  \
+struct struct_align_##name {                    \
+  char c;                                       \
+  type x;                                       \
+};                                              \
+FFI_EXTERN                                      \
+maybe_const ffi_type ffi_type_##name = {        \
+  sizeof(type),                                 \
+  offsetof(struct struct_align_##name, x),      \
+  id, NULL                                      \
 }
 
 #define FFI_COMPLEX_TYPEDEF(name, type, maybe_const)    \
 static ffi_type *ffi_elements_complex_##name [2] = {    \
-    (ffi_type *)(&ffi_type_##name), NULL        \
-};                          \
-struct struct_align_complex_##name {            \
-  char c;                       \
-  _Complex type x;                  \
-};                          \
-FFI_EXTERN                      \
-maybe_const ffi_type ffi_type_complex_##name = {    \
-  sizeof(_Complex type),                \
-  offsetof(struct struct_align_complex_##name, x),  \
-  FFI_TYPE_COMPLEX,                 \
-  (ffi_type **)ffi_elements_complex_##name      \
+        (ffi_type *)(&ffi_type_##name), NULL            \
+};                                                      \
+struct struct_align_complex_##name {                    \
+  char c;                                               \
+  _Complex type x;                                      \
+};                                                      \
+FFI_EXTERN                                              \
+maybe_const ffi_type ffi_type_complex_##name = {        \
+  sizeof(_Complex type),                                \
+  offsetof(struct struct_align_complex_##name, x),      \
+  FFI_TYPE_COMPLEX,                                     \
+  (ffi_type **)ffi_elements_complex_##name              \
 }
 
 /* Size and alignment are fake here. They must not be 0. */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffitarget.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffitarget.h
@@ -136,11 +136,26 @@ typedef enum ffi_abi {
 
 #if defined (X86_64) || defined(X86_WIN64) \
     || (defined (__x86_64__) && defined (X86_DARWIN))
-# define FFI_TRAMPOLINE_SIZE 24
+/* 4 bytes of ENDBR64 + 7 bytes of LEA + 6 bytes of JMP + 7 bytes of NOP
+   + 8 bytes of pointer.  */
+# define FFI_TRAMPOLINE_SIZE 32
 # define FFI_NATIVE_RAW_API 0
 #else
-# define FFI_TRAMPOLINE_SIZE 12
+/* 4 bytes of ENDBR32 + 5 bytes of MOV + 5 bytes of JMP + 2 unused
+   bytes.  */
+# define FFI_TRAMPOLINE_SIZE 16
 # define FFI_NATIVE_RAW_API 1  /* x86 has native raw api support */
+#endif
+
+#if !defined(GENERATE_LIBFFI_MAP) && defined(__CET__)
+# include <cet.h>
+# if (__CET__ & 1) != 0
+#   define ENDBR_PRESENT
+# endif
+# define _CET_NOTRACK notrack
+#else
+# define _CET_ENDBR
+# define _CET_NOTRACK
 #endif
 
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffiw64.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffiw64.c
@@ -30,6 +30,7 @@
 #include <ffi_common.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <tramp.h>
 
 #ifdef X86_WIN64
 #define EFI64(name) name
@@ -39,11 +40,11 @@
 
 struct win64_call_frame
 {
-  UINT64 rbp;       /* 0 */
-  UINT64 retaddr;   /* 8 */
-  UINT64 fn;        /* 16 */
-  UINT64 flags;     /* 24 */
-  UINT64 rvalue;    /* 32 */
+  UINT64 rbp;           /* 0 */
+  UINT64 retaddr;       /* 8 */
+  UINT64 fn;            /* 16 */
+  UINT64 flags;         /* 24 */
+  UINT64 rvalue;        /* 32 */
 };
 
 extern void ffi_call_win64 (void *stack, struct win64_call_frame *,
@@ -107,6 +108,13 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
   return FFI_OK;
 }
 
+/* We perform some black magic here to use some of the parent's stack frame in
+ * ffi_call_win64() that breaks with the MSVC compiler with the /RTCs or /GZ
+ * flags.  Disable the 'Stack frame run time error checking' for this function
+ * so we don't hit weird exceptions in debug builds. */
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", off)
+#endif
 static void
 ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
           void **avalue, void *closure)
@@ -171,6 +179,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 
   ffi_call_win64 (stack, frame, closure);
 }
+#if defined(_MSC_VER)
+#pragma runtime_checks("s", restore)
+#endif
 
 void
 EFI64(ffi_call)(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
@@ -187,7 +198,13 @@ EFI64(ffi_call_go)(ffi_cif *cif, void (*fn)(void), void *rvalue,
 
 
 extern void ffi_closure_win64(void) FFI_HIDDEN;
+#if defined(FFI_EXEC_STATIC_TRAMP)
+extern void ffi_closure_win64_alt(void) FFI_HIDDEN;
+#endif
+
+#ifdef FFI_GO_CLOSURES
 extern void ffi_go_closure_win64(void) FFI_HIDDEN;
+#endif
 
 ffi_status
 EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
@@ -196,13 +213,15 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
               void *user_data,
               void *codeloc)
 {
-  static const unsigned char trampoline[16] = {
-    /* leaq  -0x7(%rip),%r10   # 0x0  */
-    0x4c, 0x8d, 0x15, 0xf9, 0xff, 0xff, 0xff,
-    /* jmpq  *0x3(%rip)        # 0x10 */
-    0xff, 0x25, 0x03, 0x00, 0x00, 0x00,
-    /* nopl  (%rax) */
-    0x0f, 0x1f, 0x00
+  static const unsigned char trampoline[FFI_TRAMPOLINE_SIZE - 8] = {
+    /* endbr64 */
+    0xf3, 0x0f, 0x1e, 0xfa,
+    /* leaq  -0xb(%rip),%r10   # 0x0  */
+    0x4c, 0x8d, 0x15, 0xf5, 0xff, 0xff, 0xff,
+    /* jmpq  *0x7(%rip)        # 0x18 */
+    0xff, 0x25, 0x07, 0x00, 0x00, 0x00,
+    /* nopl  0(%rax) */
+    0x0f, 0x1f, 0x80, 0x00, 0x00, 0x00, 0x00
   };
   char *tramp = closure->tramp;
 
@@ -215,9 +234,20 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
       return FFI_BAD_ABI;
     }
 
-  memcpy (tramp, trampoline, sizeof(trampoline));
-  *(UINT64 *)(tramp + 16) = (uintptr_t)ffi_closure_win64;
+#if defined(FFI_EXEC_STATIC_TRAMP)
+  if (ffi_tramp_is_present(closure))
+    {
+      /* Initialize the static trampoline's parameters. */
+      ffi_tramp_set_parms (closure->ftramp, ffi_closure_win64_alt, closure);
+      goto out;
+    }
+#endif
 
+  /* Initialize the dynamic trampoline. */
+  memcpy (tramp, trampoline, sizeof(trampoline));
+  *(UINT64 *)(tramp + sizeof (trampoline)) = (uintptr_t)ffi_closure_win64;
+
+out:
   closure->cif = cif;
   closure->fun = fun;
   closure->user_data = user_data;
@@ -225,6 +255,7 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
   return FFI_OK;
 }
 
+#ifdef FFI_GO_CLOSURES
 ffi_status
 EFI64(ffi_prep_go_closure)(ffi_go_closure* closure, ffi_cif* cif,
              void (*fun)(ffi_cif*, void*, void**, void*))
@@ -244,6 +275,7 @@ EFI64(ffi_prep_go_closure)(ffi_go_closure* closure, ffi_cif* cif,
 
   return FFI_OK;
 }
+#endif
 
 struct win64_closure_frame
 {

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/internal.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/internal.h
@@ -1,22 +1,22 @@
-#define X86_RET_FLOAT       0
-#define X86_RET_DOUBLE      1
-#define X86_RET_LDOUBLE     2
-#define X86_RET_SINT8       3
-#define X86_RET_SINT16      4
-#define X86_RET_UINT8       5
-#define X86_RET_UINT16      6
-#define X86_RET_INT64       7
-#define X86_RET_INT32       8
-#define X86_RET_VOID        9
-#define X86_RET_STRUCTPOP   10
+#define X86_RET_FLOAT           0
+#define X86_RET_DOUBLE          1
+#define X86_RET_LDOUBLE         2
+#define X86_RET_SINT8           3
+#define X86_RET_SINT16          4
+#define X86_RET_UINT8           5
+#define X86_RET_UINT16          6
+#define X86_RET_INT64           7
+#define X86_RET_INT32           8
+#define X86_RET_VOID            9
+#define X86_RET_STRUCTPOP       10
 #define X86_RET_STRUCTARG       11
-#define X86_RET_STRUCT_1B   12
-#define X86_RET_STRUCT_2B   13
-#define X86_RET_UNUSED14    14
-#define X86_RET_UNUSED15    15
+#define X86_RET_STRUCT_1B       12
+#define X86_RET_STRUCT_2B       13
+#define X86_RET_UNUSED14        14
+#define X86_RET_UNUSED15        15
 
-#define X86_RET_TYPE_MASK   15
-#define X86_RET_POP_SHIFT   4
+#define X86_RET_TYPE_MASK       15
+#define X86_RET_POP_SHIFT       4
 
 #define R_EAX   0
 #define R_EDX   1
@@ -26,4 +26,18 @@
 # define HAVE_FASTCALL 0
 #else
 # define HAVE_FASTCALL 1
+#endif
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 4K (base page size)
+ * is chosen.
+ */
+#define X86_TRAMP_MAP_SHIFT     12
+#define X86_TRAMP_MAP_SIZE      (1 << X86_TRAMP_MAP_SHIFT)
+#ifdef ENDBR_PRESENT
+#define X86_TRAMP_SIZE          44
+#else
+#define X86_TRAMP_SIZE          40
+#endif
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/internal64.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/internal64.h
@@ -1,22 +1,36 @@
-#define UNIX64_RET_VOID     0
-#define UNIX64_RET_UINT8    1
-#define UNIX64_RET_UINT16   2
-#define UNIX64_RET_UINT32   3
-#define UNIX64_RET_SINT8    4
-#define UNIX64_RET_SINT16   5
-#define UNIX64_RET_SINT32   6
-#define UNIX64_RET_INT64    7
-#define UNIX64_RET_XMM32    8
-#define UNIX64_RET_XMM64    9
-#define UNIX64_RET_X87      10
-#define UNIX64_RET_X87_2    11
+#define UNIX64_RET_VOID         0
+#define UNIX64_RET_UINT8        1
+#define UNIX64_RET_UINT16       2
+#define UNIX64_RET_UINT32       3
+#define UNIX64_RET_SINT8        4
+#define UNIX64_RET_SINT16       5
+#define UNIX64_RET_SINT32       6
+#define UNIX64_RET_INT64        7
+#define UNIX64_RET_XMM32        8
+#define UNIX64_RET_XMM64        9
+#define UNIX64_RET_X87          10
+#define UNIX64_RET_X87_2        11
 #define UNIX64_RET_ST_XMM0_RAX  12
 #define UNIX64_RET_ST_RAX_XMM0  13
 #define UNIX64_RET_ST_XMM0_XMM1 14
 #define UNIX64_RET_ST_RAX_RDX   15
 
-#define UNIX64_RET_LAST     15
+#define UNIX64_RET_LAST         15
 
 #define UNIX64_FLAG_RET_IN_MEM  (1 << 10)
 #define UNIX64_FLAG_XMM_ARGS    (1 << 11)
-#define UNIX64_SIZE_SHIFT   12
+#define UNIX64_SIZE_SHIFT       12
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+/*
+ * For the trampoline code table mapping, a mapping size of 4K (base page size)
+ * is chosen.
+ */
+#define UNIX64_TRAMP_MAP_SHIFT  12
+#define UNIX64_TRAMP_MAP_SIZE   (1 << UNIX64_TRAMP_MAP_SHIFT)
+#ifdef ENDBR_PRESENT
+#define UNIX64_TRAMP_SIZE       40
+#else
+#define UNIX64_TRAMP_SIZE       32
+#endif
+#endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv.S
@@ -2,8 +2,8 @@
    sysv.S - Copyright (c) 2017  Anthony Green
           - Copyright (c) 2013  The Written Word, Inc.
           - Copyright (c) 1996,1998,2001-2003,2005,2008,2010  Red Hat, Inc.
-   
-   X86 Foreign Function Interface 
+
+   X86 Foreign Function Interface
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -29,7 +29,7 @@
 #ifdef __i386__
 #ifndef _MSC_VER
 
-#define LIBFFI_ASM	
+#define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
 #include "internal.h"
@@ -49,18 +49,18 @@
 #endif
 
 #ifdef __ELF__
-# define ENDF(X)  .type	X,@function; .size X, . - X
+# define ENDF(X)  .type X,@function; .size X, . - X
 #else
 # define ENDF(X)
 #endif
 
 /* Handle win32 fastcall name mangling.  */
 #ifdef X86_WIN32
-# define ffi_call_i386		"@ffi_call_i386@8"
-# define ffi_closure_inner	"@ffi_closure_inner@8"
+# define ffi_call_i386          "@ffi_call_i386@8"
+# define ffi_closure_inner      "@ffi_closure_inner@8"
 #else
-# define ffi_call_i386		C(ffi_call_i386)
-# define ffi_closure_inner	C(ffi_closure_inner)
+# define ffi_call_i386          C(ffi_call_i386)
+# define ffi_closure_inner      C(ffi_closure_inner)
 #endif
 
 /* This macro allows the safe creation of jump tables without an
@@ -68,15 +68,15 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	.balign 8
+# define E(BASE, X)     .balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + X * 8
+# define E(BASE, X)     .balign 8; .org BASE + X * 8
 #endif
 
-	.text
-	.balign	16
-	.globl	ffi_call_i386
-	FFI_HIDDEN(ffi_call_i386)
+        .text
+        .balign 16
+        .globl  ffi_call_i386
+        FFI_HIDDEN(ffi_call_i386)
 
 /* This is declared as
 
@@ -91,739 +91,827 @@
 
 ffi_call_i386:
 L(UW0):
-	# cfi_startproc
-	_CET_ENDBR
+        # cfi_startproc
+        _CET_ENDBR
 #if !HAVE_FASTCALL
-	movl	4(%esp), %ecx
-	movl	8(%esp), %edx
+        movl    4(%esp), %ecx
+        movl    8(%esp), %edx
 #endif
-	movl	(%esp), %eax		/* move the return address */
-	movl	%ebp, (%ecx)		/* store %ebp into local frame */
-	movl	%eax, 4(%ecx)		/* store retaddr into local frame */
+        movl    (%esp), %eax            /* move the return address */
+        movl    %ebp, (%ecx)            /* store %ebp into local frame */
+        movl    %eax, 4(%ecx)           /* store retaddr into local frame */
 
-	/* New stack frame based off ebp.  This is a itty bit of unwind
-	   trickery in that the CFA *has* changed.  There is no easy way
-	   to describe it correctly on entry to the function.  Fortunately,
-	   it doesn't matter too much since at all points we can correctly
-	   unwind back to ffi_call.  Note that the location to which we
-	   moved the return address is (the new) CFA-4, so from the
-	   perspective of the unwind info, it hasn't moved.  */
-	movl	%ecx, %ebp
+        /* New stack frame based off ebp.  This is a itty bit of unwind
+           trickery in that the CFA *has* changed.  There is no easy way
+           to describe it correctly on entry to the function.  Fortunately,
+           it doesn't matter too much since at all points we can correctly
+           unwind back to ffi_call.  Note that the location to which we
+           moved the return address is (the new) CFA-4, so from the
+           perspective of the unwind info, it hasn't moved.  */
+        movl    %ecx, %ebp
 L(UW1):
-	# cfi_def_cfa(%ebp, 8)
-	# cfi_rel_offset(%ebp, 0)
+        # cfi_def_cfa(%ebp, 8)
+        # cfi_rel_offset(%ebp, 0)
 
-	movl	%edx, %esp		/* set outgoing argument stack */
-	movl	20+R_EAX*4(%ebp), %eax	/* set register arguments */
-	movl	20+R_EDX*4(%ebp), %edx
-	movl	20+R_ECX*4(%ebp), %ecx
+        movl    %edx, %esp              /* set outgoing argument stack */
+        movl    20+R_EAX*4(%ebp), %eax  /* set register arguments */
+        movl    20+R_EDX*4(%ebp), %edx
+        movl    20+R_ECX*4(%ebp), %ecx
 
-	call	*8(%ebp)
+        call    *8(%ebp)
 
-	movl	12(%ebp), %ecx		/* load return type code */
-	movl	%ebx, 8(%ebp)		/* preserve %ebx */
+        movl    12(%ebp), %ecx          /* load return type code */
+        movl    %ebx, 8(%ebp)           /* preserve %ebx */
 L(UW2):
-	# cfi_rel_offset(%ebx, 8)
+        # cfi_rel_offset(%ebx, 8)
 
-	andl	$X86_RET_TYPE_MASK, %ecx
+        andl    $X86_RET_TYPE_MASK, %ecx
 #ifdef __PIC__
-	call	C(__x86.get_pc_thunk.bx)
+        call    C(__x86.get_pc_thunk.bx)
 L(pc1):
-	leal	L(store_table)-L(pc1)(%ebx, %ecx, 8), %ebx
+        leal    L(store_table)-L(pc1)(%ebx, %ecx, 8), %ebx
 #else
-	leal	L(store_table)(,%ecx, 8), %ebx
+        leal    L(store_table)(,%ecx, 8), %ebx
 #endif
-	movl	16(%ebp), %ecx		/* load result address */
-	_CET_NOTRACK jmp *%ebx
+        movl    16(%ebp), %ecx          /* load result address */
+        _CET_NOTRACK jmp *%ebx
 
-	.balign	8
+        .balign 8
 L(store_table):
 E(L(store_table), X86_RET_FLOAT)
-	fstps	(%ecx)
-	jmp	L(e1)
+        fstps   (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_DOUBLE)
-	fstpl	(%ecx)
-	jmp	L(e1)
+        fstpl   (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_LDOUBLE)
-	fstpt	(%ecx)
-	jmp	L(e1)
+        fstpt   (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT8)
-	movsbl	%al, %eax
-	mov	%eax, (%ecx)
-	jmp	L(e1)
+        movsbl  %al, %eax
+        mov     %eax, (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT16)
-	movswl	%ax, %eax
-	mov	%eax, (%ecx)
-	jmp	L(e1)
+        movswl  %ax, %eax
+        mov     %eax, (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT8)
-	movzbl	%al, %eax
-	mov	%eax, (%ecx)
-	jmp	L(e1)
+        movzbl  %al, %eax
+        mov     %eax, (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT16)
-	movzwl	%ax, %eax
-	mov	%eax, (%ecx)
-	jmp	L(e1)
+        movzwl  %ax, %eax
+        mov     %eax, (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_INT64)
-	movl	%edx, 4(%ecx)
-	/* fallthru */
+        movl    %edx, 4(%ecx)
+        /* fallthru */
 E(L(store_table), X86_RET_INT32)
-	movl	%eax, (%ecx)
-	/* fallthru */
+        movl    %eax, (%ecx)
+        /* fallthru */
 E(L(store_table), X86_RET_VOID)
 L(e1):
-	movl	8(%ebp), %ebx
-	movl	%ebp, %esp
-	popl	%ebp
+        movl    8(%ebp), %ebx
+        movl    %ebp, %esp
+        popl    %ebp
 L(UW3):
-	# cfi_remember_state
-	# cfi_def_cfa(%esp, 4)
-	# cfi_restore(%ebx)
-	# cfi_restore(%ebp)
-	ret
+        # cfi_remember_state
+        # cfi_def_cfa(%esp, 4)
+        # cfi_restore(%ebx)
+        # cfi_restore(%ebp)
+        ret
 L(UW4):
-	# cfi_restore_state
+        # cfi_restore_state
 
 E(L(store_table), X86_RET_STRUCTPOP)
-	jmp	L(e1)
+        jmp     L(e1)
 E(L(store_table), X86_RET_STRUCTARG)
-	jmp	L(e1)
+        jmp     L(e1)
 E(L(store_table), X86_RET_STRUCT_1B)
-	movb	%al, (%ecx)
-	jmp	L(e1)
+        movb    %al, (%ecx)
+        jmp     L(e1)
 E(L(store_table), X86_RET_STRUCT_2B)
-	movw	%ax, (%ecx)
-	jmp	L(e1)
+        movw    %ax, (%ecx)
+        jmp     L(e1)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(store_table), X86_RET_UNUSED14)
-	ud2
+        ud2
 E(L(store_table), X86_RET_UNUSED15)
-	ud2
+        ud2
 
 L(UW5):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(ffi_call_i386)
 
 /* The inner helper is declared as
 
    void ffi_closure_inner(struct closure_frame *frame, char *argp)
-	__attribute_((fastcall))
+        __attribute_((fastcall))
 
    Thus the arguments are placed in
 
-	ecx:	frame
-	edx:	argp
+        ecx:    frame
+        edx:    argp
 */
 
 /* Macros to help setting up the closure_data structure.  */
 
 #if HAVE_FASTCALL
-# define closure_FS	(40 + 4)
-# define closure_CF	0
+# define closure_FS     (40 + 4)
+# define closure_CF     0
 #else
-# define closure_FS	(8 + 40 + 12)
-# define closure_CF	8
+# define closure_FS     (8 + 40 + 12)
+# define closure_CF     8
 #endif
 
-#define FFI_CLOSURE_SAVE_REGS		\
-	movl	%eax, closure_CF+16+R_EAX*4(%esp);	\
-	movl	%edx, closure_CF+16+R_EDX*4(%esp);	\
-	movl	%ecx, closure_CF+16+R_ECX*4(%esp)
+#define FFI_CLOSURE_SAVE_REGS                           \
+        movl    %eax, closure_CF+16+R_EAX*4(%esp);      \
+        movl    %edx, closure_CF+16+R_EDX*4(%esp);      \
+        movl    %ecx, closure_CF+16+R_ECX*4(%esp)
 
-#define FFI_CLOSURE_COPY_TRAMP_DATA					\
-	movl	FFI_TRAMPOLINE_SIZE(%eax), %edx;	/* copy cif */	\
-	movl	FFI_TRAMPOLINE_SIZE+4(%eax), %ecx;	/* copy fun */	\
-	movl	FFI_TRAMPOLINE_SIZE+8(%eax), %eax;	/* copy user_data */ \
-	movl	%edx, closure_CF+28(%esp);				\
-	movl	%ecx, closure_CF+32(%esp);				\
-	movl	%eax, closure_CF+36(%esp)
+#define FFI_CLOSURE_COPY_TRAMP_DATA                                     \
+        movl    FFI_TRAMPOLINE_SIZE(%eax), %edx;   /* copy cif */       \
+        movl    FFI_TRAMPOLINE_SIZE+4(%eax), %ecx; /* copy fun */       \
+        movl    FFI_TRAMPOLINE_SIZE+8(%eax), %eax; /* copy user_data */ \
+        movl    %edx, closure_CF+28(%esp);                              \
+        movl    %ecx, closure_CF+32(%esp);                              \
+        movl    %eax, closure_CF+36(%esp)
 
 #if HAVE_FASTCALL
-# define FFI_CLOSURE_PREP_CALL						\
-	movl	%esp, %ecx;			/* load closure_data */	\
-	leal	closure_FS+4(%esp), %edx;	/* load incoming stack */
+# define FFI_CLOSURE_PREP_CALL                                          \
+        movl    %esp, %ecx;                   /* load closure_data */   \
+        leal    closure_FS+4(%esp), %edx;     /* load incoming stack */
 #else
-# define FFI_CLOSURE_PREP_CALL						\
-	leal	closure_CF(%esp), %ecx;		/* load closure_data */	\
-	leal	closure_FS+4(%esp), %edx;	/* load incoming stack */ \
-	movl	%ecx, (%esp);						\
-	movl	%edx, 4(%esp)
+# define FFI_CLOSURE_PREP_CALL                                          \
+        leal    closure_CF(%esp), %ecx;       /* load closure_data */   \
+        leal    closure_FS+4(%esp), %edx;     /* load incoming stack */ \
+        movl    %ecx, (%esp);                                           \
+        movl    %edx, 4(%esp)
 #endif
 
 #define FFI_CLOSURE_CALL_INNER(UWN) \
-	call	ffi_closure_inner
+        call    ffi_closure_inner
 
-#define FFI_CLOSURE_MASK_AND_JUMP(N, UW)				\
-	andl	$X86_RET_TYPE_MASK, %eax;				\
-	leal	L(C1(load_table,N))(, %eax, 8), %edx;			\
-	movl	closure_CF(%esp), %eax;		/* optimiztic load */	\
-	_CET_NOTRACK jmp *%edx
+#define FFI_CLOSURE_MASK_AND_JUMP(N, UW)                                \
+        andl    $X86_RET_TYPE_MASK, %eax;                               \
+        leal    L(C1(load_table,N))(, %eax, 8), %edx;                   \
+        movl    closure_CF(%esp), %eax;         /* optimiztic load */   \
+        _CET_NOTRACK jmp *%edx
 
 #ifdef __PIC__
 # if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
 #  undef FFI_CLOSURE_MASK_AND_JUMP
-#  define FFI_CLOSURE_MASK_AND_JUMP(N, UW)				\
-	andl	$X86_RET_TYPE_MASK, %eax;				\
-	call	C(__x86.get_pc_thunk.dx);				\
-L(C1(pc,N)):								\
-	leal	L(C1(load_table,N))-L(C1(pc,N))(%edx, %eax, 8), %edx;	\
-	movl	closure_CF(%esp), %eax;		/* optimiztic load */	\
-	_CET_NOTRACK jmp *%edx
+#  define FFI_CLOSURE_MASK_AND_JUMP(N, UW)                              \
+        andl    $X86_RET_TYPE_MASK, %eax;                               \
+        call    C(__x86.get_pc_thunk.dx);                               \
+L(C1(pc,N)):                                                            \
+        leal    L(C1(load_table,N))-L(C1(pc,N))(%edx, %eax, 8), %edx;   \
+        movl    closure_CF(%esp), %eax;         /* optimiztic load */   \
+        _CET_NOTRACK jmp *%edx
 # else
 #  define FFI_CLOSURE_CALL_INNER_SAVE_EBX
 #  undef FFI_CLOSURE_CALL_INNER
-#  define FFI_CLOSURE_CALL_INNER(UWN)					\
-	movl	%ebx, 40(%esp);			/* save ebx */		\
-L(C1(UW,UWN)):								\
-	/* cfi_rel_offset(%ebx, 40); */					\
-	call	C(__x86.get_pc_thunk.bx);	/* load got register */	\
-	addl	$C(_GLOBAL_OFFSET_TABLE_), %ebx;			\
-	call	ffi_closure_inner@PLT
+#  define FFI_CLOSURE_CALL_INNER(UWN)                                   \
+        movl    %ebx, 40(%esp);                 /* save ebx */          \
+L(C1(UW,UWN)):                                                          \
+        /* cfi_rel_offset(%ebx, 40); */                                 \
+        call    C(__x86.get_pc_thunk.bx);       /* load got register */ \
+        addl    $C(_GLOBAL_OFFSET_TABLE_), %ebx;                        \
+        call    ffi_closure_inner@PLT
 #  undef FFI_CLOSURE_MASK_AND_JUMP
-#  define FFI_CLOSURE_MASK_AND_JUMP(N, UWN)				\
-	andl	$X86_RET_TYPE_MASK, %eax;				\
-	leal	L(C1(load_table,N))@GOTOFF(%ebx, %eax, 8), %edx;	\
-	movl	40(%esp), %ebx;			/* restore ebx */	\
-L(C1(UW,UWN)):								\
-	/* cfi_restore(%ebx); */					\
-	movl	closure_CF(%esp), %eax;		/* optimiztic load */	\
-	_CET_NOTRACK jmp *%edx
+#  define FFI_CLOSURE_MASK_AND_JUMP(N, UWN)                             \
+        andl    $X86_RET_TYPE_MASK, %eax;                               \
+        leal    L(C1(load_table,N))@GOTOFF(%ebx, %eax, 8), %edx;        \
+        movl    40(%esp), %ebx;                 /* restore ebx */       \
+L(C1(UW,UWN)):                                                          \
+        /* cfi_restore(%ebx); */                                        \
+        movl    closure_CF(%esp), %eax;         /* optimiztic load */   \
+        _CET_NOTRACK jmp *%edx
 # endif /* DARWIN || HIDDEN */
 #endif /* __PIC__ */
 
-	.balign	16
-	.globl	C(ffi_go_closure_EAX)
-	FFI_HIDDEN(C(ffi_go_closure_EAX))
+        .balign 16
+        .globl  C(ffi_go_closure_EAX)
+        FFI_HIDDEN(C(ffi_go_closure_EAX))
 C(ffi_go_closure_EAX):
 L(UW6):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$closure_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $closure_FS, %esp
 L(UW7):
-	# cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	movl	4(%eax), %edx			/* copy cif */
-	movl	8(%eax), %ecx			/* copy fun */
-	movl	%edx, closure_CF+28(%esp)
-	movl	%ecx, closure_CF+32(%esp)
-	movl	%eax, closure_CF+36(%esp)	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        # cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        movl    4(%eax), %edx                   /* copy cif */
+        movl    8(%eax), %ecx                   /* copy fun */
+        movl    %edx, closure_CF+28(%esp)
+        movl    %ecx, closure_CF+32(%esp)
+        movl    %eax, closure_CF+36(%esp)       /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW8):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_go_closure_EAX))
 
-	.balign	16
-	.globl	C(ffi_go_closure_ECX)
-	FFI_HIDDEN(C(ffi_go_closure_ECX))
+        .balign 16
+        .globl  C(ffi_go_closure_ECX)
+        FFI_HIDDEN(C(ffi_go_closure_ECX))
 C(ffi_go_closure_ECX):
 L(UW9):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$closure_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $closure_FS, %esp
 L(UW10):
-	# cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	movl	4(%ecx), %edx			/* copy cif */
-	movl	8(%ecx), %eax			/* copy fun */
-	movl	%edx, closure_CF+28(%esp)
-	movl	%eax, closure_CF+32(%esp)
-	movl	%ecx, closure_CF+36(%esp)	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        # cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        movl    4(%ecx), %edx                   /* copy cif */
+        movl    8(%ecx), %eax                   /* copy fun */
+        movl    %edx, closure_CF+28(%esp)
+        movl    %eax, closure_CF+32(%esp)
+        movl    %ecx, closure_CF+36(%esp)       /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW11):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_go_closure_ECX))
 
 /* The closure entry points are reached from the ffi_closure trampoline.
    On entry, %eax contains the address of the ffi_closure.  */
 
-	.balign	16
-	.globl	C(ffi_closure_i386)
-	FFI_HIDDEN(C(ffi_closure_i386))
+        .balign 16
+        .globl  C(ffi_closure_i386)
+        FFI_HIDDEN(C(ffi_closure_i386))
 
 C(ffi_closure_i386):
 L(UW12):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$closure_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $closure_FS, %esp
 L(UW13):
-	# cfi_def_cfa_offset(closure_FS + 4)
+        # cfi_def_cfa_offset(closure_FS + 4)
 
-	FFI_CLOSURE_SAVE_REGS
-	FFI_CLOSURE_COPY_TRAMP_DATA
+        FFI_CLOSURE_SAVE_REGS
+        FFI_CLOSURE_COPY_TRAMP_DATA
 
-	/* Entry point from preceeding Go closures.  */
+        /* Entry point from preceeding Go closures.  */
 L(do_closure_i386):
 
-	FFI_CLOSURE_PREP_CALL
-	FFI_CLOSURE_CALL_INNER(14)
-	FFI_CLOSURE_MASK_AND_JUMP(2, 15)
+        FFI_CLOSURE_PREP_CALL
+        FFI_CLOSURE_CALL_INNER(14)
+        FFI_CLOSURE_MASK_AND_JUMP(2, 15)
 
-	.balign	8
+        .balign 8
 L(load_table2):
 E(L(load_table2), X86_RET_FLOAT)
-	flds	closure_CF(%esp)
-	jmp	L(e2)
+        flds    closure_CF(%esp)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_DOUBLE)
-	fldl	closure_CF(%esp)
-	jmp	L(e2)
+        fldl    closure_CF(%esp)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_LDOUBLE)
-	fldt	closure_CF(%esp)
-	jmp	L(e2)
+        fldt    closure_CF(%esp)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT8)
-	movsbl	%al, %eax
-	jmp	L(e2)
+        movsbl  %al, %eax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT16)
-	movswl	%ax, %eax
-	jmp	L(e2)
+        movswl  %ax, %eax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT8)
-	movzbl	%al, %eax
-	jmp	L(e2)
+        movzbl  %al, %eax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT16)
-	movzwl	%ax, %eax
-	jmp	L(e2)
+        movzwl  %ax, %eax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT64)
-	movl	closure_CF+4(%esp), %edx
-	jmp	L(e2)
+        movl    closure_CF+4(%esp), %edx
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table2), X86_RET_VOID)
 L(e2):
-	addl	$closure_FS, %esp
+        addl    $closure_FS, %esp
 L(UW16):
-	# cfi_adjust_cfa_offset(-closure_FS)
-	ret
+        # cfi_adjust_cfa_offset(-closure_FS)
+        ret
 L(UW17):
-	# cfi_adjust_cfa_offset(closure_FS)
+        # cfi_adjust_cfa_offset(closure_FS)
 E(L(load_table2), X86_RET_STRUCTPOP)
-	addl	$closure_FS, %esp
+        addl    $closure_FS, %esp
 L(UW18):
-	# cfi_adjust_cfa_offset(-closure_FS)
-	ret	$4
+        # cfi_adjust_cfa_offset(-closure_FS)
+        ret     $4
 L(UW19):
-	# cfi_adjust_cfa_offset(closure_FS)
+        # cfi_adjust_cfa_offset(closure_FS)
 E(L(load_table2), X86_RET_STRUCTARG)
-	jmp	L(e2)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_1B)
-	movzbl	%al, %eax
-	jmp	L(e2)
+        movzbl  %al, %eax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_2B)
-	movzwl	%ax, %eax
-	jmp	L(e2)
+        movzwl  %ax, %eax
+        jmp     L(e2)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table2), X86_RET_UNUSED14)
-	ud2
+        ud2
 E(L(load_table2), X86_RET_UNUSED15)
-	ud2
+        ud2
 
 L(UW20):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_closure_i386))
 
-	.balign	16
-	.globl	C(ffi_go_closure_STDCALL)
-	FFI_HIDDEN(C(ffi_go_closure_STDCALL))
+        .balign 16
+        .globl  C(ffi_go_closure_STDCALL)
+        FFI_HIDDEN(C(ffi_go_closure_STDCALL))
 C(ffi_go_closure_STDCALL):
 L(UW21):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$closure_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $closure_FS, %esp
 L(UW22):
-	# cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	movl	4(%ecx), %edx			/* copy cif */
-	movl	8(%ecx), %eax			/* copy fun */
-	movl	%edx, closure_CF+28(%esp)
-	movl	%eax, closure_CF+32(%esp)
-	movl	%ecx, closure_CF+36(%esp)	/* closure is user_data */
-	jmp	L(do_closure_STDCALL)
+        # cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        movl    4(%ecx), %edx                   /* copy cif */
+        movl    8(%ecx), %eax                   /* copy fun */
+        movl    %edx, closure_CF+28(%esp)
+        movl    %eax, closure_CF+32(%esp)
+        movl    %ecx, closure_CF+36(%esp)       /* closure is user_data */
+        jmp     L(do_closure_STDCALL)
 L(UW23):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_go_closure_STDCALL))
 
 /* For REGISTER, we have no available parameter registers, and so we
    enter here having pushed the closure onto the stack.  */
 
-	.balign	16
-	.globl	C(ffi_closure_REGISTER)
-	FFI_HIDDEN(C(ffi_closure_REGISTER))
+        .balign 16
+        .globl  C(ffi_closure_REGISTER)
+        FFI_HIDDEN(C(ffi_closure_REGISTER))
 C(ffi_closure_REGISTER):
 L(UW24):
-	# cfi_startproc
-	# cfi_def_cfa(%esp, 8)
-	# cfi_offset(%eip, -8)
-	_CET_ENDBR
-	subl	$closure_FS-4, %esp
+        # cfi_startproc
+        # cfi_def_cfa(%esp, 8)
+        # cfi_offset(%eip, -8)
+        _CET_ENDBR
+        subl    $closure_FS-4, %esp
 L(UW25):
-	# cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	movl	closure_FS-4(%esp), %ecx	/* load retaddr */
-	movl	closure_FS(%esp), %eax		/* load closure */
-	movl	%ecx, closure_FS(%esp)		/* move retaddr */
-	jmp	L(do_closure_REGISTER)
+        # cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        movl    closure_FS-4(%esp), %ecx        /* load retaddr */
+        movl    closure_FS(%esp), %eax          /* load closure */
+        movl    %ecx, closure_FS(%esp)          /* move retaddr */
+        jmp     L(do_closure_REGISTER)
 L(UW26):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_closure_REGISTER))
 
 /* For STDCALL (and others), we need to pop N bytes of arguments off
    the stack following the closure.  The amount needing to be popped
    is returned to us from ffi_closure_inner.  */
 
-	.balign	16
-	.globl	C(ffi_closure_STDCALL)
-	FFI_HIDDEN(C(ffi_closure_STDCALL))
+        .balign 16
+        .globl  C(ffi_closure_STDCALL)
+        FFI_HIDDEN(C(ffi_closure_STDCALL))
 C(ffi_closure_STDCALL):
 L(UW27):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$closure_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $closure_FS, %esp
 L(UW28):
-	# cfi_def_cfa_offset(closure_FS + 4)
+        # cfi_def_cfa_offset(closure_FS + 4)
 
-	FFI_CLOSURE_SAVE_REGS
+        FFI_CLOSURE_SAVE_REGS
 
-	/* Entry point from ffi_closure_REGISTER.  */
+        /* Entry point from ffi_closure_REGISTER.  */
 L(do_closure_REGISTER):
 
-	FFI_CLOSURE_COPY_TRAMP_DATA
+        FFI_CLOSURE_COPY_TRAMP_DATA
 
-	/* Entry point from preceeding Go closure.  */
+        /* Entry point from preceeding Go closure.  */
 L(do_closure_STDCALL):
 
-	FFI_CLOSURE_PREP_CALL
-	FFI_CLOSURE_CALL_INNER(29)
+        FFI_CLOSURE_PREP_CALL
+        FFI_CLOSURE_CALL_INNER(29)
 
-	movl	%eax, %ecx
-	shrl	$X86_RET_POP_SHIFT, %ecx	/* isolate pop count */
-	leal	closure_FS(%esp, %ecx), %ecx	/* compute popped esp */
-	movl	closure_FS(%esp), %edx		/* move return address */
-	movl	%edx, (%ecx)
+        movl    %eax, %ecx
+        shrl    $X86_RET_POP_SHIFT, %ecx        /* isolate pop count */
+        leal    closure_FS(%esp, %ecx), %ecx    /* compute popped esp */
+        movl    closure_FS(%esp), %edx          /* move return address */
+        movl    %edx, (%ecx)
 
-	/* From this point on, the value of %esp upon return is %ecx+4,
-	   and we've copied the return address to %ecx to make return easy.
-	   There's no point in representing this in the unwind info, as
-	   there is always a window between the mov and the ret which
-	   will be wrong from one point of view or another.  */
+        /* From this point on, the value of %esp upon return is %ecx+4,
+           and we've copied the return address to %ecx to make return easy.
+           There's no point in representing this in the unwind info, as
+           there is always a window between the mov and the ret which
+           will be wrong from one point of view or another.  */
 
-	FFI_CLOSURE_MASK_AND_JUMP(3, 30)
+        FFI_CLOSURE_MASK_AND_JUMP(3, 30)
 
-	.balign	8
+        .balign 8
 L(load_table3):
 E(L(load_table3), X86_RET_FLOAT)
-	flds    closure_CF(%esp)
-	movl    %ecx, %esp
-	ret
+        flds    closure_CF(%esp)
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_DOUBLE)
-	fldl    closure_CF(%esp)
-	movl    %ecx, %esp
-	ret
+        fldl    closure_CF(%esp)
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_LDOUBLE)
-	fldt    closure_CF(%esp)
-	movl    %ecx, %esp
-	ret
+        fldt    closure_CF(%esp)
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_SINT8)
-	movsbl  %al, %eax
-	movl    %ecx, %esp
-	ret
+        movsbl  %al, %eax
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_SINT16)
-	movswl  %ax, %eax
-	movl    %ecx, %esp
-	ret
+        movswl  %ax, %eax
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_UINT8)
-	movzbl  %al, %eax
-	movl    %ecx, %esp
-	ret
+        movzbl  %al, %eax
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_UINT16)
-	movzwl  %ax, %eax
-	movl    %ecx, %esp
-	ret
+        movzwl  %ax, %eax
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_INT64)
-	movl	closure_CF+4(%esp), %edx
-	movl    %ecx, %esp
-	ret
+        movl    closure_CF+4(%esp), %edx
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_INT32)
-	movl    %ecx, %esp
-	ret
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_VOID)
-	movl    %ecx, %esp
-	ret
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_STRUCTPOP)
-	movl    %ecx, %esp
-	ret
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_STRUCTARG)
-	movl	%ecx, %esp
-	ret
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_STRUCT_1B)
-	movzbl	%al, %eax
-	movl	%ecx, %esp
-	ret
+        movzbl  %al, %eax
+        movl    %ecx, %esp
+        ret
 E(L(load_table3), X86_RET_STRUCT_2B)
-	movzwl	%ax, %eax
-	movl	%ecx, %esp
-	ret
+        movzwl  %ax, %eax
+        movl    %ecx, %esp
+        ret
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table3), X86_RET_UNUSED14)
-	ud2
+        ud2
 E(L(load_table3), X86_RET_UNUSED15)
-	ud2
+        ud2
 
 L(UW31):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_closure_STDCALL))
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+        .balign 16
+        .globl  C(ffi_closure_i386_alt)
+        FFI_HIDDEN(C(ffi_closure_i386_alt))
+C(ffi_closure_i386_alt):
+        /* See the comments above trampoline_code_table. */
+        _CET_ENDBR
+        movl    4(%esp), %eax                   /* Load closure in eax */
+        add     $8, %esp                        /* Restore the stack */
+        jmp     C(ffi_closure_i386)
+ENDF(C(ffi_closure_i386_alt))
+
+        .balign 16
+        .globl  C(ffi_closure_REGISTER_alt)
+        FFI_HIDDEN(C(ffi_closure_REGISTER_alt))
+C(ffi_closure_REGISTER_alt):
+        /* See the comments above trampoline_code_table. */
+        _CET_ENDBR
+        movl    (%esp), %eax                    /* Restore eax */
+        add     $4, %esp                        /* Leave closure on stack */
+        jmp     C(ffi_closure_REGISTER)
+ENDF(C(ffi_closure_REGISTER_alt))
+
+        .balign 16
+        .globl  C(ffi_closure_STDCALL_alt)
+        FFI_HIDDEN(C(ffi_closure_STDCALL_alt))
+C(ffi_closure_STDCALL_alt):
+        /* See the comments above trampoline_code_table. */
+        _CET_ENDBR
+        movl    4(%esp), %eax                   /* Load closure in eax */
+        add     $8, %esp                        /* Restore the stack */
+        jmp     C(ffi_closure_STDCALL)
+ENDF(C(ffi_closure_STDCALL_alt))
+
+/*
+ * Below is the definition of the trampoline code table. Each element in
+ * the code table is a trampoline.
+ *
+ * Because we jump to the trampoline, we place a _CET_ENDBR at the
+ * beginning of the trampoline to mark it as a valid branch target. This is
+ * part of the the Intel CET (Control Flow Enforcement Technology).
+ */
+/*
+ * The trampoline uses register eax.  It saves the original value of eax on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of eax
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+#ifdef ENDBR_PRESENT
+#define X86_DATA_OFFSET         4081
+#define X86_CODE_OFFSET         4070
+#else
+#define X86_DATA_OFFSET         4085
+#define X86_CODE_OFFSET         4074
+#endif
+
+        .align  X86_TRAMP_MAP_SIZE
+        .globl  C(trampoline_code_table)
+        FFI_HIDDEN(C(trampoline_code_table))
+C(trampoline_code_table):
+        .rept   X86_TRAMP_MAP_SIZE / X86_TRAMP_SIZE
+        _CET_ENDBR
+        sub     $8, %esp
+        movl    %eax, (%esp)                    /* Save %eax on stack */
+        call    1f                              /* Get next PC into %eax */
+        movl    X86_DATA_OFFSET(%eax), %eax     /* Copy data into %eax */
+        movl    %eax, 4(%esp)                   /* Save data on stack */
+        call    1f                              /* Get next PC into %eax */
+        movl    X86_CODE_OFFSET(%eax), %eax     /* Copy code into %eax */
+        jmp     *%eax                           /* Jump to code */
+1:
+        mov     (%esp), %eax
+        ret
+        .align  4
+        .endr
+ENDF(C(trampoline_code_table))
+        .align  X86_TRAMP_MAP_SIZE
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if !FFI_NO_RAW_API
 
-#define raw_closure_S_FS	(16+16+12)
+#define raw_closure_S_FS        (16+16+12)
 
-	.balign	16
-	.globl	C(ffi_closure_raw_SYSV)
-	FFI_HIDDEN(C(ffi_closure_raw_SYSV))
+        .balign 16
+        .globl  C(ffi_closure_raw_SYSV)
+        FFI_HIDDEN(C(ffi_closure_raw_SYSV))
 C(ffi_closure_raw_SYSV):
 L(UW32):
-	# cfi_startproc
-	_CET_ENDBR
-	subl	$raw_closure_S_FS, %esp
+        # cfi_startproc
+        _CET_ENDBR
+        subl    $raw_closure_S_FS, %esp
 L(UW33):
-	# cfi_def_cfa_offset(raw_closure_S_FS + 4)
-	movl	%ebx, raw_closure_S_FS-4(%esp)
+        # cfi_def_cfa_offset(raw_closure_S_FS + 4)
+        movl    %ebx, raw_closure_S_FS-4(%esp)
 L(UW34):
-	# cfi_rel_offset(%ebx, raw_closure_S_FS-4)
+        # cfi_rel_offset(%ebx, raw_closure_S_FS-4)
 
-	movl	FFI_TRAMPOLINE_SIZE+8(%eax), %edx	/* load cl->user_data */
-	movl	%edx, 12(%esp)
-	leal	raw_closure_S_FS+4(%esp), %edx		/* load raw_args */
-	movl	%edx, 8(%esp)
-	leal	16(%esp), %edx				/* load &res */
-	movl	%edx, 4(%esp)
-	movl	FFI_TRAMPOLINE_SIZE(%eax), %ebx		/* load cl->cif */
-	movl	%ebx, (%esp)
-	call	*FFI_TRAMPOLINE_SIZE+4(%eax)		/* call cl->fun */
+        movl    FFI_TRAMPOLINE_SIZE+8(%eax), %edx       /* load cl->user_data */
+        movl    %edx, 12(%esp)
+        leal    raw_closure_S_FS+4(%esp), %edx          /* load raw_args */
+        movl    %edx, 8(%esp)
+        leal    16(%esp), %edx                          /* load &res */
+        movl    %edx, 4(%esp)
+        movl    FFI_TRAMPOLINE_SIZE(%eax), %ebx         /* load cl->cif */
+        movl    %ebx, (%esp)
+        call    *FFI_TRAMPOLINE_SIZE+4(%eax)            /* call cl->fun */
 
-	movl	20(%ebx), %eax				/* load cif->flags */
-	andl	$X86_RET_TYPE_MASK, %eax
+        movl    20(%ebx), %eax                          /* load cif->flags */
+        andl    $X86_RET_TYPE_MASK, %eax
 #ifdef __PIC__
-	call	C(__x86.get_pc_thunk.bx)
+        call    C(__x86.get_pc_thunk.bx)
 L(pc4):
-	leal	L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx
+        leal    L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx
 #else
-	leal	L(load_table4)(,%eax, 8), %ecx
+        leal    L(load_table4)(,%eax, 8), %ecx
 #endif
-	movl	raw_closure_S_FS-4(%esp), %ebx
+        movl    raw_closure_S_FS-4(%esp), %ebx
 L(UW35):
-	# cfi_restore(%ebx)
-	movl	16(%esp), %eax				/* Optimistic load */
-	jmp	*%ecx
+        # cfi_restore(%ebx)
+        movl    16(%esp), %eax                          /* Optimistic load */
+        jmp     *%ecx
 
-	.balign	8
+        .balign 8
 L(load_table4):
 E(L(load_table4), X86_RET_FLOAT)
-	flds	16(%esp)
-	jmp	L(e4)
+        flds    16(%esp)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_DOUBLE)
-	fldl	16(%esp)
-	jmp	L(e4)
+        fldl    16(%esp)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_LDOUBLE)
-	fldt	16(%esp)
-	jmp	L(e4)
+        fldt    16(%esp)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT8)
-	movsbl	%al, %eax
-	jmp	L(e4)
+        movsbl  %al, %eax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT16)
-	movswl	%ax, %eax
-	jmp	L(e4)
+        movswl  %ax, %eax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT8)
-	movzbl	%al, %eax
-	jmp	L(e4)
+        movzbl  %al, %eax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT16)
-	movzwl	%ax, %eax
-	jmp	L(e4)
+        movzwl  %ax, %eax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_INT64)
-	movl	16+4(%esp), %edx
-	jmp	L(e4)
+        movl    16+4(%esp), %edx
+        jmp     L(e4)
 E(L(load_table4), X86_RET_INT32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table4), X86_RET_VOID)
 L(e4):
-	addl	$raw_closure_S_FS, %esp
+        addl    $raw_closure_S_FS, %esp
 L(UW36):
-	# cfi_adjust_cfa_offset(-raw_closure_S_FS)
-	ret
+        # cfi_adjust_cfa_offset(-raw_closure_S_FS)
+        ret
 L(UW37):
-	# cfi_adjust_cfa_offset(raw_closure_S_FS)
+        # cfi_adjust_cfa_offset(raw_closure_S_FS)
 E(L(load_table4), X86_RET_STRUCTPOP)
-	addl	$raw_closure_S_FS, %esp
+        addl    $raw_closure_S_FS, %esp
 L(UW38):
-	# cfi_adjust_cfa_offset(-raw_closure_S_FS)
-	ret	$4
+        # cfi_adjust_cfa_offset(-raw_closure_S_FS)
+        ret     $4
 L(UW39):
-	# cfi_adjust_cfa_offset(raw_closure_S_FS)
+        # cfi_adjust_cfa_offset(raw_closure_S_FS)
 E(L(load_table4), X86_RET_STRUCTARG)
-	jmp	L(e4)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_1B)
-	movzbl	%al, %eax
-	jmp	L(e4)
+        movzbl  %al, %eax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_2B)
-	movzwl	%ax, %eax
-	jmp	L(e4)
+        movzwl  %ax, %eax
+        jmp     L(e4)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table4), X86_RET_UNUSED14)
-	ud2
+        ud2
 E(L(load_table4), X86_RET_UNUSED15)
-	ud2
+        ud2
 
 L(UW40):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_closure_raw_SYSV))
 
-#define raw_closure_T_FS	(16+16+8)
+#define raw_closure_T_FS        (16+16+8)
 
-	.balign	16
-	.globl	C(ffi_closure_raw_THISCALL)
-	FFI_HIDDEN(C(ffi_closure_raw_THISCALL))
+        .balign 16
+        .globl  C(ffi_closure_raw_THISCALL)
+        FFI_HIDDEN(C(ffi_closure_raw_THISCALL))
 C(ffi_closure_raw_THISCALL):
 L(UW41):
-	# cfi_startproc
-	_CET_ENDBR
-	/* Rearrange the stack such that %ecx is the first argument.
-	   This means moving the return address.  */
-	popl	%edx
+        # cfi_startproc
+        _CET_ENDBR
+        /* Rearrange the stack such that %ecx is the first argument.
+           This means moving the return address.  */
+        popl    %edx
 L(UW42):
-	# cfi_def_cfa_offset(0)
-	# cfi_register(%eip, %edx)
-	pushl	%ecx
+        # cfi_def_cfa_offset(0)
+        # cfi_register(%eip, %edx)
+        pushl   %ecx
 L(UW43):
-	# cfi_adjust_cfa_offset(4)
-	pushl	%edx
+        # cfi_adjust_cfa_offset(4)
+        pushl   %edx
 L(UW44):
-	# cfi_adjust_cfa_offset(4)
-	# cfi_rel_offset(%eip, 0)
-	subl	$raw_closure_T_FS, %esp
+        # cfi_adjust_cfa_offset(4)
+        # cfi_rel_offset(%eip, 0)
+        subl    $raw_closure_T_FS, %esp
 L(UW45):
-	# cfi_adjust_cfa_offset(raw_closure_T_FS)
-	movl	%ebx, raw_closure_T_FS-4(%esp)
+        # cfi_adjust_cfa_offset(raw_closure_T_FS)
+        movl    %ebx, raw_closure_T_FS-4(%esp)
 L(UW46):
-	# cfi_rel_offset(%ebx, raw_closure_T_FS-4)
+        # cfi_rel_offset(%ebx, raw_closure_T_FS-4)
 
-	movl	FFI_TRAMPOLINE_SIZE+8(%eax), %edx	/* load cl->user_data */
-	movl	%edx, 12(%esp)
-	leal	raw_closure_T_FS+4(%esp), %edx		/* load raw_args */
-	movl	%edx, 8(%esp)
-	leal	16(%esp), %edx				/* load &res */
-	movl	%edx, 4(%esp)
-	movl	FFI_TRAMPOLINE_SIZE(%eax), %ebx		/* load cl->cif */
-	movl	%ebx, (%esp)
-	call	*FFI_TRAMPOLINE_SIZE+4(%eax)		/* call cl->fun */
+        movl    FFI_TRAMPOLINE_SIZE+8(%eax), %edx       /* load cl->user_data */
+        movl    %edx, 12(%esp)
+        leal    raw_closure_T_FS+4(%esp), %edx          /* load raw_args */
+        movl    %edx, 8(%esp)
+        leal    16(%esp), %edx                          /* load &res */
+        movl    %edx, 4(%esp)
+        movl    FFI_TRAMPOLINE_SIZE(%eax), %ebx         /* load cl->cif */
+        movl    %ebx, (%esp)
+        call    *FFI_TRAMPOLINE_SIZE+4(%eax)            /* call cl->fun */
 
-	movl	20(%ebx), %eax				/* load cif->flags */
-	andl	$X86_RET_TYPE_MASK, %eax
+        movl    20(%ebx), %eax                          /* load cif->flags */
+        andl    $X86_RET_TYPE_MASK, %eax
 #ifdef __PIC__
-	call	C(__x86.get_pc_thunk.bx)
+        call    C(__x86.get_pc_thunk.bx)
 L(pc5):
-	leal	L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx
+        leal    L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx
 #else
-	leal	L(load_table5)(,%eax, 8), %ecx
+        leal    L(load_table5)(,%eax, 8), %ecx
 #endif
-	movl	raw_closure_T_FS-4(%esp), %ebx
+        movl    raw_closure_T_FS-4(%esp), %ebx
 L(UW47):
-	# cfi_restore(%ebx)
-	movl	16(%esp), %eax				/* Optimistic load */
-	jmp	*%ecx
+        # cfi_restore(%ebx)
+        movl    16(%esp), %eax                          /* Optimistic load */
+        jmp     *%ecx
 
-	.balign	8
+        .balign 8
 L(load_table5):
 E(L(load_table5), X86_RET_FLOAT)
-	flds	16(%esp)
-	jmp	L(e5)
+        flds    16(%esp)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_DOUBLE)
-	fldl	16(%esp)
-	jmp	L(e5)
+        fldl    16(%esp)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_LDOUBLE)
-	fldt	16(%esp)
-	jmp	L(e5)
+        fldt    16(%esp)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT8)
-	movsbl	%al, %eax
-	jmp	L(e5)
+        movsbl  %al, %eax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT16)
-	movswl	%ax, %eax
-	jmp	L(e5)
+        movswl  %ax, %eax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT8)
-	movzbl	%al, %eax
-	jmp	L(e5)
+        movzbl  %al, %eax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT16)
-	movzwl	%ax, %eax
-	jmp	L(e5)
+        movzwl  %ax, %eax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_INT64)
-	movl	16+4(%esp), %edx
-	jmp	L(e5)
+        movl    16+4(%esp), %edx
+        jmp     L(e5)
 E(L(load_table5), X86_RET_INT32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table5), X86_RET_VOID)
 L(e5):
-	addl	$raw_closure_T_FS, %esp
+        addl    $raw_closure_T_FS, %esp
 L(UW48):
-	# cfi_adjust_cfa_offset(-raw_closure_T_FS)
-	/* Remove the extra %ecx argument we pushed.  */
-	ret	$4
+        # cfi_adjust_cfa_offset(-raw_closure_T_FS)
+        /* Remove the extra %ecx argument we pushed.  */
+        ret     $4
 L(UW49):
-	# cfi_adjust_cfa_offset(raw_closure_T_FS)
+        # cfi_adjust_cfa_offset(raw_closure_T_FS)
 E(L(load_table5), X86_RET_STRUCTPOP)
-	addl	$raw_closure_T_FS, %esp
+        addl    $raw_closure_T_FS, %esp
 L(UW50):
-	# cfi_adjust_cfa_offset(-raw_closure_T_FS)
-	ret	$8
+        # cfi_adjust_cfa_offset(-raw_closure_T_FS)
+        ret     $8
 L(UW51):
-	# cfi_adjust_cfa_offset(raw_closure_T_FS)
+        # cfi_adjust_cfa_offset(raw_closure_T_FS)
 E(L(load_table5), X86_RET_STRUCTARG)
-	jmp	L(e5)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_1B)
-	movzbl	%al, %eax
-	jmp	L(e5)
+        movzbl  %al, %eax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_2B)
-	movzwl	%ax, %eax
-	jmp	L(e5)
+        movzwl  %ax, %eax
+        jmp     L(e5)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table5), X86_RET_UNUSED14)
-	ud2
+        ud2
 E(L(load_table5), X86_RET_UNUSED15)
-	ud2
+        ud2
 
 L(UW52):
-	# cfi_endproc
+        # cfi_endproc
 ENDF(C(ffi_closure_raw_THISCALL))
 
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef X86_DARWIN
-# define COMDAT(X)							\
-        .section __TEXT,__text,coalesced,pure_instructions;		\
-        .weak_definition X;						\
+# define COMDAT(X)                                                      \
+        .section __TEXT,__text,coalesced,pure_instructions;             \
+        .weak_definition X;                                             \
         FFI_HIDDEN(X)
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
-# define COMDAT(X)							\
-	.section .text.X,"axG",@progbits,X,comdat;			\
-	.globl	X;							\
-	FFI_HIDDEN(X)
+# define COMDAT(X)                                                      \
+        .section .text.X,"axG",@progbits,X,comdat;                      \
+        .globl  X;                                                      \
+        FFI_HIDDEN(X)
 #else
 # define COMDAT(X)
 #endif
 
 #if defined(__PIC__)
-	COMDAT(C(__x86.get_pc_thunk.bx))
+        COMDAT(C(__x86.get_pc_thunk.bx))
 C(__x86.get_pc_thunk.bx):
-	movl	(%esp), %ebx
-	ret
+        movl    (%esp), %ebx
+        ret
 ENDF(C(__x86.get_pc_thunk.bx))
 # if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
-	COMDAT(C(__x86.get_pc_thunk.dx))
+        COMDAT(C(__x86.get_pc_thunk.dx))
 C(__x86.get_pc_thunk.dx):
-	movl	(%esp), %edx
-	ret
+        movl    (%esp), %edx
+        ret
 ENDF(C(__x86.get_pc_thunk.dx))
 #endif /* DARWIN || HIDDEN */
 #endif /* __PIC__ */
@@ -842,214 +930,214 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)	X - .
+# define PCREL(X)       X - .
 #else
-# define PCREL(X)	X@rel
+# define PCREL(X)       X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)	.byte 2, L(N)-L(P)
+#define ADV(N, P)       .byte 2, L(N)-L(P)
 
-	.balign 4
+        .balign 4
 L(CIE):
-	.set	L(set0),L(ECIE)-L(SCIE)
-	.long	L(set0)			/* CIE Length */
+        .set    L(set0),L(ECIE)-L(SCIE)
+        .long   L(set0)                 /* CIE Length */
 L(SCIE):
-	.long	0			/* CIE Identifier Tag */
-	.byte	1			/* CIE Version */
-	.ascii	"zR\0"			/* CIE Augmentation */
-	.byte	1			/* CIE Code Alignment Factor */
-	.byte	0x7c			/* CIE Data Alignment Factor */
-	.byte	0x8			/* CIE RA Column */
-	.byte	1			/* Augmentation size */
-	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp offset 4 */
-	.byte	0x80+8, 1		/* DW_CFA_offset, %eip offset 1*-4 */
-	.balign 4
+        .long   0                       /* CIE Identifier Tag */
+        .byte   1                       /* CIE Version */
+        .ascii  "zR\0"                  /* CIE Augmentation */
+        .byte   1                       /* CIE Code Alignment Factor */
+        .byte   0x7c                    /* CIE Data Alignment Factor */
+        .byte   0x8                     /* CIE RA Column */
+        .byte   1                       /* Augmentation size */
+        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp offset 4 */
+        .byte   0x80+8, 1               /* DW_CFA_offset, %eip offset 1*-4 */
+        .balign 4
 L(ECIE):
 
-	.set	L(set1),L(EFDE1)-L(SFDE1)
-	.long	L(set1)			/* FDE Length */
+        .set    L(set1),L(EFDE1)-L(SFDE1)
+        .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW0))		/* Initial location */
-	.long	L(UW5)-L(UW0)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW1, UW0)
-	.byte	0xc, 5, 8		/* DW_CFA_def_cfa, %ebp 8 */
-	.byte	0x80+5, 2		/* DW_CFA_offset, %ebp 2*-4 */
-	ADV(UW2, UW1)
-	.byte	0x80+3, 0		/* DW_CFA_offset, %ebx 0*-4 */
-	ADV(UW3, UW2)
-	.byte	0xa			/* DW_CFA_remember_state */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp 4 */
-	.byte	0xc0+3			/* DW_CFA_restore, %ebx */
-	.byte	0xc0+5			/* DW_CFA_restore, %ebp */
-	ADV(UW4, UW3)
-	.byte	0xb			/* DW_CFA_restore_state */
-	.balign	4
+        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW0))           /* Initial location */
+        .long   L(UW5)-L(UW0)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW1, UW0)
+        .byte   0xc, 5, 8               /* DW_CFA_def_cfa, %ebp 8 */
+        .byte   0x80+5, 2               /* DW_CFA_offset, %ebp 2*-4 */
+        ADV(UW2, UW1)
+        .byte   0x80+3, 0               /* DW_CFA_offset, %ebx 0*-4 */
+        ADV(UW3, UW2)
+        .byte   0xa                     /* DW_CFA_remember_state */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp 4 */
+        .byte   0xc0+3                  /* DW_CFA_restore, %ebx */
+        .byte   0xc0+5                  /* DW_CFA_restore, %ebp */
+        ADV(UW4, UW3)
+        .byte   0xb                     /* DW_CFA_restore_state */
+        .balign 4
 L(EFDE1):
 
-	.set	L(set2),L(EFDE2)-L(SFDE2)
-	.long	L(set2)			/* FDE Length */
+        .set    L(set2),L(EFDE2)-L(SFDE2)
+        .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW6))		/* Initial location */
-	.long	L(UW8)-L(UW6)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW7, UW6)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW6))           /* Initial location */
+        .long   L(UW8)-L(UW6)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW7, UW6)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE2):
 
-	.set	L(set3),L(EFDE3)-L(SFDE3)
-	.long	L(set3)			/* FDE Length */
+        .set    L(set3),L(EFDE3)-L(SFDE3)
+        .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW9))		/* Initial location */
-	.long	L(UW11)-L(UW9)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW10, UW9)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW9))           /* Initial location */
+        .long   L(UW11)-L(UW9)          /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW10, UW9)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE3):
 
-	.set	L(set4),L(EFDE4)-L(SFDE4)
-	.long	L(set4)			/* FDE Length */
+        .set    L(set4),L(EFDE4)-L(SFDE4)
+        .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW12))		/* Initial location */
-	.long	L(UW20)-L(UW12)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW13, UW12)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW12))          /* Initial location */
+        .long   L(UW20)-L(UW12)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW13, UW12)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
-	ADV(UW14, UW13)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
-	ADV(UW15, UW14)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW16, UW15)
+        ADV(UW14, UW13)
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        ADV(UW15, UW14)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW16, UW15)
 #else
-	ADV(UW16, UW13)
+        ADV(UW16, UW13)
 #endif
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW17, UW16)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW18, UW17)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW19, UW18)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW17, UW16)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        ADV(UW18, UW17)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW19, UW18)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE4):
 
-	.set	L(set5),L(EFDE5)-L(SFDE5)
-	.long	L(set5)			/* FDE Length */
+        .set    L(set5),L(EFDE5)-L(SFDE5)
+        .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW21))		/* Initial location */
-	.long	L(UW23)-L(UW21)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW22, UW21)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW21))          /* Initial location */
+        .long   L(UW23)-L(UW21)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW22, UW21)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE5):
 
-	.set	L(set6),L(EFDE6)-L(SFDE6)
-	.long	L(set6)			/* FDE Length */
+        .set    L(set6),L(EFDE6)-L(SFDE6)
+        .long   L(set6)                 /* FDE Length */
 L(SFDE6):
-	.long	L(SFDE6)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW24))		/* Initial location */
-	.long	L(UW26)-L(UW24)		/* Address range */
-	.byte	0			/* Augmentation size */
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip, 2*-4 */
-	ADV(UW25, UW24)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE6)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW24))          /* Initial location */
+        .long   L(UW26)-L(UW24)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip, 2*-4 */
+        ADV(UW25, UW24)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE6):
 
-	.set	L(set7),L(EFDE7)-L(SFDE7)
-	.long	L(set7)			/* FDE Length */
+        .set    L(set7),L(EFDE7)-L(SFDE7)
+        .long   L(set7)                 /* FDE Length */
 L(SFDE7):
-	.long	L(SFDE7)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW27))		/* Initial location */
-	.long	L(UW31)-L(UW27)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW28, UW27)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .long   L(SFDE7)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW27))          /* Initial location */
+        .long   L(UW31)-L(UW27)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW28, UW27)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
-	ADV(UW29, UW28)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
-	ADV(UW30, UW29)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        ADV(UW29, UW28)
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        ADV(UW30, UW29)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
 #endif
-	.balign	4
+        .balign 4
 L(EFDE7):
 
 #if !FFI_NO_RAW_API
-	.set	L(set8),L(EFDE8)-L(SFDE8)
-	.long	L(set8)			/* FDE Length */
+        .set    L(set8),L(EFDE8)-L(SFDE8)
+        .long   L(set8)                 /* FDE Length */
 L(SFDE8):
-	.long	L(SFDE8)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW32))		/* Initial location */
-	.long	L(UW40)-L(UW32)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW33, UW32)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW34, UW33)
-	.byte	0x80+3, 2		/* DW_CFA_offset %ebx 2*-4 */
-	ADV(UW35, UW34)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW36, UW35)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW37, UW36)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW38, UW37)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW39, UW38)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE8)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW32))          /* Initial location */
+        .long   L(UW40)-L(UW32)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW33, UW32)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        ADV(UW34, UW33)
+        .byte   0x80+3, 2               /* DW_CFA_offset %ebx 2*-4 */
+        ADV(UW35, UW34)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW36, UW35)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW37, UW36)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        ADV(UW38, UW37)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW39, UW38)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE8):
 
-	.set	L(set9),L(EFDE9)-L(SFDE9)
-	.long	L(set9)			/* FDE Length */
+        .set    L(set9),L(EFDE9)-L(SFDE9)
+        .long   L(set9)                 /* FDE Length */
 L(SFDE9):
-	.long	L(SFDE9)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW41))		/* Initial location */
-	.long	L(UW52)-L(UW41)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW42, UW41)
-	.byte	0xe, 0			/* DW_CFA_def_cfa_offset */
-	.byte	0x9, 8, 2		/* DW_CFA_register %eip, %edx */
-	ADV(UW43, UW42)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW44, UW43)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip 2*-4 */
-	ADV(UW45, UW44)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	ADV(UW46, UW45)
-	.byte	0x80+3, 3		/* DW_CFA_offset %ebx 3*-4 */
-	ADV(UW47, UW46)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW48, UW47)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	ADV(UW49, UW48)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	ADV(UW50, UW49)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	ADV(UW51, UW50)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE9)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW41))          /* Initial location */
+        .long   L(UW52)-L(UW41)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW42, UW41)
+        .byte   0xe, 0                  /* DW_CFA_def_cfa_offset */
+        .byte   0x9, 8, 2               /* DW_CFA_register %eip, %edx */
+        ADV(UW43, UW42)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW44, UW43)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip 2*-4 */
+        ADV(UW45, UW44)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        ADV(UW46, UW45)
+        .byte   0x80+3, 3               /* DW_CFA_offset %ebx 3*-4 */
+        ADV(UW47, UW46)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW48, UW47)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        ADV(UW49, UW48)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        ADV(UW50, UW49)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        ADV(UW51, UW50)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE9):
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef _WIN32
-	.def	 @feat.00;
-	.scl	3;
-	.type	0;
-	.endef
-	.globl	@feat.00
+        .def     @feat.00;
+        .scl    3;
+        .type   0;
+        .endef
+        .globl  @feat.00
 @feat.00 = 1
 #endif
 
@@ -1131,8 +1219,9 @@ L(EFDE9):
 #endif /* __APPLE__ */
 
 #endif /* ifndef _MSC_VER */
+
 #endif /* ifdef __i386__ */
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
@@ -45,15 +45,15 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	ALIGN 8
+# define E(BASE, X)     ALIGN 8
 #else
-# define E(BASE, X)	ALIGN 8; ORG BASE + X * 8
+# define E(BASE, X)     ALIGN 8; ORG BASE + X * 8
 #endif
 
     .686P
     .MODEL FLAT
 
-EXTRN	@ffi_closure_inner@8:PROC
+EXTRN   @ffi_closure_inner@8:PROC
 _TEXT SEGMENT
 
 /* This is declared as
@@ -71,209 +71,209 @@ ALIGN 16
 PUBLIC @ffi_call_i386@8
 @ffi_call_i386@8 PROC
 L(UW0):
-	cfi_startproc
+        cfi_startproc
  #if !HAVE_FASTCALL
-	mov	    ecx, [esp+4]
-	mov 	edx, [esp+8]
+        mov         ecx, [esp+4]
+        mov     edx, [esp+8]
  #endif
-	mov	    eax, [esp]		/* move the return address */
-	mov	    [ecx], ebp		/* store ebp into local frame */
-	mov 	[ecx+4], eax	/* store retaddr into local frame */
+        mov         eax, [esp]          /* move the return address */
+        mov         [ecx], ebp          /* store ebp into local frame */
+        mov     [ecx+4], eax    /* store retaddr into local frame */
 
-	/* New stack frame based off ebp.  This is a itty bit of unwind
-	   trickery in that the CFA *has* changed.  There is no easy way
-	   to describe it correctly on entry to the function.  Fortunately,
-	   it doesn't matter too much since at all points we can correctly
-	   unwind back to ffi_call.  Note that the location to which we
-	   moved the return address is (the new) CFA-4, so from the
-	   perspective of the unwind info, it hasn't moved.  */
-	mov 	ebp, ecx
+        /* New stack frame based off ebp.  This is a itty bit of unwind
+           trickery in that the CFA *has* changed.  There is no easy way
+           to describe it correctly on entry to the function.  Fortunately,
+           it doesn't matter too much since at all points we can correctly
+           unwind back to ffi_call.  Note that the location to which we
+           moved the return address is (the new) CFA-4, so from the
+           perspective of the unwind info, it hasn't moved.  */
+        mov     ebp, ecx
 L(UW1):
-	// cfi_def_cfa(%ebp, 8)
-	// cfi_rel_offset(%ebp, 0)
+        // cfi_def_cfa(%ebp, 8)
+        // cfi_rel_offset(%ebp, 0)
 
-	mov 	esp, edx		/* set outgoing argument stack */
-	mov 	eax, [20+R_EAX*4+ebp]	/* set register arguments */
-	mov 	edx, [20+R_EDX*4+ebp]
-	mov	    ecx, [20+R_ECX*4+ebp]
+        mov     esp, edx                /* set outgoing argument stack */
+        mov     eax, [20+R_EAX*4+ebp]   /* set register arguments */
+        mov     edx, [20+R_EDX*4+ebp]
+        mov         ecx, [20+R_ECX*4+ebp]
 
-	call	dword ptr [ebp+8]
+        call    dword ptr [ebp+8]
 
-	mov	    ecx, [12+ebp]		/* load return type code */
-	mov 	[ebp+8], ebx		/* preserve %ebx */
+        mov         ecx, [12+ebp]               /* load return type code */
+        mov     [ebp+8], ebx            /* preserve %ebx */
 L(UW2):
-	// cfi_rel_offset(%ebx, 8)
+        // cfi_rel_offset(%ebx, 8)
 
-	and 	ecx, X86_RET_TYPE_MASK
-	lea 	ebx, [L(store_table) + ecx * 8]
-	mov 	ecx, [ebp+16]		/* load result address */
-	jmp	    ebx
+        and     ecx, X86_RET_TYPE_MASK
+        lea     ebx, [L(store_table) + ecx * 8]
+        mov     ecx, [ebp+16]           /* load result address */
+        jmp         ebx
 
-	ALIGN	8
+        ALIGN   8
 L(store_table):
 E(L(store_table), X86_RET_FLOAT)
-	fstp	DWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    DWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_DOUBLE)
-	fstp	QWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    QWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_LDOUBLE)
-	fstp	QWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    QWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT8)
-	movsx	eax, al
-	mov	[ecx], eax
-	jmp	L(e1)
+        movsx   eax, al
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT16)
-	movsx	eax, ax
-	mov	[ecx], eax
-	jmp	L(e1)
+        movsx   eax, ax
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT8)
-	movzx	eax, al
-	mov	[ecx], eax
-	jmp	L(e1)
+        movzx   eax, al
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT16)
-	movzx	eax, ax
-	mov	[ecx], eax
-	jmp	L(e1)
+        movzx   eax, ax
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_INT64)
-	mov	[ecx+4], edx
-	/* fallthru */
+        mov     [ecx+4], edx
+        /* fallthru */
 E(L(store_table), X86_RET_int 32)
-	mov	[ecx], eax
-	/* fallthru */
+        mov     [ecx], eax
+        /* fallthru */
 E(L(store_table), X86_RET_VOID)
 L(e1):
-	mov	    ebx, [ebp+8]
-	mov	    esp, ebp
-	pop 	ebp
+        mov         ebx, [ebp+8]
+        mov         esp, ebp
+        pop     ebp
 L(UW3):
-	// cfi_remember_state
-	// cfi_def_cfa(%esp, 4)
-	// cfi_restore(%ebx)
-	// cfi_restore(%ebp)
-	ret
+        // cfi_remember_state
+        // cfi_def_cfa(%esp, 4)
+        // cfi_restore(%ebx)
+        // cfi_restore(%ebp)
+        ret
 L(UW4):
-	// cfi_restore_state
+        // cfi_restore_state
 
 E(L(store_table), X86_RET_STRUCTPOP)
-	jmp	    L(e1)
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCTARG)
-	jmp	    L(e1)
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCT_1B)
-	mov 	[ecx], al
-	jmp	    L(e1)
+        mov     [ecx], al
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCT_2B)
-	mov 	[ecx], ax
-	jmp	    L(e1)
+        mov     [ecx], ax
+        jmp         L(e1)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(store_table), X86_RET_UNUSED14)
-	int 3
+        int 3
 E(L(store_table), X86_RET_UNUSED15)
-	int 3
+        int 3
 
 L(UW5):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(@ffi_call_i386@8)
 
 /* The inner helper is declared as
 
    void ffi_closure_inner(struct closure_frame *frame, char *argp)
-	__attribute_((fastcall))
+        __attribute_((fastcall))
 
    Thus the arguments are placed in
 
-	ecx:	frame
-	edx:	argp
+        ecx:    frame
+        edx:    argp
 */
 
 /* Macros to help setting up the closure_data structure.  */
 
 #if HAVE_FASTCALL
-# define closure_FS	(40 + 4)
-# define closure_CF	0
+# define closure_FS     (40 + 4)
+# define closure_CF     0
 #else
-# define closure_FS	(8 + 40 + 12)
-# define closure_CF	8
+# define closure_FS     (8 + 40 + 12)
+# define closure_CF     8
 #endif
 
 FFI_CLOSURE_SAVE_REGS MACRO
-	mov 	[esp + closure_CF+16+R_EAX*4], eax
-	mov 	[esp + closure_CF+16+R_EDX*4], edx
-	mov 	[esp + closure_CF+16+R_ECX*4], ecx
+        mov     [esp + closure_CF+16+R_EAX*4], eax
+        mov     [esp + closure_CF+16+R_EDX*4], edx
+        mov     [esp + closure_CF+16+R_ECX*4], ecx
 ENDM
 
 FFI_CLOSURE_COPY_TRAMP_DATA MACRO
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
-	mov 	ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
-	mov 	eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], ecx
-	mov 	[esp+closure_CF+36], eax
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
+        mov     ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
+        mov     eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], ecx
+        mov     [esp+closure_CF+36], eax
 ENDM
 
 #if HAVE_FASTCALL
 FFI_CLOSURE_PREP_CALL MACRO
-	mov	    ecx, esp                    /* load closure_data */
-	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
+        mov         ecx, esp                    /* load closure_data */
+        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
 ENDM
 #else
 FFI_CLOSURE_PREP_CALL MACRO
-	lea 	ecx, [esp+closure_CF]       /* load closure_data */
-	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
-	mov 	[esp], ecx
-	mov 	[esp+4], edx
+        lea     ecx, [esp+closure_CF]       /* load closure_data */
+        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
+        mov     [esp], ecx
+        mov     [esp+4], edx
 ENDM
 #endif
 
 FFI_CLOSURE_CALL_INNER MACRO UWN
-	call	@ffi_closure_inner@8
+        call    @ffi_closure_inner@8
 ENDM
 
 FFI_CLOSURE_MASK_AND_JUMP MACRO LABEL
-	and	    eax, X86_RET_TYPE_MASK
-	lea 	edx, [LABEL+eax*8]
-	mov 	eax, [esp+closure_CF]       /* optimiztic load */
-	jmp	    edx
+        and         eax, X86_RET_TYPE_MASK
+        lea     edx, [LABEL+eax*8]
+        mov     eax, [esp+closure_CF]       /* optimiztic load */
+        jmp         edx
 ENDM
 
 ALIGN 16
 PUBLIC ffi_go_closure_EAX
 ffi_go_closure_EAX PROC C
 L(UW6):
-	// cfi_startproc
-	sub	esp, closure_FS
+        // cfi_startproc
+        sub     esp, closure_FS
 L(UW7):
-	// cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	mov     edx, [eax+4]			/* copy cif */
-	mov 	ecx, [eax +8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], ecx
-	mov 	[esp+closure_CF+36], eax	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        // cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        mov     edx, [eax+4]                    /* copy cif */
+        mov     ecx, [eax +8]                   /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], ecx
+        mov     [esp+closure_CF+36], eax        /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW8):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_go_closure_EAX)
 
 ALIGN 16
 PUBLIC ffi_go_closure_ECX
 ffi_go_closure_ECX PROC C
 L(UW9):
-	// cfi_startproc
-	sub 	esp, closure_FS
+        // cfi_startproc
+        sub     esp, closure_FS
 L(UW10):
-	// cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	mov 	edx, [ecx+4]			/* copy cif */
-	mov 	eax, [ecx+8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], eax
-	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        // cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        mov     edx, [ecx+4]                    /* copy cif */
+        mov     eax, [ecx+8]                    /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], eax
+        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW11):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_go_closure_ECX)
 
 /* The closure entry points are reached from the ffi_closure trampoline.
@@ -283,101 +283,101 @@ ALIGN 16
 PUBLIC ffi_closure_i386
 ffi_closure_i386 PROC C
 L(UW12):
-	// cfi_startproc
-	sub	    esp, closure_FS
+        // cfi_startproc
+        sub         esp, closure_FS
 L(UW13):
-	// cfi_def_cfa_offset(closure_FS + 4)
+        // cfi_def_cfa_offset(closure_FS + 4)
 
-	FFI_CLOSURE_SAVE_REGS
-	FFI_CLOSURE_COPY_TRAMP_DATA
+        FFI_CLOSURE_SAVE_REGS
+        FFI_CLOSURE_COPY_TRAMP_DATA
 
-	/* Entry point from preceeding Go closures.  */
+        /* Entry point from preceeding Go closures.  */
 L(do_closure_i386)::
 
-	FFI_CLOSURE_PREP_CALL
-	FFI_CLOSURE_CALL_INNER(14)
-	FFI_CLOSURE_MASK_AND_JUMP L(C1(load_table,2))
+        FFI_CLOSURE_PREP_CALL
+        FFI_CLOSURE_CALL_INNER(14)
+        FFI_CLOSURE_MASK_AND_JUMP L(C1(load_table,2))
 
     ALIGN 8
 L(load_table2):
 E(L(load_table2), X86_RET_FLOAT)
-	fld 	dword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     dword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_DOUBLE)
-	fld 	qword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     qword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_LDOUBLE)
-	fld 	qword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     qword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e2)
+        movsx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e2)
+        movsx   eax, ax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e2)
+        movzx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e2)
+        movzx   eax, ax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT64)
-	mov 	edx, [esp+closure_CF+4]
-	jmp	L(e2)
+        mov     edx, [esp+closure_CF+4]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table2), X86_RET_VOID)
 L(e2):
-	add 	esp, closure_FS
+        add     esp, closure_FS
 L(UW16):
-	// cfi_adjust_cfa_offset(-closure_FS)
-	ret
+        // cfi_adjust_cfa_offset(-closure_FS)
+        ret
 L(UW17):
-	// cfi_adjust_cfa_offset(closure_FS)
+        // cfi_adjust_cfa_offset(closure_FS)
 E(L(load_table2), X86_RET_STRUCTPOP)
-	add 	esp, closure_FS
+        add     esp, closure_FS
 L(UW18):
-	// cfi_adjust_cfa_offset(-closure_FS)
-	ret	4
+        // cfi_adjust_cfa_offset(-closure_FS)
+        ret     4
 L(UW19):
-	// cfi_adjust_cfa_offset(closure_FS)
+        // cfi_adjust_cfa_offset(closure_FS)
 E(L(load_table2), X86_RET_STRUCTARG)
-	jmp	L(e2)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e2)
+        movzx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e2)
+        movzx   eax, ax
+        jmp     L(e2)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table2), X86_RET_UNUSED14)
-	int 3
+        int 3
 E(L(load_table2), X86_RET_UNUSED15)
-	int 3
+        int 3
 
 L(UW20):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_closure_i386)
 
 ALIGN 16
-PUBLIC	ffi_go_closure_STDCALL
+PUBLIC  ffi_go_closure_STDCALL
 ffi_go_closure_STDCALL PROC C
 L(UW21):
-	// cfi_startproc
-	sub 	esp, closure_FS
+        // cfi_startproc
+        sub     esp, closure_FS
 L(UW22):
-	// cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	mov 	edx, [ecx+4]			/* copy cif */
-	mov 	eax, [ecx+8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], eax
-	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
-	jmp	L(do_closure_STDCALL)
+        // cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        mov     edx, [ecx+4]                    /* copy cif */
+        mov     eax, [ecx+8]                    /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], eax
+        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
+        jmp     L(do_closure_STDCALL)
 L(UW23):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_go_closure_STDCALL)
 
 /* For REGISTER, we have no available parameter registers, and so we
@@ -387,19 +387,19 @@ ALIGN 16
 PUBLIC ffi_closure_REGISTER
 ffi_closure_REGISTER PROC C
 L(UW24):
-	// cfi_startproc
-	// cfi_def_cfa(%esp, 8)
-	// cfi_offset(%eip, -8)
-	sub 	esp, closure_FS-4
+        // cfi_startproc
+        // cfi_def_cfa(%esp, 8)
+        // cfi_offset(%eip, -8)
+        sub     esp, closure_FS-4
 L(UW25):
-	// cfi_def_cfa_offset(closure_FS + 4)
-	FFI_CLOSURE_SAVE_REGS
-	mov	ecx, [esp+closure_FS-4] 	/* load retaddr */
-	mov	eax, [esp+closure_FS]		/* load closure */
-	mov	[esp+closure_FS], ecx		/* move retaddr */
-	jmp	L(do_closure_REGISTER)
+        // cfi_def_cfa_offset(closure_FS + 4)
+        FFI_CLOSURE_SAVE_REGS
+        mov     ecx, [esp+closure_FS-4]         /* load retaddr */
+        mov     eax, [esp+closure_FS]           /* load closure */
+        mov     [esp+closure_FS], ecx           /* move retaddr */
+        jmp     L(do_closure_REGISTER)
 L(UW26):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_closure_REGISTER)
 
 /* For STDCALL (and others), we need to pop N bytes of arguments off
@@ -410,350 +410,350 @@ ALIGN 16
 PUBLIC ffi_closure_STDCALL
 ffi_closure_STDCALL PROC C
 L(UW27):
-	// cfi_startproc
-	sub 	esp, closure_FS
+        // cfi_startproc
+        sub     esp, closure_FS
 L(UW28):
-	// cfi_def_cfa_offset(closure_FS + 4)
+        // cfi_def_cfa_offset(closure_FS + 4)
 
-	FFI_CLOSURE_SAVE_REGS
+        FFI_CLOSURE_SAVE_REGS
 
-	/* Entry point from ffi_closure_REGISTER.  */
+        /* Entry point from ffi_closure_REGISTER.  */
 L(do_closure_REGISTER)::
 
-	FFI_CLOSURE_COPY_TRAMP_DATA
+        FFI_CLOSURE_COPY_TRAMP_DATA
 
-	/* Entry point from preceeding Go closure.  */
+        /* Entry point from preceeding Go closure.  */
 L(do_closure_STDCALL)::
 
-	FFI_CLOSURE_PREP_CALL
-	FFI_CLOSURE_CALL_INNER(29)
+        FFI_CLOSURE_PREP_CALL
+        FFI_CLOSURE_CALL_INNER(29)
 
-	mov 	ecx, eax
-	shr 	ecx, X86_RET_POP_SHIFT	    /* isolate pop count */
-	lea 	ecx, [esp+closure_FS+ecx]	/* compute popped esp */
-	mov 	edx, [esp+closure_FS]		/* move return address */
-	mov 	[ecx], edx
+        mov     ecx, eax
+        shr     ecx, X86_RET_POP_SHIFT      /* isolate pop count */
+        lea     ecx, [esp+closure_FS+ecx]       /* compute popped esp */
+        mov     edx, [esp+closure_FS]           /* move return address */
+        mov     [ecx], edx
 
-	/* From this point on, the value of %esp upon return is %ecx+4,
-	   and we've copied the return address to %ecx to make return easy.
-	   There's no point in representing this in the unwind info, as
-	   there is always a window between the mov and the ret which
-	   will be wrong from one point of view or another.  */
+        /* From this point on, the value of %esp upon return is %ecx+4,
+           and we've copied the return address to %ecx to make return easy.
+           There's no point in representing this in the unwind info, as
+           there is always a window between the mov and the ret which
+           will be wrong from one point of view or another.  */
 
-	FFI_CLOSURE_MASK_AND_JUMP  L(C1(load_table,3))
+        FFI_CLOSURE_MASK_AND_JUMP  L(C1(load_table,3))
 
     ALIGN 8
 L(load_table3):
 E(L(load_table3), X86_RET_FLOAT)
-	fld    DWORD PTR [esp+closure_CF]
-	mov     esp, ecx
-	ret
+        fld    DWORD PTR [esp+closure_CF]
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_DOUBLE)
-	fld    QWORD PTR [esp+closure_CF]
-	mov     esp, ecx
-	ret
+        fld    QWORD PTR [esp+closure_CF]
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_LDOUBLE)
-	fld    QWORD PTR [esp+closure_CF]
-	mov     esp, ecx
-	ret
+        fld    QWORD PTR [esp+closure_CF]
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_SINT8)
-	movsx   eax, al
-	mov     esp, ecx
-	ret
+        movsx   eax, al
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_SINT16)
-	movsx   eax, ax
-	mov     esp, ecx
-	ret
+        movsx   eax, ax
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_UINT8)
-	movzx   eax, al
-	mov     esp, ecx
-	ret
+        movzx   eax, al
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_UINT16)
-	movzx   eax, ax
-	mov     esp, ecx
-	ret
+        movzx   eax, ax
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_INT64)
-	mov 	edx, [esp+closure_CF+4]
-	mov     esp, ecx
-	ret
+        mov     edx, [esp+closure_CF+4]
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_int 32)
-	mov     esp, ecx
-	ret
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_VOID)
-	mov     esp, ecx
-	ret
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_STRUCTPOP)
-	mov     esp, ecx
-	ret
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_STRUCTARG)
-	mov 	esp, ecx
-	ret
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	mov 	esp, ecx
-	ret
+        movzx   eax, al
+        mov     esp, ecx
+        ret
 E(L(load_table3), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	mov 	esp, ecx
-	ret
+        movzx   eax, ax
+        mov     esp, ecx
+        ret
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table3), X86_RET_UNUSED14)
-	int 3
+        int 3
 E(L(load_table3), X86_RET_UNUSED15)
-	int 3
+        int 3
 
 L(UW31):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_closure_STDCALL)
 
 #if !FFI_NO_RAW_API
 
-#define raw_closure_S_FS	(16+16+12)
+#define raw_closure_S_FS        (16+16+12)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_SYSV
 ffi_closure_raw_SYSV PROC C
 L(UW32):
-	// cfi_startproc
-	sub 	esp, raw_closure_S_FS
+        // cfi_startproc
+        sub     esp, raw_closure_S_FS
 L(UW33):
-	// cfi_def_cfa_offset(raw_closure_S_FS + 4)
-	mov 	[esp+raw_closure_S_FS-4], ebx
+        // cfi_def_cfa_offset(raw_closure_S_FS + 4)
+        mov     [esp+raw_closure_S_FS-4], ebx
 L(UW34):
-	// cfi_rel_offset(%ebx, raw_closure_S_FS-4)
+        // cfi_rel_offset(%ebx, raw_closure_S_FS-4)
 
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
-	mov 	[esp+12], edx
-	lea 	edx, [esp+raw_closure_S_FS+4]		/* load raw_args */
-	mov 	[esp+8], edx
-	lea 	edx, [esp+16]				/* load &res */
-	mov 	[esp+4], edx
-	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
-	mov 	[esp], ebx
-	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
+        mov     [esp+12], edx
+        lea     edx, [esp+raw_closure_S_FS+4]           /* load raw_args */
+        mov     [esp+8], edx
+        lea     edx, [esp+16]                           /* load &res */
+        mov     [esp+4], edx
+        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
+        mov     [esp], ebx
+        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
 
-	mov 	eax, [ebx+20]			/* load cif->flags */
-	and 	eax, X86_RET_TYPE_MASK
+        mov     eax, [ebx+20]                   /* load cif->flags */
+        and     eax, X86_RET_TYPE_MASK
 // #ifdef __PIC__
-// 	call	__x86.get_pc_thunk.bx
+//      call    __x86.get_pc_thunk.bx
 // L(pc4):
-// 	lea 	ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx
+//      lea     ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx
 // #else
-	lea 	ecx, [L(load_table4)+eax+8]
+        lea     ecx, [L(load_table4)+eax+8]
 // #endif
-	mov 	ebx, [esp+raw_closure_S_FS-4]
+        mov     ebx, [esp+raw_closure_S_FS-4]
 L(UW35):
-	// cfi_restore(%ebx)
-	mov 	eax, [esp+16]				/* Optimistic load */
-	jmp	    dword ptr [ecx]
+        // cfi_restore(%ebx)
+        mov     eax, [esp+16]                           /* Optimistic load */
+        jmp         dword ptr [ecx]
 
-	ALIGN 8
+        ALIGN 8
 L(load_table4):
 E(L(load_table4), X86_RET_FLOAT)
-	fld 	DWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     DWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_DOUBLE)
-	fld 	QWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_LDOUBLE)
-	fld 	QWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e4)
+        movsx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e4)
+        movsx   eax, ax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e4)
+        movzx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e4)
+        movzx   eax, ax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_INT64)
-	mov 	edx, [esp+16+4]
-	jmp	L(e4)
+        mov     edx, [esp+16+4]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_int 32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table4), X86_RET_VOID)
 L(e4):
-	add 	esp, raw_closure_S_FS
+        add     esp, raw_closure_S_FS
 L(UW36):
-	// cfi_adjust_cfa_offset(-raw_closure_S_FS)
-	ret
+        // cfi_adjust_cfa_offset(-raw_closure_S_FS)
+        ret
 L(UW37):
-	// cfi_adjust_cfa_offset(raw_closure_S_FS)
+        // cfi_adjust_cfa_offset(raw_closure_S_FS)
 E(L(load_table4), X86_RET_STRUCTPOP)
-	add 	esp, raw_closure_S_FS
+        add     esp, raw_closure_S_FS
 L(UW38):
-	// cfi_adjust_cfa_offset(-raw_closure_S_FS)
-	ret	4
+        // cfi_adjust_cfa_offset(-raw_closure_S_FS)
+        ret     4
 L(UW39):
-	// cfi_adjust_cfa_offset(raw_closure_S_FS)
+        // cfi_adjust_cfa_offset(raw_closure_S_FS)
 E(L(load_table4), X86_RET_STRUCTARG)
-	jmp	L(e4)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e4)
+        movzx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e4)
+        movzx   eax, ax
+        jmp     L(e4)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table4), X86_RET_UNUSED14)
-	int 3
+        int 3
 E(L(load_table4), X86_RET_UNUSED15)
-	int 3
+        int 3
 
 L(UW40):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_closure_raw_SYSV)
 
-#define raw_closure_T_FS	(16+16+8)
+#define raw_closure_T_FS        (16+16+8)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_THISCALL
 ffi_closure_raw_THISCALL PROC C
 L(UW41):
-	// cfi_startproc
-	/* Rearrange the stack such that %ecx is the first argument.
-	   This means moving the return address.  */
-	pop 	edx
+        // cfi_startproc
+        /* Rearrange the stack such that %ecx is the first argument.
+           This means moving the return address.  */
+        pop     edx
 L(UW42):
-	// cfi_def_cfa_offset(0)
-	// cfi_register(%eip, %edx)
-	push	ecx
+        // cfi_def_cfa_offset(0)
+        // cfi_register(%eip, %edx)
+        push    ecx
 L(UW43):
-	// cfi_adjust_cfa_offset(4)
-	push 	edx
+        // cfi_adjust_cfa_offset(4)
+        push    edx
 L(UW44):
-	// cfi_adjust_cfa_offset(4)
-	// cfi_rel_offset(%eip, 0)
-	sub 	esp, raw_closure_T_FS
+        // cfi_adjust_cfa_offset(4)
+        // cfi_rel_offset(%eip, 0)
+        sub     esp, raw_closure_T_FS
 L(UW45):
-	// cfi_adjust_cfa_offset(raw_closure_T_FS)
-	mov 	[esp+raw_closure_T_FS-4], ebx
+        // cfi_adjust_cfa_offset(raw_closure_T_FS)
+        mov     [esp+raw_closure_T_FS-4], ebx
 L(UW46):
-	// cfi_rel_offset(%ebx, raw_closure_T_FS-4)
+        // cfi_rel_offset(%ebx, raw_closure_T_FS-4)
 
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
-	mov 	[esp+12], edx
-	lea 	edx, [esp+raw_closure_T_FS+4]		/* load raw_args */
-	mov 	[esp+8], edx
-	lea 	edx, [esp+16]				/* load &res */
-	mov 	[esp+4], edx
-	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
-	mov 	[esp], ebx
-	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
+        mov     [esp+12], edx
+        lea     edx, [esp+raw_closure_T_FS+4]           /* load raw_args */
+        mov     [esp+8], edx
+        lea     edx, [esp+16]                           /* load &res */
+        mov     [esp+4], edx
+        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
+        mov     [esp], ebx
+        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
 
-	mov 	eax, [ebx+20]				/* load cif->flags */
-	and 	eax, X86_RET_TYPE_MASK
+        mov     eax, [ebx+20]                           /* load cif->flags */
+        and     eax, X86_RET_TYPE_MASK
 // #ifdef __PIC__
-// 	call	__x86.get_pc_thunk.bx
+//      call    __x86.get_pc_thunk.bx
 // L(pc5):
-// 	leal	L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx
+//      leal    L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx
 // #else
-	lea 	ecx, [L(load_table5)+eax*8]
+        lea     ecx, [L(load_table5)+eax*8]
 //#endif
-	mov 	ebx, [esp+raw_closure_T_FS-4]
+        mov     ebx, [esp+raw_closure_T_FS-4]
 L(UW47):
-	// cfi_restore(%ebx)
-	mov 	eax, [esp+16]				/* Optimistic load */
-	jmp	    DWORD PTR [ecx]
+        // cfi_restore(%ebx)
+        mov     eax, [esp+16]                           /* Optimistic load */
+        jmp         DWORD PTR [ecx]
 
-	AlIGN 4
+        AlIGN 4
 L(load_table5):
 E(L(load_table5), X86_RET_FLOAT)
-	fld	DWORD PTR [esp +16]
-	jmp	L(e5)
+        fld     DWORD PTR [esp +16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_DOUBLE)
-	fld	QWORD PTR [esp +16]
-	jmp	L(e5)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_LDOUBLE)
-	fld	QWORD PTR [esp+16]
-	jmp	L(e5)
+        fld     QWORD PTR [esp+16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e5)
+        movsx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e5)
+        movsx   eax, ax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e5)
+        movzx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e5)
+        movzx   eax, ax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_INT64)
-	mov 	edx, [esp+16+4]
-	jmp	L(e5)
+        mov     edx, [esp+16+4]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_int 32)
-	nop
-	/* fallthru */
+        nop
+        /* fallthru */
 E(L(load_table5), X86_RET_VOID)
 L(e5):
-	add 	esp, raw_closure_T_FS
+        add     esp, raw_closure_T_FS
 L(UW48):
-	// cfi_adjust_cfa_offset(-raw_closure_T_FS)
-	/* Remove the extra %ecx argument we pushed.  */
-	ret	4
+        // cfi_adjust_cfa_offset(-raw_closure_T_FS)
+        /* Remove the extra %ecx argument we pushed.  */
+        ret     4
 L(UW49):
-	// cfi_adjust_cfa_offset(raw_closure_T_FS)
+        // cfi_adjust_cfa_offset(raw_closure_T_FS)
 E(L(load_table5), X86_RET_STRUCTPOP)
-	add 	esp, raw_closure_T_FS
+        add     esp, raw_closure_T_FS
 L(UW50):
-	// cfi_adjust_cfa_offset(-raw_closure_T_FS)
-	ret	8
+        // cfi_adjust_cfa_offset(-raw_closure_T_FS)
+        ret     8
 L(UW51):
-	// cfi_adjust_cfa_offset(raw_closure_T_FS)
+        // cfi_adjust_cfa_offset(raw_closure_T_FS)
 E(L(load_table5), X86_RET_STRUCTARG)
-	jmp	L(e5)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e5)
+        movzx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e5)
+        movzx   eax, ax
+        jmp     L(e5)
 
-	/* Fill out the table so that bad values are predictable.  */
+        /* Fill out the table so that bad values are predictable.  */
 E(L(load_table5), X86_RET_UNUSED14)
-	int 3
+        int 3
 E(L(load_table5), X86_RET_UNUSED15)
-	int 3
+        int 3
 
 L(UW52):
-	// cfi_endproc
+        // cfi_endproc
 ENDF(ffi_closure_raw_THISCALL)
 
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef X86_DARWIN
-# define COMDAT(X)							\
-        .section __TEXT,__text,coalesced,pure_instructions;		\
-        .weak_definition X;						\
+# define COMDAT(X)                                                      \
+        .section __TEXT,__text,coalesced,pure_instructions;             \
+        .weak_definition X;                                             \
         FFI_HIDDEN(X)
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
-# define COMDAT(X)							\
-	.section .text.X,"axG",@progbits,X,comdat;			\
-	PUBLIC	X;							\
-	FFI_HIDDEN(X)
+# define COMDAT(X)                                                      \
+        .section .text.X,"axG",@progbits,X,comdat;                      \
+        PUBLIC  X;                                                      \
+        FFI_HIDDEN(X)
 #else
 # define COMDAT(X)
 #endif
 
 // #if defined(__PIC__)
-// 	COMDAT(C(__x86.get_pc_thunk.bx))
+//      COMDAT(C(__x86.get_pc_thunk.bx))
 // C(__x86.get_pc_thunk.bx):
-// 	movl	(%esp), %ebx
-// 	ret
+//      movl    (%esp), %ebx
+//      ret
 // ENDF(C(__x86.get_pc_thunk.bx))
 // # if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
-// 	COMDAT(C(__x86.get_pc_thunk.dx))
+//      COMDAT(C(__x86.get_pc_thunk.dx))
 // C(__x86.get_pc_thunk.dx):
-// 	movl	(%esp), %edx
-// 	ret
+//      movl    (%esp), %edx
+//      ret
 // ENDF(C(__x86.get_pc_thunk.dx))
 // #endif /* DARWIN || HIDDEN */
 // #endif /* __PIC__ */
@@ -773,214 +773,214 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)	X - .
+# define PCREL(X)       X - .
 #else
-# define PCREL(X)	X@rel
+# define PCREL(X)       X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)	.byte 2, L(N)-L(P)
+#define ADV(N, P)       .byte 2, L(N)-L(P)
 
-	.balign 4
+        .balign 4
 L(CIE):
-	.set	L(set0),L(ECIE)-L(SCIE)
-	.long	L(set0)			/* CIE Length */
+        .set    L(set0),L(ECIE)-L(SCIE)
+        .long   L(set0)                 /* CIE Length */
 L(SCIE):
-	.long	0			/* CIE Identifier Tag */
-	.byte	1			/* CIE Version */
-	.ascii	"zR\0"			/* CIE Augmentation */
-	.byte	1			/* CIE Code Alignment Factor */
-	.byte	0x7c			/* CIE Data Alignment Factor */
-	.byte	0x8			/* CIE RA Column */
-	.byte	1			/* Augmentation size */
-	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp offset 4 */
-	.byte	0x80+8, 1		/* DW_CFA_offset, %eip offset 1*-4 */
-	.balign 4
+        .long   0                       /* CIE Identifier Tag */
+        .byte   1                       /* CIE Version */
+        .ascii  "zR\0"                  /* CIE Augmentation */
+        .byte   1                       /* CIE Code Alignment Factor */
+        .byte   0x7c                    /* CIE Data Alignment Factor */
+        .byte   0x8                     /* CIE RA Column */
+        .byte   1                       /* Augmentation size */
+        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp offset 4 */
+        .byte   0x80+8, 1               /* DW_CFA_offset, %eip offset 1*-4 */
+        .balign 4
 L(ECIE):
 
-	.set	L(set1),L(EFDE1)-L(SFDE1)
-	.long	L(set1)			/* FDE Length */
+        .set    L(set1),L(EFDE1)-L(SFDE1)
+        .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW0))		/* Initial location */
-	.long	L(UW5)-L(UW0)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW1, UW0)
-	.byte	0xc, 5, 8		/* DW_CFA_def_cfa, %ebp 8 */
-	.byte	0x80+5, 2		/* DW_CFA_offset, %ebp 2*-4 */
-	ADV(UW2, UW1)
-	.byte	0x80+3, 0		/* DW_CFA_offset, %ebx 0*-4 */
-	ADV(UW3, UW2)
-	.byte	0xa			/* DW_CFA_remember_state */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp 4 */
-	.byte	0xc0+3			/* DW_CFA_restore, %ebx */
-	.byte	0xc0+5			/* DW_CFA_restore, %ebp */
-	ADV(UW4, UW3)
-	.byte	0xb			/* DW_CFA_restore_state */
-	.balign	4
+        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW0))           /* Initial location */
+        .long   L(UW5)-L(UW0)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW1, UW0)
+        .byte   0xc, 5, 8               /* DW_CFA_def_cfa, %ebp 8 */
+        .byte   0x80+5, 2               /* DW_CFA_offset, %ebp 2*-4 */
+        ADV(UW2, UW1)
+        .byte   0x80+3, 0               /* DW_CFA_offset, %ebx 0*-4 */
+        ADV(UW3, UW2)
+        .byte   0xa                     /* DW_CFA_remember_state */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp 4 */
+        .byte   0xc0+3                  /* DW_CFA_restore, %ebx */
+        .byte   0xc0+5                  /* DW_CFA_restore, %ebp */
+        ADV(UW4, UW3)
+        .byte   0xb                     /* DW_CFA_restore_state */
+        .balign 4
 L(EFDE1):
 
-	.set	L(set2),L(EFDE2)-L(SFDE2)
-	.long	L(set2)			/* FDE Length */
+        .set    L(set2),L(EFDE2)-L(SFDE2)
+        .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW6))		/* Initial location */
-	.long	L(UW8)-L(UW6)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW7, UW6)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW6))           /* Initial location */
+        .long   L(UW8)-L(UW6)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW7, UW6)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE2):
 
-	.set	L(set3),L(EFDE3)-L(SFDE3)
-	.long	L(set3)			/* FDE Length */
+        .set    L(set3),L(EFDE3)-L(SFDE3)
+        .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW9))		/* Initial location */
-	.long	L(UW11)-L(UW9)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW10, UW9)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW9))           /* Initial location */
+        .long   L(UW11)-L(UW9)          /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW10, UW9)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE3):
 
-	.set	L(set4),L(EFDE4)-L(SFDE4)
-	.long	L(set4)			/* FDE Length */
+        .set    L(set4),L(EFDE4)-L(SFDE4)
+        .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW12))		/* Initial location */
-	.long	L(UW20)-L(UW12)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW13, UW12)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW12))          /* Initial location */
+        .long   L(UW20)-L(UW12)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW13, UW12)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
-	ADV(UW14, UW13)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
-	ADV(UW15, UW14)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW16, UW15)
+        ADV(UW14, UW13)
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        ADV(UW15, UW14)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW16, UW15)
 #else
-	ADV(UW16, UW13)
+        ADV(UW16, UW13)
 #endif
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW17, UW16)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW18, UW17)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW19, UW18)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW17, UW16)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        ADV(UW18, UW17)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW19, UW18)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE4):
 
-	.set	L(set5),L(EFDE5)-L(SFDE5)
-	.long	L(set5)			/* FDE Length */
+        .set    L(set5),L(EFDE5)-L(SFDE5)
+        .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW21))		/* Initial location */
-	.long	L(UW23)-L(UW21)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW22, UW21)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW21))          /* Initial location */
+        .long   L(UW23)-L(UW21)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW22, UW21)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE5):
 
-	.set	L(set6),L(EFDE6)-L(SFDE6)
-	.long	L(set6)			/* FDE Length */
+        .set    L(set6),L(EFDE6)-L(SFDE6)
+        .long   L(set6)                 /* FDE Length */
 L(SFDE6):
-	.long	L(SFDE6)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW24))		/* Initial location */
-	.long	L(UW26)-L(UW24)		/* Address range */
-	.byte	0			/* Augmentation size */
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip, 2*-4 */
-	ADV(UW25, UW24)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE6)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW24))          /* Initial location */
+        .long   L(UW26)-L(UW24)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip, 2*-4 */
+        ADV(UW25, UW24)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE6):
 
-	.set	L(set7),L(EFDE7)-L(SFDE7)
-	.long	L(set7)			/* FDE Length */
+        .set    L(set7),L(EFDE7)-L(SFDE7)
+        .long   L(set7)                 /* FDE Length */
 L(SFDE7):
-	.long	L(SFDE7)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW27))		/* Initial location */
-	.long	L(UW31)-L(UW27)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW28, UW27)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .long   L(SFDE7)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW27))          /* Initial location */
+        .long   L(UW31)-L(UW27)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW28, UW27)
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
-	ADV(UW29, UW28)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
-	ADV(UW30, UW29)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        ADV(UW29, UW28)
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        ADV(UW30, UW29)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
 #endif
-	.balign	4
+        .balign 4
 L(EFDE7):
 
 #if !FFI_NO_RAW_API
-	.set	L(set8),L(EFDE8)-L(SFDE8)
-	.long	L(set8)			/* FDE Length */
+        .set    L(set8),L(EFDE8)-L(SFDE8)
+        .long   L(set8)                 /* FDE Length */
 L(SFDE8):
-	.long	L(SFDE8)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW32))		/* Initial location */
-	.long	L(UW40)-L(UW32)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW33, UW32)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW34, UW33)
-	.byte	0x80+3, 2		/* DW_CFA_offset %ebx 2*-4 */
-	ADV(UW35, UW34)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW36, UW35)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW37, UW36)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	ADV(UW38, UW37)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW39, UW38)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE8)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW32))          /* Initial location */
+        .long   L(UW40)-L(UW32)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW33, UW32)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        ADV(UW34, UW33)
+        .byte   0x80+3, 2               /* DW_CFA_offset %ebx 2*-4 */
+        ADV(UW35, UW34)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW36, UW35)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW37, UW36)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        ADV(UW38, UW37)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW39, UW38)
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE8):
 
-	.set	L(set9),L(EFDE9)-L(SFDE9)
-	.long	L(set9)			/* FDE Length */
+        .set    L(set9),L(EFDE9)-L(SFDE9)
+        .long   L(set9)                 /* FDE Length */
 L(SFDE9):
-	.long	L(SFDE9)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW41))		/* Initial location */
-	.long	L(UW52)-L(UW41)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW42, UW41)
-	.byte	0xe, 0			/* DW_CFA_def_cfa_offset */
-	.byte	0x9, 8, 2		/* DW_CFA_register %eip, %edx */
-	ADV(UW43, UW42)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
-	ADV(UW44, UW43)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip 2*-4 */
-	ADV(UW45, UW44)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	ADV(UW46, UW45)
-	.byte	0x80+3, 3		/* DW_CFA_offset %ebx 3*-4 */
-	ADV(UW47, UW46)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
-	ADV(UW48, UW47)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	ADV(UW49, UW48)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	ADV(UW50, UW49)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	ADV(UW51, UW50)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .long   L(SFDE9)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW41))          /* Initial location */
+        .long   L(UW52)-L(UW41)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW42, UW41)
+        .byte   0xe, 0                  /* DW_CFA_def_cfa_offset */
+        .byte   0x9, 8, 2               /* DW_CFA_register %eip, %edx */
+        ADV(UW43, UW42)
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+        ADV(UW44, UW43)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip 2*-4 */
+        ADV(UW45, UW44)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        ADV(UW46, UW45)
+        .byte   0x80+3, 3               /* DW_CFA_offset %ebx 3*-4 */
+        ADV(UW47, UW46)
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+        ADV(UW48, UW47)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        ADV(UW49, UW48)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        ADV(UW50, UW49)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        ADV(UW51, UW50)
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE9):
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef _WIN32
-	.def	 @feat.00;
-	.scl	3;
-	.type	0;
-	.endef
-	PUBLIC	@feat.00
+        .def     @feat.00;
+        .scl    3;
+        .type   0;
+        .endef
+        PUBLIC  @feat.00
 @feat.00 = 1
 #endif
 
@@ -988,7 +988,7 @@ L(EFDE9):
 #endif /* ifndef __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif
 #endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------
    unix64.S - Copyright (c) 2013  The Written Word, Inc.
-	    - Copyright (c) 2008  Red Hat, Inc
-	    - Copyright (c) 2002  Bo Thorsen <bo@suse.de>
+            - Copyright (c) 2008  Red Hat, Inc
+            - Copyright (c) 2002  Bo Thorsen <bo@suse.de>
 
    x86-64 Foreign Function Interface
 
@@ -40,371 +40,496 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	.balign 8
+# define E(BASE, X)     .balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + X * 8
+# ifdef __CET__
+#  define E(BASE, X)    .balign 8; .org BASE + X * 16
+# else
+#  define E(BASE, X)    .balign 8; .org BASE + X * 8
+# endif
 #endif
 
 /* ffi_call_unix64 (void *args, unsigned long bytes, unsigned flags,
-	            void *raddr, void (*fnaddr)(void));
+                    void *raddr, void (*fnaddr)(void));
 
    Bit o trickiness here -- ARGS+BYTES is the base of the stack frame
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-	.balign	8
-	.globl	C(ffi_call_unix64)
-	FFI_HIDDEN(C(ffi_call_unix64))
+        .balign 8
+        .globl  C(ffi_call_unix64)
+        FFI_HIDDEN(C(ffi_call_unix64))
 
 C(ffi_call_unix64):
 L(UW0):
-	movq	(%rsp), %r10		/* Load return address.  */
-	leaq	(%rdi, %rsi), %rax	/* Find local stack base.  */
-	movq	%rdx, (%rax)		/* Save flags.  */
-	movq	%rcx, 8(%rax)		/* Save raddr.  */
-	movq	%rbp, 16(%rax)		/* Save old frame pointer.  */
-	movq	%r10, 24(%rax)		/* Relocate return address.  */
-	movq	%rax, %rbp		/* Finalize local stack frame.  */
+        _CET_ENDBR
+        movq    (%rsp), %r10            /* Load return address.  */
+        leaq    (%rdi, %rsi), %rax      /* Find local stack base.  */
+        movq    %rdx, (%rax)            /* Save flags.  */
+        movq    %rcx, 8(%rax)           /* Save raddr.  */
+        movq    %rbp, 16(%rax)          /* Save old frame pointer.  */
+        movq    %r10, 24(%rax)          /* Relocate return address.  */
+        movq    %rax, %rbp              /* Finalize local stack frame.  */
 
-	/* New stack frame based off rbp.  This is a itty bit of unwind
-	   trickery in that the CFA *has* changed.  There is no easy way
-	   to describe it correctly on entry to the function.  Fortunately,
-	   it doesn't matter too much since at all points we can correctly
-	   unwind back to ffi_call.  Note that the location to which we
-	   moved the return address is (the new) CFA-8, so from the
-	   perspective of the unwind info, it hasn't moved.  */
+        /* New stack frame based off rbp.  This is a itty bit of unwind
+           trickery in that the CFA *has* changed.  There is no easy way
+           to describe it correctly on entry to the function.  Fortunately,
+           it doesn't matter too much since at all points we can correctly
+           unwind back to ffi_call.  Note that the location to which we
+           moved the return address is (the new) CFA-8, so from the
+           perspective of the unwind info, it hasn't moved.  */
 L(UW1):
-	/* cfi_def_cfa(%rbp, 32) */
-	/* cfi_rel_offset(%rbp, 16) */
+        /* cfi_def_cfa(%rbp, 32) */
+        /* cfi_rel_offset(%rbp, 16) */
 
-	movq	%rdi, %r10		/* Save a copy of the register area. */
-	movq	%r8, %r11		/* Save a copy of the target fn.  */
-	movl	%r9d, %eax		/* Set number of SSE registers.  */
+        movq    %rdi, %r10              /* Save a copy of the register area. */
+        movq    %r8, %r11               /* Save a copy of the target fn.  */
 
-	/* Load up all argument registers.  */
-	movq	(%r10), %rdi
-	movq	0x08(%r10), %rsi
-	movq	0x10(%r10), %rdx
-	movq	0x18(%r10), %rcx
-	movq	0x20(%r10), %r8
-	movq	0x28(%r10), %r9
-	movl	0xb0(%r10), %eax
-	testl	%eax, %eax
-	jnz	L(load_sse)
+        /* Load up all argument registers.  */
+        movq    (%r10), %rdi
+        movq    0x08(%r10), %rsi
+        movq    0x10(%r10), %rdx
+        movq    0x18(%r10), %rcx
+        movq    0x20(%r10), %r8
+        movq    0x28(%r10), %r9
+        movl    0xb0(%r10), %eax        /* Set number of SSE registers.  */
+        testl   %eax, %eax
+        jnz     L(load_sse)
 L(ret_from_load_sse):
 
-	/* Deallocate the reg arg area, except for r10, then load via pop.  */
-	leaq	0xb8(%r10), %rsp
-	popq	%r10
+        /* Deallocate the reg arg area, except for r10, then load via pop.  */
+        leaq    0xb8(%r10), %rsp
+        popq    %r10
 
-	/* Call the user function.  */
-	call	*%r11
+        /* Call the user function.  */
+        call    *%r11
 
-	/* Deallocate stack arg area; local stack frame in redzone.  */
-	leaq	24(%rbp), %rsp
+        /* Deallocate stack arg area; local stack frame in redzone.  */
+        leaq    24(%rbp), %rsp
 
-	movq	0(%rbp), %rcx		/* Reload flags.  */
-	movq	8(%rbp), %rdi		/* Reload raddr.  */
-	movq	16(%rbp), %rbp		/* Reload old frame pointer.  */
+        movq    0(%rbp), %rcx           /* Reload flags.  */
+        movq    8(%rbp), %rdi           /* Reload raddr.  */
+        movq    16(%rbp), %rbp          /* Reload old frame pointer.  */
 L(UW2):
-	/* cfi_remember_state */
-	/* cfi_def_cfa(%rsp, 8) */
-	/* cfi_restore(%rbp) */
+        /* cfi_remember_state */
+        /* cfi_def_cfa(%rsp, 8) */
+        /* cfi_restore(%rbp) */
 
-	/* The first byte of the flags contains the FFI_TYPE.  */
-	cmpb	$UNIX64_RET_LAST, %cl
-	movzbl	%cl, %r10d
-	leaq	L(store_table)(%rip), %r11
-	ja	L(sa)
-	leaq	(%r11, %r10, 8), %r10
+        /* The first byte of the flags contains the FFI_TYPE.  */
+        cmpb    $UNIX64_RET_LAST, %cl
+        movzbl  %cl, %r10d
+        leaq    L(store_table)(%rip), %r11
+        ja      L(sa)
+#ifdef __CET__
+        /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
+           4 bytes NOP padding double slot size to 16 bytes.  */
+        addl    %r10d, %r10d
+#endif
+        leaq    (%r11, %r10, 8), %r10
 
-	/* Prep for the structure cases: scratch area in redzone.  */
-	leaq	-20(%rsp), %rsi
-	jmp	*%r10
+        /* Prep for the structure cases: scratch area in redzone.  */
+        leaq    -20(%rsp), %rsi
+        jmp     *%r10
 
-	.balign	8
+        .balign 8
 L(store_table):
 E(L(store_table), UNIX64_RET_VOID)
-	ret
+        _CET_ENDBR
+        ret
 E(L(store_table), UNIX64_RET_UINT8)
-	movzbl	%al, %eax
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movzbl  %al, %eax
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_UINT16)
-	movzwl	%ax, %eax
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movzwl  %ax, %eax
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_UINT32)
-	movl	%eax, %eax
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movl    %eax, %eax
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_SINT8)
-	movsbq	%al, %rax
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movsbq  %al, %rax
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_SINT16)
-	movswq	%ax, %rax
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movswq  %ax, %rax
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_SINT32)
-	cltq
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        cltq
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_INT64)
-	movq	%rax, (%rdi)
-	ret
+        _CET_ENDBR
+        movq    %rax, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_XMM32)
-	movd	%xmm0, (%rdi)
-	ret
+        _CET_ENDBR
+        movd    %xmm0, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_XMM64)
-	movq	%xmm0, (%rdi)
-	ret
+        _CET_ENDBR
+        movq    %xmm0, (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_X87)
-	fstpt	(%rdi)
-	ret
+        _CET_ENDBR
+        fstpt   (%rdi)
+        ret
 E(L(store_table), UNIX64_RET_X87_2)
-	fstpt	(%rdi)
-	fstpt	16(%rdi)
-	ret
+        _CET_ENDBR
+        fstpt   (%rdi)
+        fstpt   16(%rdi)
+        ret
 E(L(store_table), UNIX64_RET_ST_XMM0_RAX)
-	movq	%rax, 8(%rsi)
-	jmp	L(s3)
+        _CET_ENDBR
+        movq    %rax, 8(%rsi)
+        jmp     L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_XMM0)
-	movq	%xmm0, 8(%rsi)
-	jmp	L(s2)
+        _CET_ENDBR
+        movq    %xmm0, 8(%rsi)
+        jmp     L(s2)
 E(L(store_table), UNIX64_RET_ST_XMM0_XMM1)
-	movq	%xmm1, 8(%rsi)
-	jmp	L(s3)
+        _CET_ENDBR
+        movq    %xmm1, 8(%rsi)
+        jmp     L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_RDX)
-	movq	%rdx, 8(%rsi)
+        _CET_ENDBR
+        movq    %rdx, 8(%rsi)
 L(s2):
-	movq	%rax, (%rsi)
-	shrl	$UNIX64_SIZE_SHIFT, %ecx
-	rep movsb
-	ret
-	.balign 8
+        movq    %rax, (%rsi)
+        shrl    $UNIX64_SIZE_SHIFT, %ecx
+        rep movsb
+        ret
+        .balign 8
 L(s3):
-	movq	%xmm0, (%rsi)
-	shrl	$UNIX64_SIZE_SHIFT, %ecx
-	rep movsb
-	ret
+        movq    %xmm0, (%rsi)
+        shrl    $UNIX64_SIZE_SHIFT, %ecx
+        rep movsb
+        ret
 
-L(sa):	call	PLT(C(abort))
+L(sa):  call    PLT(C(abort))
 
-	/* Many times we can avoid loading any SSE registers at all.
-	   It's not worth an indirect jump to load the exact set of
-	   SSE registers needed; zero or all is a good compromise.  */
-	.balign 2
+        /* Many times we can avoid loading any SSE registers at all.
+           It's not worth an indirect jump to load the exact set of
+           SSE registers needed; zero or all is a good compromise.  */
+        .balign 2
 L(UW3):
-	/* cfi_restore_state */
+        /* cfi_restore_state */
 L(load_sse):
-	movdqa	0x30(%r10), %xmm0
-	movdqa	0x40(%r10), %xmm1
-	movdqa	0x50(%r10), %xmm2
-	movdqa	0x60(%r10), %xmm3
-	movdqa	0x70(%r10), %xmm4
-	movdqa	0x80(%r10), %xmm5
-	movdqa	0x90(%r10), %xmm6
-	movdqa	0xa0(%r10), %xmm7
-	jmp	L(ret_from_load_sse)
+        movdqa  0x30(%r10), %xmm0
+        movdqa  0x40(%r10), %xmm1
+        movdqa  0x50(%r10), %xmm2
+        movdqa  0x60(%r10), %xmm3
+        movdqa  0x70(%r10), %xmm4
+        movdqa  0x80(%r10), %xmm5
+        movdqa  0x90(%r10), %xmm6
+        movdqa  0xa0(%r10), %xmm7
+        jmp     L(ret_from_load_sse)
 
 L(UW4):
 ENDF(C(ffi_call_unix64))
 
 /* 6 general registers, 8 vector registers,
    32 bytes of rvalue, 8 bytes of alignment.  */
-#define ffi_closure_OFS_G	0
-#define ffi_closure_OFS_V	(6*8)
-#define ffi_closure_OFS_RVALUE	(ffi_closure_OFS_V + 8*16)
-#define ffi_closure_FS		(ffi_closure_OFS_RVALUE + 32 + 8)
+#define ffi_closure_OFS_G       0
+#define ffi_closure_OFS_V       (6*8)
+#define ffi_closure_OFS_RVALUE  (ffi_closure_OFS_V + 8*16)
+#define ffi_closure_FS          (ffi_closure_OFS_RVALUE + 32 + 8)
 
 /* The location of rvalue within the red zone after deallocating the frame.  */
-#define ffi_closure_RED_RVALUE	(ffi_closure_OFS_RVALUE - ffi_closure_FS)
+#define ffi_closure_RED_RVALUE  (ffi_closure_OFS_RVALUE - ffi_closure_FS)
 
-	.balign	2
-	.globl	C(ffi_closure_unix64_sse)
-	FFI_HIDDEN(C(ffi_closure_unix64_sse))
+        .balign 2
+        .globl  C(ffi_closure_unix64_sse)
+        FFI_HIDDEN(C(ffi_closure_unix64_sse))
 
 C(ffi_closure_unix64_sse):
 L(UW5):
-	subq	$ffi_closure_FS, %rsp
+        _CET_ENDBR
+        subq    $ffi_closure_FS, %rsp
 L(UW6):
-	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
+        /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
-	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
-	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
-	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
-	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
-	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
-	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
-	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
-	jmp	L(sse_entry1)
+        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
+        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
+        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
+        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
+        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
+        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
+        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
+        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
+        jmp     L(sse_entry1)
 
 L(UW7):
 ENDF(C(ffi_closure_unix64_sse))
 
-	.balign	2
-	.globl	C(ffi_closure_unix64)
-	FFI_HIDDEN(C(ffi_closure_unix64))
+        .balign 2
+        .globl  C(ffi_closure_unix64)
+        FFI_HIDDEN(C(ffi_closure_unix64))
 
 C(ffi_closure_unix64):
 L(UW8):
-	subq	$ffi_closure_FS, %rsp
+        _CET_ENDBR
+        subq    $ffi_closure_FS, %rsp
 L(UW9):
-	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
+        /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry1):
-	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
-	movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
-	movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
-	movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
-	movq    %r8,  ffi_closure_OFS_G+0x20(%rsp)
-	movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
+        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
+        movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
+        movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
+        movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
+        movq    %r8,  ffi_closure_OFS_G+0x20(%rsp)
+        movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-	movl	FFI_TRAMPOLINE_SIZE(%r10), %edi		/* Load cif */
-	movl	FFI_TRAMPOLINE_SIZE+4(%r10), %esi	/* Load fun */
-	movl	FFI_TRAMPOLINE_SIZE+8(%r10), %edx	/* Load user_data */
+        movl    FFI_TRAMPOLINE_SIZE(%r10), %edi         /* Load cif */
+        movl    FFI_TRAMPOLINE_SIZE+4(%r10), %esi       /* Load fun */
+        movl    FFI_TRAMPOLINE_SIZE+8(%r10), %edx       /* Load user_data */
 #else
-	movq	FFI_TRAMPOLINE_SIZE(%r10), %rdi		/* Load cif */
-	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rsi	/* Load fun */
-	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %rdx	/* Load user_data */
+        movq    FFI_TRAMPOLINE_SIZE(%r10), %rdi         /* Load cif */
+        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rsi       /* Load fun */
+        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %rdx      /* Load user_data */
 #endif
 L(do_closure):
-	leaq	ffi_closure_OFS_RVALUE(%rsp), %rcx	/* Load rvalue */
-	movq	%rsp, %r8				/* Load reg_args */
-	leaq	ffi_closure_FS+8(%rsp), %r9		/* Load argp */
-	call	PLT(C(ffi_closure_unix64_inner))
+        leaq    ffi_closure_OFS_RVALUE(%rsp), %rcx      /* Load rvalue */
+        movq    %rsp, %r8                               /* Load reg_args */
+        leaq    ffi_closure_FS+8(%rsp), %r9             /* Load argp */
+        call    PLT(C(ffi_closure_unix64_inner))
 
-	/* Deallocate stack frame early; return value is now in redzone.  */
-	addq	$ffi_closure_FS, %rsp
+        /* Deallocate stack frame early; return value is now in redzone.  */
+        addq    $ffi_closure_FS, %rsp
 L(UW10):
-	/* cfi_adjust_cfa_offset(-ffi_closure_FS) */
+        /* cfi_adjust_cfa_offset(-ffi_closure_FS) */
 
-	/* The first byte of the return value contains the FFI_TYPE.  */
-	cmpb	$UNIX64_RET_LAST, %al
-	movzbl	%al, %r10d
-	leaq	L(load_table)(%rip), %r11
-	ja	L(la)
-	leaq	(%r11, %r10, 8), %r10
-	leaq	ffi_closure_RED_RVALUE(%rsp), %rsi
-	jmp	*%r10
+        /* The first byte of the return value contains the FFI_TYPE.  */
+        cmpb    $UNIX64_RET_LAST, %al
+        movzbl  %al, %r10d
+        leaq    L(load_table)(%rip), %r11
+        ja      L(la)
+#ifdef __CET__
+        /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
+           4 bytes NOP padding double slot size to 16 bytes.  */
+        addl    %r10d, %r10d
+#endif
+        leaq    (%r11, %r10, 8), %r10
+        leaq    ffi_closure_RED_RVALUE(%rsp), %rsi
+        jmp     *%r10
 
-	.balign	8
+        .balign 8
 L(load_table):
 E(L(load_table), UNIX64_RET_VOID)
-	ret
+        _CET_ENDBR
+        ret
 E(L(load_table), UNIX64_RET_UINT8)
-	movzbl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movzbl  (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_UINT16)
-	movzwl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movzwl  (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_UINT32)
-	movl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movl    (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_SINT8)
-	movsbl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movsbl  (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_SINT16)
-	movswl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movswl  (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_SINT32)
-	movl	(%rsi), %eax
-	ret
+        _CET_ENDBR
+        movl    (%rsi), %eax
+        ret
 E(L(load_table), UNIX64_RET_INT64)
-	movq	(%rsi), %rax
-	ret
+        _CET_ENDBR
+        movq    (%rsi), %rax
+        ret
 E(L(load_table), UNIX64_RET_XMM32)
-	movd	(%rsi), %xmm0
-	ret
+        _CET_ENDBR
+        movd    (%rsi), %xmm0
+        ret
 E(L(load_table), UNIX64_RET_XMM64)
-	movq	(%rsi), %xmm0
-	ret
+        _CET_ENDBR
+        movq    (%rsi), %xmm0
+        ret
 E(L(load_table), UNIX64_RET_X87)
-	fldt	(%rsi)
-	ret
+        _CET_ENDBR
+        fldt    (%rsi)
+        ret
 E(L(load_table), UNIX64_RET_X87_2)
-	fldt	16(%rsi)
-	fldt	(%rsi)
-	ret
+        _CET_ENDBR
+        fldt    16(%rsi)
+        fldt    (%rsi)
+        ret
 E(L(load_table), UNIX64_RET_ST_XMM0_RAX)
-	movq	8(%rsi), %rax
-	jmp	L(l3)
+        _CET_ENDBR
+        movq    8(%rsi), %rax
+        jmp     L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_XMM0)
-	movq	8(%rsi), %xmm0
-	jmp	L(l2)
+        _CET_ENDBR
+        movq    8(%rsi), %xmm0
+        jmp     L(l2)
 E(L(load_table), UNIX64_RET_ST_XMM0_XMM1)
-	movq	8(%rsi), %xmm1
-	jmp	L(l3)
+        _CET_ENDBR
+        movq    8(%rsi), %xmm1
+        jmp     L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_RDX)
-	movq	8(%rsi), %rdx
+        _CET_ENDBR
+        movq    8(%rsi), %rdx
 L(l2):
-	movq	(%rsi), %rax
-	ret
-	.balign	8
+        movq    (%rsi), %rax
+        ret
+        .balign 8
 L(l3):
-	movq	(%rsi), %xmm0
-	ret
+        movq    (%rsi), %xmm0
+        ret
 
-L(la):	call	PLT(C(abort))
+L(la):  call    PLT(C(abort))
 
 L(UW11):
 ENDF(C(ffi_closure_unix64))
 
-	.balign	2
-	.globl	C(ffi_go_closure_unix64_sse)
-	FFI_HIDDEN(C(ffi_go_closure_unix64_sse))
+        .balign 2
+        .globl  C(ffi_go_closure_unix64_sse)
+        FFI_HIDDEN(C(ffi_go_closure_unix64_sse))
 
 C(ffi_go_closure_unix64_sse):
 L(UW12):
-	subq	$ffi_closure_FS, %rsp
+        _CET_ENDBR
+        subq    $ffi_closure_FS, %rsp
 L(UW13):
-	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
+        /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
-	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
-	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
-	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
-	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
-	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
-	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
-	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
-	jmp	L(sse_entry2)
+        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
+        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
+        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
+        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
+        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
+        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
+        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
+        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
+        jmp     L(sse_entry2)
 
 L(UW14):
 ENDF(C(ffi_go_closure_unix64_sse))
 
-	.balign	2
-	.globl	C(ffi_go_closure_unix64)
-	FFI_HIDDEN(C(ffi_go_closure_unix64))
+        .balign 2
+        .globl  C(ffi_go_closure_unix64)
+        FFI_HIDDEN(C(ffi_go_closure_unix64))
 
 C(ffi_go_closure_unix64):
 L(UW15):
-	subq	$ffi_closure_FS, %rsp
+        _CET_ENDBR
+        subq    $ffi_closure_FS, %rsp
 L(UW16):
-	/* cfi_adjust_cfa_offset(ffi_closure_FS) */
+        /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry2):
-	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
-	movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
-	movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
-	movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
-	movq    %r8,  ffi_closure_OFS_G+0x20(%rsp)
-	movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
+        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
+        movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
+        movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
+        movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
+        movq    %r8,  ffi_closure_OFS_G+0x20(%rsp)
+        movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-	movl	4(%r10), %edi		/* Load cif */
-	movl	8(%r10), %esi		/* Load fun */
-	movl	%r10d, %edx		/* Load closure (user_data) */
+        movl    4(%r10), %edi           /* Load cif */
+        movl    8(%r10), %esi           /* Load fun */
+        movl    %r10d, %edx             /* Load closure (user_data) */
 #else
-	movq	8(%r10), %rdi		/* Load cif */
-	movq	16(%r10), %rsi		/* Load fun */
-	movq	%r10, %rdx		/* Load closure (user_data) */
+        movq    8(%r10), %rdi           /* Load cif */
+        movq    16(%r10), %rsi          /* Load fun */
+        movq    %r10, %rdx              /* Load closure (user_data) */
 #endif
-	jmp	L(do_closure)
+        jmp     L(do_closure)
 
 L(UW17):
 ENDF(C(ffi_go_closure_unix64))
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+        .balign 8
+        .globl  C(ffi_closure_unix64_sse_alt)
+        FFI_HIDDEN(C(ffi_closure_unix64_sse_alt))
+
+C(ffi_closure_unix64_sse_alt):
+        /* See the comments above trampoline_code_table. */
+        _CET_ENDBR
+        movq    8(%rsp), %r10                   /* Load closure in r10 */
+        addq    $16, %rsp                       /* Restore the stack */
+        jmp     C(ffi_closure_unix64_sse)
+ENDF(C(ffi_closure_unix64_sse_alt))
+
+        .balign 8
+        .globl  C(ffi_closure_unix64_alt)
+        FFI_HIDDEN(C(ffi_closure_unix64_alt))
+
+C(ffi_closure_unix64_alt):
+        /* See the comments above trampoline_code_table. */
+        _CET_ENDBR
+        movq    8(%rsp), %r10                   /* Load closure in r10 */
+        addq    $16, %rsp                       /* Restore the stack */
+        jmp     C(ffi_closure_unix64)
+        ENDF(C(ffi_closure_unix64_alt))
+
+/*
+ * Below is the definition of the trampoline code table. Each element in
+ * the code table is a trampoline.
+ *
+ * Because we jump to the trampoline, we place a _CET_ENDBR at the
+ * beginning of the trampoline to mark it as a valid branch target. This is
+ * part of the the Intel CET (Control Flow Enforcement Technology).
+ */
+/*
+ * The trampoline uses register r10. It saves the original value of r10 on
+ * the stack.
+ *
+ * The trampoline has two parameters - target code to jump to and data for
+ * the target code. The trampoline extracts the parameters from its parameter
+ * block (see tramp_table_map()). The trampoline saves the data address on
+ * the stack. Finally, it jumps to the target code.
+ *
+ * The target code can choose to:
+ *
+ * - restore the value of r10
+ * - load the data address in a register
+ * - restore the stack pointer to what it was when the trampoline was invoked.
+ */
+#ifdef ENDBR_PRESENT
+#define X86_DATA_OFFSET         4077
+#define X86_CODE_OFFSET         4073
+#else
+#define X86_DATA_OFFSET         4081
+#define X86_CODE_OFFSET         4077
+#endif
+
+        .align  UNIX64_TRAMP_MAP_SIZE
+        .globl  trampoline_code_table
+        FFI_HIDDEN(C(trampoline_code_table))
+
+C(trampoline_code_table):
+        .rept   UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
+        _CET_ENDBR
+        subq    $16, %rsp                       /* Make space on the stack */
+        movq    %r10, (%rsp)                    /* Save %r10 on stack */
+        movq    X86_DATA_OFFSET(%rip), %r10     /* Copy data into %r10 */
+        movq    %r10, 8(%rsp)                   /* Save data on stack */
+        movq    X86_CODE_OFFSET(%rip), %r10     /* Copy code into %r10 */
+        jmp     *%r10                           /* Jump to code */
+        .align  8
+        .endr
+ENDF(C(trampoline_code_table))
+        .align  UNIX64_TRAMP_MAP_SIZE
+#endif /* FFI_EXEC_STATIC_TRAMP */
 
 /* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
 
@@ -418,149 +543,154 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)	X - .
+# define PCREL(X)       X - .
 #else
-# define PCREL(X)	X@rel
+# define PCREL(X)       X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)	.byte 2, L(N)-L(P)
+#ifdef __CET__
+/* Use DW_CFA_advance_loc2 when IBT is enabled.  */
+# define ADV(N, P)      .byte 3; .2byte L(N)-L(P)
+#else
+# define ADV(N, P)      .byte 2, L(N)-L(P)
+#endif
 
-	.balign 8
+        .balign 8
 L(CIE):
-	.set	L(set0),L(ECIE)-L(SCIE)
-	.long	L(set0)			/* CIE Length */
+        .set    L(set0),L(ECIE)-L(SCIE)
+        .long   L(set0)                 /* CIE Length */
 L(SCIE):
-	.long	0			/* CIE Identifier Tag */
-	.byte	1			/* CIE Version */
-	.ascii	"zR\0"			/* CIE Augmentation */
-	.byte	1			/* CIE Code Alignment Factor */
-	.byte	0x78			/* CIE Data Alignment Factor */
-	.byte	0x10			/* CIE RA Column */
-	.byte	1			/* Augmentation size */
-	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
-	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp offset 8 */
-	.byte	0x80+16, 1		/* DW_CFA_offset, %rip offset 1*-8 */
-	.balign 8
+        .long   0                       /* CIE Identifier Tag */
+        .byte   1                       /* CIE Version */
+        .ascii  "zR\0"                  /* CIE Augmentation */
+        .byte   1                       /* CIE Code Alignment Factor */
+        .byte   0x78                    /* CIE Data Alignment Factor */
+        .byte   0x10                    /* CIE RA Column */
+        .byte   1                       /* Augmentation size */
+        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
+        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp offset 8 */
+        .byte   0x80+16, 1              /* DW_CFA_offset, %rip offset 1*-8 */
+        .balign 8
 L(ECIE):
 
-	.set	L(set1),L(EFDE1)-L(SFDE1)
-	.long	L(set1)			/* FDE Length */
+        .set    L(set1),L(EFDE1)-L(SFDE1)
+        .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW0))		/* Initial location */
-	.long	L(UW4)-L(UW0)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW1, UW0)
-	.byte	0xc, 6, 32		/* DW_CFA_def_cfa, %rbp 32 */
-	.byte	0x80+6, 2		/* DW_CFA_offset, %rbp 2*-8 */
-	ADV(UW2, UW1)
-	.byte	0xa			/* DW_CFA_remember_state */
-	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp 8 */
-	.byte	0xc0+6			/* DW_CFA_restore, %rbp */
-	ADV(UW3, UW2)
-	.byte	0xb			/* DW_CFA_restore_state */
-	.balign	8
+        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW0))           /* Initial location */
+        .long   L(UW4)-L(UW0)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW1, UW0)
+        .byte   0xc, 6, 32              /* DW_CFA_def_cfa, %rbp 32 */
+        .byte   0x80+6, 2               /* DW_CFA_offset, %rbp 2*-8 */
+        ADV(UW2, UW1)
+        .byte   0xa                     /* DW_CFA_remember_state */
+        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp 8 */
+        .byte   0xc0+6                  /* DW_CFA_restore, %rbp */
+        ADV(UW3, UW2)
+        .byte   0xb                     /* DW_CFA_restore_state */
+        .balign 8
 L(EFDE1):
 
-	.set	L(set2),L(EFDE2)-L(SFDE2)
-	.long	L(set2)			/* FDE Length */
+        .set    L(set2),L(EFDE2)-L(SFDE2)
+        .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW5))		/* Initial location */
-	.long	L(UW7)-L(UW5)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW6, UW5)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW5))           /* Initial location */
+        .long   L(UW7)-L(UW5)           /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW6, UW5)
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE2):
 
-	.set	L(set3),L(EFDE3)-L(SFDE3)
-	.long	L(set3)			/* FDE Length */
+        .set    L(set3),L(EFDE3)-L(SFDE3)
+        .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW8))		/* Initial location */
-	.long	L(UW11)-L(UW8)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW9, UW8)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	ADV(UW10, UW9)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset 8 */
+        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW8))           /* Initial location */
+        .long   L(UW11)-L(UW8)          /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW9, UW8)
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        ADV(UW10, UW9)
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset 8 */
 L(EFDE3):
 
-	.set	L(set4),L(EFDE4)-L(SFDE4)
-	.long	L(set4)			/* FDE Length */
+        .set    L(set4),L(EFDE4)-L(SFDE4)
+        .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW12))		/* Initial location */
-	.long	L(UW14)-L(UW12)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW13, UW12)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW12))          /* Initial location */
+        .long   L(UW14)-L(UW12)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW13, UW12)
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE4):
 
-	.set	L(set5),L(EFDE5)-L(SFDE5)
-	.long	L(set5)			/* FDE Length */
+        .set    L(set5),L(EFDE5)-L(SFDE5)
+        .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW15))		/* Initial location */
-	.long	L(UW17)-L(UW15)		/* Address range */
-	.byte	0			/* Augmentation size */
-	ADV(UW16, UW15)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW15))          /* Initial location */
+        .long   L(UW17)-L(UW15)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        ADV(UW16, UW15)
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE5):
 #ifdef __APPLE__
-	.subsections_via_symbols
-	.section __LD,__compact_unwind,regular,debug
+        .subsections_via_symbols
+        .section __LD,__compact_unwind,regular,debug
 
-	/* compact unwind for ffi_call_unix64 */
-	.quad    C(ffi_call_unix64)
-	.set     L1,L(UW4)-L(UW0)
-	.long    L1
-	.long    0x04000000 /* use dwarf unwind info */
-	.quad    0
-	.quad    0
+        /* compact unwind for ffi_call_unix64 */
+        .quad    C(ffi_call_unix64)
+        .set     L1,L(UW4)-L(UW0)
+        .long    L1
+        .long    0x04000000 /* use dwarf unwind info */
+        .quad    0
+        .quad    0
 
-	/* compact unwind for ffi_closure_unix64_sse */
-	.quad    C(ffi_closure_unix64_sse)
-	.set     L2,L(UW7)-L(UW5)
-	.long    L2
-	.long    0x04000000 /* use dwarf unwind info */
-	.quad    0
-	.quad    0
+        /* compact unwind for ffi_closure_unix64_sse */
+        .quad    C(ffi_closure_unix64_sse)
+        .set     L2,L(UW7)-L(UW5)
+        .long    L2
+        .long    0x04000000 /* use dwarf unwind info */
+        .quad    0
+        .quad    0
 
-	/* compact unwind for ffi_closure_unix64 */
-	.quad    C(ffi_closure_unix64)
-	.set     L3,L(UW11)-L(UW8)
-	.long    L3
-	.long    0x04000000 /* use dwarf unwind info */
-	.quad    0
-	.quad    0
+        /* compact unwind for ffi_closure_unix64 */
+        .quad    C(ffi_closure_unix64)
+        .set     L3,L(UW11)-L(UW8)
+        .long    L3
+        .long    0x04000000 /* use dwarf unwind info */
+        .quad    0
+        .quad    0
 
-	/* compact unwind for ffi_go_closure_unix64_sse */
-	.quad    C(ffi_go_closure_unix64_sse)
-	.set     L4,L(UW14)-L(UW12)
-	.long    L4
-	.long    0x04000000 /* use dwarf unwind info */
-	.quad    0
-	.quad    0
+        /* compact unwind for ffi_go_closure_unix64_sse */
+        .quad    C(ffi_go_closure_unix64_sse)
+        .set     L4,L(UW14)-L(UW12)
+        .long    L4
+        .long    0x04000000 /* use dwarf unwind info */
+        .quad    0
+        .quad    0
 
-	/* compact unwind for ffi_go_closure_unix64 */
-	.quad    C(ffi_go_closure_unix64)
-	.set     L5,L(UW17)-L(UW15)
-	.long    L5
-	.long    0x04000000 /* use dwarf unwind info */
-	.quad    0
-	.quad    0
+        /* compact unwind for ffi_go_closure_unix64 */
+        .quad    C(ffi_go_closure_unix64)
+        .set     L5,L(UW17)-L(UW15)
+        .long    L5
+        .long    0x04000000 /* use dwarf unwind info */
+        .quad    0
+        .quad    0
 #endif
 
 #endif /* __x86_64__ */
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
@@ -11,16 +11,16 @@
 
 #ifdef X86_WIN64
 #define SEH(...) __VA_ARGS__
-#define arg0	%rcx
-#define arg1	%rdx
-#define arg2	%r8
-#define arg3	%r9
+#define arg0    %rcx
+#define arg1    %rdx
+#define arg2    %r8
+#define arg3    %r9
 #else
 #define SEH(...)
-#define arg0	%rdi
-#define arg1	%rsi
-#define arg2	%rdx
-#define arg3	%rcx
+#define arg0    %rdi
+#define arg1    %rsi
+#define arg2    %rdx
+#define arg3    %rcx
 #endif
 
 /* This macro allows the safe creation of jump tables without an
@@ -28,12 +28,12 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	.balign 8
+# define E(BASE, X)     .balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + X * 8
+# define E(BASE, X)     .balign 8; .org BASE + (X) * 8
 #endif
 
-	.text
+        .text
 
 /* ffi_call_win64 (void *stack, struct win64_call_frame *frame, void *r10)
 
@@ -41,197 +41,215 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-	.align	8
-	.globl	C(ffi_call_win64)
-	FFI_HIDDEN(C(ffi_call_win64))
+        .align  8
+        .globl  C(ffi_call_win64)
+        FFI_HIDDEN(C(ffi_call_win64))
 
-	SEH(.seh_proc ffi_call_win64)
+        SEH(.seh_proc ffi_call_win64)
 C(ffi_call_win64):
-	cfi_startproc
-	/* Set up the local stack frame and install it in rbp/rsp.  */
-	movq	(%rsp), %rax
-	movq	%rbp, (arg1)
-	movq	%rax, 8(arg1)
-	movq	arg1, %rbp
-	cfi_def_cfa(%rbp, 16)
-	cfi_rel_offset(%rbp, 0)
-	SEH(.seh_pushreg %rbp)
-	SEH(.seh_setframe %rbp, 0)
-	SEH(.seh_endprologue)
-	movq	arg0, %rsp
+        cfi_startproc
+        _CET_ENDBR
+        /* Set up the local stack frame and install it in rbp/rsp.  */
+        movq    (%rsp), %rax
+        movq    %rbp, (arg1)
+        movq    %rax, 8(arg1)
+        movq    arg1, %rbp
+        cfi_def_cfa(%rbp, 16)
+        cfi_rel_offset(%rbp, 0)
+        SEH(.seh_pushreg %rbp)
+        SEH(.seh_setframe %rbp, 0)
+        SEH(.seh_endprologue)
+        movq    arg0, %rsp
 
-	movq	arg2, %r10
+        movq    arg2, %r10
 
-	/* Load all slots into both general and xmm registers.  */
-	movq	(%rsp), %rcx
-	movsd	(%rsp), %xmm0
-	movq	8(%rsp), %rdx
-	movsd	8(%rsp), %xmm1
-	movq	16(%rsp), %r8
-	movsd	16(%rsp), %xmm2
-	movq	24(%rsp), %r9
-	movsd	24(%rsp), %xmm3
+        /* Load all slots into both general and xmm registers.  */
+        movq    (%rsp), %rcx
+        movsd   (%rsp), %xmm0
+        movq    8(%rsp), %rdx
+        movsd   8(%rsp), %xmm1
+        movq    16(%rsp), %r8
+        movsd   16(%rsp), %xmm2
+        movq    24(%rsp), %r9
+        movsd   24(%rsp), %xmm3
 
-	call	*16(%rbp)
+        call    *16(%rbp)
 
-	movl	24(%rbp), %ecx
-	movq	32(%rbp), %r8
-	leaq	0f(%rip), %r10
-	cmpl	$FFI_TYPE_SMALL_STRUCT_4B, %ecx
-	leaq	(%r10, %rcx, 8), %r10
-	ja	99f
-	jmp	*%r10
+        movl    24(%rbp), %ecx
+        movq    32(%rbp), %r8
+        leaq    0f(%rip), %r10
+        cmpl    $FFI_TYPE_SMALL_STRUCT_4B, %ecx
+        leaq    (%r10, %rcx, 8), %r10
+        ja      99f
+        _CET_NOTRACK jmp *%r10
 
 /* Below, we're space constrained most of the time.  Thus we eschew the
    modern "mov, pop, ret" sequence (5 bytes) for "leave, ret" (2 bytes).  */
 .macro epilogue
-	leaveq
-	cfi_remember_state
-	cfi_def_cfa(%rsp, 8)
-	cfi_restore(%rbp)
-	ret
-	cfi_restore_state
+        leaveq
+        cfi_remember_state
+        cfi_def_cfa(%rsp, 8)
+        cfi_restore(%rbp)
+        ret
+        cfi_restore_state
 .endm
 
-	.align	8
+        .align  8
 0:
 E(0b, FFI_TYPE_VOID)
-	epilogue
+        epilogue
 E(0b, FFI_TYPE_INT)
-	movslq	%eax, %rax
-	movq	%rax, (%r8)
-	epilogue
+        movslq  %eax, %rax
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_FLOAT)
-	movss	%xmm0, (%r8)
-	epilogue
+        movss   %xmm0, (%r8)
+        epilogue
 E(0b, FFI_TYPE_DOUBLE)
-	movsd	%xmm0, (%r8)
-	epilogue
-E(0b, FFI_TYPE_LONGDOUBLE)
-	call	PLT(C(abort))
+        movsd   %xmm0, (%r8)
+        epilogue
+// FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
+E(0b, FFI_TYPE_DOUBLE + 1)
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
-	movzbl	%al, %eax
-	movq	%rax, (%r8)
-	epilogue
+        movzbl  %al, %eax
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT8)
-	movsbq	%al, %rax
-	jmp	98f
+        movsbq  %al, %rax
+        jmp     98f
 E(0b, FFI_TYPE_UINT16)
-	movzwl	%ax, %eax
-	movq	%rax, (%r8)
-	epilogue
+        movzwl  %ax, %eax
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT16)
-	movswq	%ax, %rax
-	jmp	98f
+        movswq  %ax, %rax
+        jmp     98f
 E(0b, FFI_TYPE_UINT32)
-	movl	%eax, %eax
-	movq	%rax, (%r8)
-	epilogue
+        movl    %eax, %eax
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT32)
-	movslq	%eax, %rax
-	movq	%rax, (%r8)
-	epilogue
+        movslq  %eax, %rax
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_UINT64)
-98:	movq	%rax, (%r8)
-	epilogue
+98:     movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT64)
-	movq	%rax, (%r8)
-	epilogue
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_STRUCT)
-	epilogue
+        epilogue
 E(0b, FFI_TYPE_POINTER)
-	movq	%rax, (%r8)
-	epilogue
+        movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_COMPLEX)
-	call	PLT(C(abort))
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
-	movb	%al, (%r8)
-	epilogue
+        movb    %al, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_2B)
-	movw	%ax, (%r8)
-	epilogue
+        movw    %ax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_4B)
-	movl	%eax, (%r8)
-	epilogue
+        movl    %eax, (%r8)
+        epilogue
 
-	.align	8
-99:	call	PLT(C(abort))
+        .align  8
+99:     call    PLT(C(abort))
 
-	epilogue
+        epilogue
 
-	cfi_endproc
-	SEH(.seh_endproc)
+        cfi_endproc
+        SEH(.seh_endproc)
 
 
 /* 32 bytes of outgoing register stack space, 8 bytes of alignment,
    16 bytes of result, 32 bytes of xmm registers.  */
-#define ffi_clo_FS	(32+8+16+32)
-#define ffi_clo_OFF_R	(32+8)
-#define ffi_clo_OFF_X	(32+8+16)
+#define ffi_clo_FS      (32+8+16+32)
+#define ffi_clo_OFF_R   (32+8)
+#define ffi_clo_OFF_X   (32+8+16)
 
-	.align	8
-	.globl	C(ffi_go_closure_win64)
-	FFI_HIDDEN(C(ffi_go_closure_win64))
+        .align  8
+        .globl  C(ffi_go_closure_win64)
+        FFI_HIDDEN(C(ffi_go_closure_win64))
 
-	SEH(.seh_proc ffi_go_closure_win64)
+        SEH(.seh_proc ffi_go_closure_win64)
 C(ffi_go_closure_win64):
-	cfi_startproc
-	/* Save all integer arguments into the incoming reg stack space.  */
-	movq	%rcx, 8(%rsp)
-	movq	%rdx, 16(%rsp)
-	movq	%r8, 24(%rsp)
-	movq	%r9, 32(%rsp)
+        cfi_startproc
+        _CET_ENDBR
+        /* Save all integer arguments into the incoming reg stack space.  */
+        movq    %rcx, 8(%rsp)
+        movq    %rdx, 16(%rsp)
+        movq    %r8, 24(%rsp)
+        movq    %r9, 32(%rsp)
 
-	movq	8(%r10), %rcx			/* load cif */
-	movq	16(%r10), %rdx			/* load fun */
-	movq	%r10, %r8			/* closure is user_data */
-	jmp	0f
-	cfi_endproc
-	SEH(.seh_endproc)
+        movq    8(%r10), %rcx                   /* load cif */
+        movq    16(%r10), %rdx                  /* load fun */
+        movq    %r10, %r8                       /* closure is user_data */
+        jmp     0f
+        cfi_endproc
+        SEH(.seh_endproc)
 
-	.align	8
-	.globl	C(ffi_closure_win64)
-	FFI_HIDDEN(C(ffi_closure_win64))
+        .align  8
+        .globl  C(ffi_closure_win64)
+        FFI_HIDDEN(C(ffi_closure_win64))
 
-	SEH(.seh_proc ffi_closure_win64)
+        SEH(.seh_proc ffi_closure_win64)
 C(ffi_closure_win64):
-	cfi_startproc
-	/* Save all integer arguments into the incoming reg stack space.  */
-	movq	%rcx, 8(%rsp)
-	movq	%rdx, 16(%rsp)
-	movq	%r8, 24(%rsp)
-	movq	%r9, 32(%rsp)
+        cfi_startproc
+        _CET_ENDBR
+        /* Save all integer arguments into the incoming reg stack space.  */
+        movq    %rcx, 8(%rsp)
+        movq    %rdx, 16(%rsp)
+        movq    %r8, 24(%rsp)
+        movq    %r9, 32(%rsp)
 
-	movq	FFI_TRAMPOLINE_SIZE(%r10), %rcx		/* load cif */
-	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rdx	/* load fun */
-	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %r8	/* load user_data */
+        movq    FFI_TRAMPOLINE_SIZE(%r10), %rcx         /* load cif */
+        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rdx       /* load fun */
+        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %r8       /* load user_data */
 0:
-	subq	$ffi_clo_FS, %rsp
-	cfi_adjust_cfa_offset(ffi_clo_FS)
-	SEH(.seh_stackalloc ffi_clo_FS)
-	SEH(.seh_endprologue)
+        subq    $ffi_clo_FS, %rsp
+        cfi_adjust_cfa_offset(ffi_clo_FS)
+        SEH(.seh_stackalloc ffi_clo_FS)
+        SEH(.seh_endprologue)
 
-	/* Save all sse arguments into the stack frame.  */
-	movsd	%xmm0, ffi_clo_OFF_X(%rsp)
-	movsd	%xmm1, ffi_clo_OFF_X+8(%rsp)
-	movsd	%xmm2, ffi_clo_OFF_X+16(%rsp)
-	movsd	%xmm3, ffi_clo_OFF_X+24(%rsp)
+        /* Save all sse arguments into the stack frame.  */
+        movsd   %xmm0, ffi_clo_OFF_X(%rsp)
+        movsd   %xmm1, ffi_clo_OFF_X+8(%rsp)
+        movsd   %xmm2, ffi_clo_OFF_X+16(%rsp)
+        movsd   %xmm3, ffi_clo_OFF_X+24(%rsp)
 
-	leaq	ffi_clo_OFF_R(%rsp), %r9
-	call	PLT(C(ffi_closure_win64_inner))
+        leaq    ffi_clo_OFF_R(%rsp), %r9
+        call    PLT(C(ffi_closure_win64_inner))
 
-	/* Load the result into both possible result registers.  */
-	movq    ffi_clo_OFF_R(%rsp), %rax
-	movsd   ffi_clo_OFF_R(%rsp), %xmm0
+        /* Load the result into both possible result registers.  */
+        movq    ffi_clo_OFF_R(%rsp), %rax
+        movsd   ffi_clo_OFF_R(%rsp), %xmm0
 
-	addq	$ffi_clo_FS, %rsp
-	cfi_adjust_cfa_offset(-ffi_clo_FS)
-	ret
+        addq    $ffi_clo_FS, %rsp
+        cfi_adjust_cfa_offset(-ffi_clo_FS)
+        ret
 
-	cfi_endproc
-	SEH(.seh_endproc)
+        cfi_endproc
+        SEH(.seh_endproc)
+
+#if defined(FFI_EXEC_STATIC_TRAMP)
+        .align  8
+        .globl  C(ffi_closure_win64_alt)
+        FFI_HIDDEN(C(ffi_closure_win64_alt))
+
+        SEH(.seh_proc ffi_closure_win64_alt)
+C(ffi_closure_win64_alt):
+        _CET_ENDBR
+        movq    8(%rsp), %r10
+        addq    $16, %rsp
+        jmp     C(ffi_closure_win64)
+        SEH(.seh_endproc)
+#endif
 #endif /* __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64_intel.S
@@ -10,16 +10,16 @@
 
 #ifdef X86_WIN64
 #define SEH(...) __VA_ARGS__
-#define arg0	rcx
-#define arg1	rdx
-#define arg2	r8
-#define arg3	r9
+#define arg0    rcx
+#define arg1    rdx
+#define arg2    r8
+#define arg3    r9
 #else
 #define SEH(...)
-#define arg0	rdi
-#define arg1	rsi
-#define arg2	rdx
-#define arg3	rcx
+#define arg0    rdi
+#define arg1    rsi
+#define arg2    rdx
+#define arg3    rcx
 #endif
 
 /* This macro allows the safe creation of jump tables without an
@@ -27,14 +27,14 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	ALIGN 8
+# define E(BASE, X)     ALIGN 8
 #else
-# define E(BASE, X)	ALIGN 8; ORG BASE + X * 8
+# define E(BASE, X)     ALIGN 8; ORG BASE + (X) * 8
 #endif
 
-	.CODE
-	extern PLT(C(abort)):near
-	extern C(ffi_closure_win64_inner):near
+        .CODE
+        extern PLT(C(abort)):near
+        extern C(ffi_closure_win64_inner):near
 
 /* ffi_call_win64 (void *stack, struct win64_call_frame *frame, void *r10)
 
@@ -42,196 +42,197 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-	ALIGN	8
-	PUBLIC	C(ffi_call_win64)
+        ALIGN   8
+        PUBLIC  C(ffi_call_win64)
 
-	; SEH(.safesh ffi_call_win64)
+        ; SEH(.safesh ffi_call_win64)
 C(ffi_call_win64) proc SEH(frame)
-	cfi_startproc
-	/* Set up the local stack frame and install it in rbp/rsp.  */
-	mov	RAX, [RSP] ; 	movq	(%rsp), %rax
-	mov [arg1], RBP ; movq	%rbp, (arg1)
-	mov [arg1 + 8], RAX;	movq	%rax, 8(arg1)
-	mov	 RBP, arg1; movq	arg1, %rbp
-	cfi_def_cfa(rbp, 16)
-	cfi_rel_offset(rbp, 0)
-	SEH(.pushreg rbp)
-	SEH(.setframe rbp, 0)
-	SEH(.endprolog)
-	mov	RSP, arg0 ;	movq	arg0, %rsp
+        cfi_startproc
+        /* Set up the local stack frame and install it in rbp/rsp.  */
+        mov     RAX, [RSP] ;    movq    (%rsp), %rax
+        mov [arg1], RBP ; movq  %rbp, (arg1)
+        mov [arg1 + 8], RAX;    movq    %rax, 8(arg1)
+        mov      RBP, arg1; movq        arg1, %rbp
+        cfi_def_cfa(rbp, 16)
+        cfi_rel_offset(rbp, 0)
+        SEH(.pushreg rbp)
+        SEH(.setframe rbp, 0)
+        SEH(.endprolog)
+        mov     RSP, arg0 ;     movq    arg0, %rsp
 
-	mov	R10, arg2 ; movq	arg2, %r10
+        mov     R10, arg2 ; movq        arg2, %r10
 
-	/* Load all slots into both general and xmm registers.  */
-	mov	RCX, [RSP] ;	movq	(%rsp), %rcx
-	movsd XMM0, qword ptr [RSP] ; movsd	(%rsp), %xmm0
-	mov	RDX, [RSP + 8] ;movq	8(%rsp), %rdx
-	movsd XMM1, qword ptr [RSP + 8];	movsd	8(%rsp), %xmm1
-	mov R8, [RSP + 16] ; movq	16(%rsp), %r8
-	movsd	XMM2, qword ptr [RSP + 16] ; movsd	16(%rsp), %xmm2
-	mov	R9, [RSP + 24] ; movq	24(%rsp), %r9
-	movsd	XMM3, qword ptr [RSP + 24] ;movsd	24(%rsp), %xmm3
+        /* Load all slots into both general and xmm registers.  */
+        mov     RCX, [RSP] ;    movq    (%rsp), %rcx
+        movsd XMM0, qword ptr [RSP] ; movsd     (%rsp), %xmm0
+        mov     RDX, [RSP + 8] ;movq    8(%rsp), %rdx
+        movsd XMM1, qword ptr [RSP + 8];        movsd   8(%rsp), %xmm1
+        mov R8, [RSP + 16] ; movq       16(%rsp), %r8
+        movsd   XMM2, qword ptr [RSP + 16] ; movsd      16(%rsp), %xmm2
+        mov     R9, [RSP + 24] ; movq   24(%rsp), %r9
+        movsd   XMM3, qword ptr [RSP + 24] ;movsd       24(%rsp), %xmm3
 
-	CALL qword ptr [RBP + 16] ; call	*16(%rbp)
+        CALL qword ptr [RBP + 16] ; call        *16(%rbp)
 
-	mov	 ECX, [RBP + 24] ; movl	24(%rbp), %ecx
-	mov	R8, [RBP + 32] ; movq	32(%rbp), %r8
-	LEA	R10, ffi_call_win64_tab ; leaq	0f(%rip), %r10
-	CMP	ECX, FFI_TYPE_SMALL_STRUCT_4B ; cmpl	$FFI_TYPE_SMALL_STRUCT_4B, %ecx
-	LEA	R10, [R10 + RCX*8] ; leaq	(%r10, %rcx, 8), %r10
-	JA	L99 ; ja	99f
-	JMP	R10 ; jmp	*%r10
+        mov      ECX, [RBP + 24] ; movl 24(%rbp), %ecx
+        mov     R8, [RBP + 32] ; movq   32(%rbp), %r8
+        LEA     R10, ffi_call_win64_tab ; leaq  0f(%rip), %r10
+        CMP     ECX, FFI_TYPE_SMALL_STRUCT_4B ; cmpl    $FFI_TYPE_SMALL_STRUCT_4B, %ecx
+        LEA     R10, [R10 + RCX*8] ; leaq       (%r10, %rcx, 8), %r10
+        JA      L99 ; ja        99f
+        JMP     R10 ; jmp       *%r10
 
 /* Below, we're space constrained most of the time.  Thus we eschew the
    modern "mov, pop, ret" sequence (5 bytes) for "leave, ret" (2 bytes).  */
 epilogue macro
-	LEAVE
-	cfi_remember_state
-	cfi_def_cfa(rsp, 8)
-	cfi_restore(rbp)
-	RET
-	cfi_restore_state
+        LEAVE
+        cfi_remember_state
+        cfi_def_cfa(rsp, 8)
+        cfi_restore(rbp)
+        RET
+        cfi_restore_state
 endm
 
-	ALIGN 8
+        ALIGN 8
 ffi_call_win64_tab LABEL NEAR
 E(0b, FFI_TYPE_VOID)
-	epilogue
+        epilogue
 E(0b, FFI_TYPE_INT)
-	movsxd rax, eax ; movslq	%eax, %rax
-	mov qword ptr [r8], rax; movq	%rax, (%r8)
-	epilogue
+        movsxd rax, eax ; movslq        %eax, %rax
+        mov qword ptr [r8], rax; movq   %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_FLOAT)
-	movss dword ptr [r8], xmm0 ; movss	%xmm0, (%r8)
-	epilogue
+        movss dword ptr [r8], xmm0 ; movss      %xmm0, (%r8)
+        epilogue
 E(0b, FFI_TYPE_DOUBLE)
-	movsd qword ptr[r8], xmm0; movsd	%xmm0, (%r8)
-	epilogue
-E(0b, FFI_TYPE_LONGDOUBLE)
-	call	PLT(C(abort))
+        movsd qword ptr[r8], xmm0; movsd        %xmm0, (%r8)
+        epilogue
+// FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
+E(0b, FFI_TYPE_DOUBLE + 1)
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
-	movzx eax, al ;movzbl	%al, %eax
-	mov qword ptr[r8], rax; movq	%rax, (%r8)
-	epilogue
+        movzx eax, al ;movzbl   %al, %eax
+        mov qword ptr[r8], rax; movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT8)
-	movsx rax, al ; movsbq	%al, %rax
-	jmp	L98
+        movsx rax, al ; movsbq  %al, %rax
+        jmp     L98
 E(0b, FFI_TYPE_UINT16)
-	movzx eax, ax ; movzwl	%ax, %eax
-	mov qword ptr[r8], rax; movq	%rax, (%r8)
-	epilogue
+        movzx eax, ax ; movzwl  %ax, %eax
+        mov qword ptr[r8], rax; movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT16)
-	movsx rax, ax; movswq	%ax, %rax
-	jmp	L98
+        movsx rax, ax; movswq   %ax, %rax
+        jmp     L98
 E(0b, FFI_TYPE_UINT32)
-	mov eax, eax; movl	%eax, %eax
-	mov qword ptr[r8], rax ; movq	%rax, (%r8)
-	epilogue
+        mov eax, eax; movl      %eax, %eax
+        mov qword ptr[r8], rax ; movq   %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT32)
-	movsxd rax, eax; movslq	%eax, %rax
-	mov qword ptr [r8], rax; movq	%rax, (%r8)
-	epilogue
+        movsxd rax, eax; movslq %eax, %rax
+        mov qword ptr [r8], rax; movq   %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_UINT64)
 L98 LABEL near
-	mov qword ptr [r8], rax ; movq	%rax, (%r8)
-	epilogue
+        mov qword ptr [r8], rax ; movq  %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SINT64)
-	mov qword ptr [r8], rax;movq	%rax, (%r8)
-	epilogue
+        mov qword ptr [r8], rax;movq    %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_STRUCT)
-	epilogue
+        epilogue
 E(0b, FFI_TYPE_POINTER)
-	mov qword ptr [r8], rax ;movq	%rax, (%r8)
-	epilogue
+        mov qword ptr [r8], rax ;movq   %rax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_COMPLEX)
-	call	PLT(C(abort))
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
-	mov byte ptr [r8], al ; movb	%al, (%r8)
-	epilogue
+        mov byte ptr [r8], al ; movb    %al, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_2B)
-	mov word ptr [r8], ax ; movw	%ax, (%r8)
-	epilogue
+        mov word ptr [r8], ax ; movw    %ax, (%r8)
+        epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_4B)
-	mov dword ptr [r8], eax ; movl	%eax, (%r8)
-	epilogue
+        mov dword ptr [r8], eax ; movl  %eax, (%r8)
+        epilogue
 
-	align	8
+        align   8
 L99 LABEL near
-	call	PLT(C(abort))
+        call    PLT(C(abort))
 
-	epilogue
+        epilogue
 
-	cfi_endproc
-	C(ffi_call_win64) endp
+        cfi_endproc
+        C(ffi_call_win64) endp
 
 
 /* 32 bytes of outgoing register stack space, 8 bytes of alignment,
    16 bytes of result, 32 bytes of xmm registers.  */
-#define ffi_clo_FS	(32+8+16+32)
-#define ffi_clo_OFF_R	(32+8)
-#define ffi_clo_OFF_X	(32+8+16)
+#define ffi_clo_FS      (32+8+16+32)
+#define ffi_clo_OFF_R   (32+8)
+#define ffi_clo_OFF_X   (32+8+16)
 
-	align	8
-	PUBLIC	C(ffi_go_closure_win64)
+        align   8
+        PUBLIC  C(ffi_go_closure_win64)
 
 C(ffi_go_closure_win64) proc
-	cfi_startproc
-	/* Save all integer arguments into the incoming reg stack space.  */
-	mov qword ptr [rsp + 8], rcx; movq	%rcx, 8(%rsp)
-	mov qword ptr [rsp + 16], rdx; movq	%rdx, 16(%rsp)
-	mov qword ptr [rsp + 24], r8; movq	%r8, 24(%rsp)
-	mov qword ptr [rsp + 32], r9 ;movq	%r9, 32(%rsp)
+        cfi_startproc
+        /* Save all integer arguments into the incoming reg stack space.  */
+        mov qword ptr [rsp + 8], rcx; movq      %rcx, 8(%rsp)
+        mov qword ptr [rsp + 16], rdx; movq     %rdx, 16(%rsp)
+        mov qword ptr [rsp + 24], r8; movq      %r8, 24(%rsp)
+        mov qword ptr [rsp + 32], r9 ;movq      %r9, 32(%rsp)
 
-	mov rcx, qword ptr [r10 + 8]; movq	8(%r10), %rcx			/* load cif */
-	mov rdx, qword ptr [r10 + 16];  movq	16(%r10), %rdx			/* load fun */
-	mov r8, r10 ; movq	%r10, %r8			/* closure is user_data */
-	jmp	ffi_closure_win64_2
-	cfi_endproc
-	C(ffi_go_closure_win64) endp
+        mov rcx, qword ptr [r10 + 8]; movq      8(%r10), %rcx                   /* load cif */
+        mov rdx, qword ptr [r10 + 16];  movq    16(%r10), %rdx                  /* load fun */
+        mov r8, r10 ; movq      %r10, %r8                       /* closure is user_data */
+        jmp     ffi_closure_win64_2
+        cfi_endproc
+        C(ffi_go_closure_win64) endp
 
-	align	8
+        align   8
 
 PUBLIC C(ffi_closure_win64)
 C(ffi_closure_win64) PROC FRAME
-	cfi_startproc
-	/* Save all integer arguments into the incoming reg stack space.  */
-	mov qword ptr [rsp + 8], rcx; movq	%rcx, 8(%rsp)
-	mov qword ptr [rsp + 16], rdx;	movq	%rdx, 16(%rsp)
-	mov qword ptr [rsp + 24], r8; 	movq	%r8, 24(%rsp)
-	mov qword ptr [rsp + 32], r9;	movq	%r9, 32(%rsp)
+        cfi_startproc
+        /* Save all integer arguments into the incoming reg stack space.  */
+        mov qword ptr [rsp + 8], rcx; movq      %rcx, 8(%rsp)
+        mov qword ptr [rsp + 16], rdx;  movq    %rdx, 16(%rsp)
+        mov qword ptr [rsp + 24], r8;   movq    %r8, 24(%rsp)
+        mov qword ptr [rsp + 32], r9;   movq    %r9, 32(%rsp)
 
-	mov rcx, qword ptr [FFI_TRAMPOLINE_SIZE + r10]	;movq	FFI_TRAMPOLINE_SIZE(%r10), %rcx		/* load cif */
-	mov rdx, qword ptr [FFI_TRAMPOLINE_SIZE + 8 + r10] ;	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rdx	/* load fun */
-	mov r8, qword ptr [FFI_TRAMPOLINE_SIZE+16+r10] ;movq	FFI_TRAMPOLINE_SIZE+16(%r10), %r8	/* load user_data */
+        mov rcx, qword ptr [FFI_TRAMPOLINE_SIZE + r10]  ;movq   FFI_TRAMPOLINE_SIZE(%r10), %rcx         /* load cif */
+        mov rdx, qword ptr [FFI_TRAMPOLINE_SIZE + 8 + r10] ;    movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rdx       /* load fun */
+        mov r8, qword ptr [FFI_TRAMPOLINE_SIZE+16+r10] ;movq    FFI_TRAMPOLINE_SIZE+16(%r10), %r8       /* load user_data */
 ffi_closure_win64_2 LABEL near
-	sub rsp, ffi_clo_FS ;subq	$ffi_clo_FS, %rsp
-	cfi_adjust_cfa_offset(ffi_clo_FS)
-	SEH(.allocstack ffi_clo_FS)
-	SEH(.endprolog)
+        sub rsp, ffi_clo_FS ;subq       $ffi_clo_FS, %rsp
+        cfi_adjust_cfa_offset(ffi_clo_FS)
+        SEH(.allocstack ffi_clo_FS)
+        SEH(.endprolog)
 
-	/* Save all sse arguments into the stack frame.  */
-	movsd qword ptr [ffi_clo_OFF_X + rsp], xmm0	; movsd	%xmm0, ffi_clo_OFF_X(%rsp)
-	movsd qword ptr [ffi_clo_OFF_X+8+rsp], xmm1 ; movsd	%xmm1, ffi_clo_OFF_X+8(%rsp)
-	movsd qword ptr [ffi_clo_OFF_X+16+rsp], xmm2 ; movsd %xmm2, ffi_clo_OFF_X+16(%rsp)
-	movsd qword ptr [ffi_clo_OFF_X+24+rsp], xmm3 ; movsd %xmm3, ffi_clo_OFF_X+24(%rsp)
+        /* Save all sse arguments into the stack frame.  */
+        movsd qword ptr [ffi_clo_OFF_X + rsp], xmm0     ; movsd %xmm0, ffi_clo_OFF_X(%rsp)
+        movsd qword ptr [ffi_clo_OFF_X+8+rsp], xmm1 ; movsd     %xmm1, ffi_clo_OFF_X+8(%rsp)
+        movsd qword ptr [ffi_clo_OFF_X+16+rsp], xmm2 ; movsd %xmm2, ffi_clo_OFF_X+16(%rsp)
+        movsd qword ptr [ffi_clo_OFF_X+24+rsp], xmm3 ; movsd %xmm3, ffi_clo_OFF_X+24(%rsp)
 
-	lea	r9, [ffi_clo_OFF_R + rsp] ; leaq	ffi_clo_OFF_R(%rsp), %r9
-	call C(ffi_closure_win64_inner)
+        lea     r9, [ffi_clo_OFF_R + rsp] ; leaq        ffi_clo_OFF_R(%rsp), %r9
+        call C(ffi_closure_win64_inner)
 
-	/* Load the result into both possible result registers.  */
+        /* Load the result into both possible result registers.  */
 
-	mov rax, qword ptr [ffi_clo_OFF_R + rsp] ;movq    ffi_clo_OFF_R(%rsp), %rax
-	movsd xmm0, qword ptr [rsp + ffi_clo_OFF_R] ;movsd   ffi_clo_OFF_R(%rsp), %xmm0
+        mov rax, qword ptr [ffi_clo_OFF_R + rsp] ;movq    ffi_clo_OFF_R(%rsp), %rax
+        movsd xmm0, qword ptr [rsp + ffi_clo_OFF_R] ;movsd   ffi_clo_OFF_R(%rsp), %xmm0
 
-	add rsp, ffi_clo_FS ;addq	$ffi_clo_FS, %rsp
-	cfi_adjust_cfa_offset(-ffi_clo_FS)
-	ret
+        add rsp, ffi_clo_FS ;addq       $ffi_clo_FS, %rsp
+        cfi_adjust_cfa_offset(-ffi_clo_FS)
+        ret
 
-	cfi_endproc
-	C(ffi_closure_win64) endp
+        cfi_endproc
+        C(ffi_closure_win64) endp
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif
 _text ends
 end


### PR DESCRIPTION
Clean backport to `jfx11u`. Tested in connection with gstreamer / glib update in the `test-kcr-11.0.16` branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280840](https://bugs.openjdk.java.net/browse/JDK-8280840): Update libFFI to 3.4.2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/93.diff">https://git.openjdk.java.net/jfx11u/pull/93.diff</a>

</details>
