### PR TITLE
8281564: Update cmake to 3.22.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -93,6 +93,6 @@ jfx.build.windows.msvc.version=VS2019-16.9.3+1.0
 jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools
-jfx.build.cmake.version=3.13.3
+jfx.build.cmake.version=3.22.3
 jfx.build.ninja.version=1.8.2
 jfx.build.ant.version=1.10.5


### PR DESCRIPTION
Simple backport to `jfx11u`. It isn't a clean backport since the mainline patch had an update to `gradle/verification-metadata.xml`, which doesn't exist in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281564](https://bugs.openjdk.java.net/browse/JDK-8281564): Update cmake to 3.22.3


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/95.diff">https://git.openjdk.java.net/jfx11u/pull/95.diff</a>

</details>
