### PR TITLE
8286256: Update libxml2 to 2.9.14

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.9.13
+## xmlsoft.org: libxml2 v2.9.14
 
 ### libxml2 License
 ```

--- a/modules/javafx.web/src/main/legal/libxslt.md
+++ b/modules/javafx.web/src/main/legal/libxslt.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxslt v1.1.34
+## xmlsoft.org: libxslt v1.1.35
 
 ### libxslt License
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/UPDATING.txt
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/UPDATING.txt
@@ -41,15 +41,17 @@ Updating libxml in OpenJFX:
 
 9.2 Copy libxml\src\config.h to libxml\linux\config.h
 
-10. Helper commands for removing tabs and trailing whitespaces from source files(.h and .c).
+10. Update version info in 'modules/javafx.web/src/main/legal/libxml.md'. Also, update copyright if any new files are added.
 
-10.1 > cd modules/javafx.web/src/main/native/Source/ThirdParty/libxml
+11. Helper commands for removing tabs and trailing whitespaces from source files(.h and .c).
 
-10.2 Remove tabs from source files:
+11.1 > cd modules/javafx.web/src/main/native/Source/ThirdParty/libxml
+
+11.2 Remove tabs from source files:
     > sudo apt install moreutils
     > find src/ -name "*.c" -type f -exec bash -c 'expand -t 8 "$0" | sponge "$0"' {} \;
     > find src/ -name "*.h" -type f -exec bash -c 'expand -t 8 "$0" | sponge "$0"' {} \;
 
-10.3 Remove trailing whitespaces from source files:
+11.3 Remove trailing whitespaces from source files:
     > find src/ -name “*.c” -type f -exec sed --in-place 's/[[:space:]]\+$//' {} \+
     > find src/ -name “*.h” -type f -exec sed --in-place 's/[[:space:]]\+$//' {} \+

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
@@ -241,7 +241,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.9.13"
+#define PACKAGE_STRING "libxml2 2.9.14"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -250,7 +250,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.9.13"
+#define PACKAGE_VERSION "2.9.14"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
@@ -265,7 +265,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.9.13"
+#define VERSION "2.9.14"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.13"
+#define LIBXML_DOTTED_VERSION "2.9.14"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20913
+#define LIBXML_VERSION 20914
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20913"
+#define LIBXML_VERSION_STRING "20914"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20913);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20914);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
@@ -22,14 +22,15 @@
 /* Define to 1 if you have the <ctype.h> header file. */
 #define HAVE_CTYPE_H 1
 
-/* Define to 1 if you have the <dirent.h> header file. */
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+   */
 #define HAVE_DIRENT_H 1
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
 /* Have dlopen based dso */
-/* #undef HAVE_DLOPEN */
+#define HAVE_DLOPEN /**/
 
 /* Define to 1 if you have the <dl.h> header file. */
 /* #undef HAVE_DL_H */
@@ -61,17 +62,8 @@
 /* Define to 1 if you have the `isascii' function. */
 #define HAVE_ISASCII 1
 
-/* Define if isinf is there */
-#define HAVE_ISINF /**/
-
-/* Define if isnan is there */
-#define HAVE_ISNAN /**/
-
 /* Define if history library is there (-lhistory) */
 /* #undef HAVE_LIBHISTORY */
-
-/* Define if pthread library is there (-lpthread) */
-#define HAVE_LIBPTHREAD /**/
 
 /* Define if readline library is there (-lreadline) */
 /* #undef HAVE_LIBREADLINE */
@@ -90,9 +82,6 @@
 
 /* Define to 1 if you have the <math.h> header file. */
 #define HAVE_MATH_H 1
-
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `mmap' function. */
 #define HAVE_MMAP 1
@@ -130,7 +119,7 @@
 #define HAVE_RAND 1
 
 /* Define to 1 if you have the `rand_r' function. */
-/* #undef HAVE_RAND_R 1 */
+#define HAVE_RAND_R 1
 
 /* Define to 1 if you have the <resolv.h> header file. */
 #define HAVE_RESOLV_H 1
@@ -164,6 +153,9 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -234,7 +226,7 @@
 /* #undef HAVE___VA_COPY */
 
 /* Define as const if the declaration of iconv() needs const. */
-/* #undef ICONV_CONST */
+#define ICONV_CONST
 
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
@@ -246,24 +238,26 @@
 #define PACKAGE_BUGREPORT ""
 
 /* Define to the full name of this package. */
-#define PACKAGE_NAME ""
+#define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING ""
+#define PACKAGE_STRING "libxml2 2.9.14"
 
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME ""
+#define PACKAGE_TARNAME "libxml2"
 
 /* Define to the home page for this package. */
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION ""
+#define PACKAGE_VERSION "2.9.14"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
 /* Support for IPv6 */
@@ -273,7 +267,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.9.12"
+#define VERSION "2.9.14"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.13"
+#define LIBXML_DOTTED_VERSION "2.9.14"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20913
+#define LIBXML_VERSION 20914
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20913"
+#define LIBXML_VERSION_STRING "20914"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20913);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20914);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLparser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLparser.c
@@ -614,7 +614,8 @@ htmlSkipBlankChars(xmlParserCtxtPtr ctxt) {
             if (*ctxt->input->cur == 0)
                 xmlParserInputGrow(ctxt->input, INPUT_CHUNK);
         }
-        res++;
+        if (res < INT_MAX)
+            res++;
     }
     return(res);
 }
@@ -3960,26 +3961,6 @@ htmlParseStartTag(htmlParserCtxtPtr ctxt) {
         htmlParseErr(ctxt, XML_ERR_NAME_REQUIRED,
                      "htmlParseStartTag: invalid element name\n",
                      NULL, NULL);
-        /*
-         * The recovery code is disabled for now as it can result in
-         * quadratic behavior with the push parser. htmlParseStartTag
-         * must consume all content up to the final '>' in order to avoid
-         * rescanning for this terminator.
-         *
-         * For a proper fix in line with HTML5, htmlParseStartTag and
-         * htmlParseElement should only be called when there's an ASCII
-         * alpha character following the initial '<'. Otherwise, the '<'
-         * should be emitted as text (unless followed by '!', '/' or '?').
-         */
-#if 0
-        /* if recover preserve text on classic misconstructs */
-        if ((ctxt->recovery) && ((IS_BLANK_CH(CUR)) || (CUR == '<') ||
-            (CUR == '=') || (CUR == '>') || (((CUR >= '0') && (CUR <= '9'))))) {
-            htmlParseCharDataInternal(ctxt, '<');
-            return(-1);
-        }
-#endif
-
         /* Dump the bogus tag like browsers do */
         while ((CUR != 0) && (CUR != '>') &&
                (ctxt->instate != XML_PARSER_EOF))
@@ -4432,8 +4413,14 @@ htmlParseContent(htmlParserCtxtPtr ctxt) {
             /*
              * Third case :  a sub-element.
              */
-            else if (CUR == '<') {
+            else if ((CUR == '<') && IS_ASCII_LETTER(NXT(1))) {
                 htmlParseElement(ctxt);
+            }
+            else if (CUR == '<') {
+                if ((ctxt->sax != NULL) && (!ctxt->disableSAX) &&
+                    (ctxt->sax->characters != NULL))
+                    ctxt->sax->characters(ctxt->userData, BAD_CAST "<", 1);
+                NEXT;
             }
 
             /*
@@ -4831,12 +4818,18 @@ htmlParseContentInternal(htmlParserCtxtPtr ctxt) {
             /*
              * Third case :  a sub-element.
              */
-            else if (CUR == '<') {
+            else if ((CUR == '<') && IS_ASCII_LETTER(NXT(1))) {
                 htmlParseElementInternal(ctxt);
                 if (currentNode != NULL) xmlFree(currentNode);
 
                 currentNode = xmlStrdup(ctxt->name);
                 depth = ctxt->nameNr;
+            }
+            else if (CUR == '<') {
+                if ((ctxt->sax != NULL) && (!ctxt->disableSAX) &&
+                    (ctxt->sax->characters != NULL))
+                    ctxt->sax->characters(ctxt->userData, BAD_CAST "<", 1);
+                NEXT;
             }
 
             /*
@@ -6004,7 +5997,7 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
                                 "HPP: entering END_TAG\n");
 #endif
                         break;
-                    } else if (cur == '<') {
+                    } else if ((cur == '<') && IS_ASCII_LETTER(next)) {
                         if ((!terminate) && (next == 0))
                             goto done;
                         ctxt->instate = XML_PARSER_START_TAG;
@@ -6014,6 +6007,12 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
                                 "HPP: entering START_TAG\n");
 #endif
                         break;
+                    } else if (cur == '<') {
+                        if ((ctxt->sax != NULL) && (!ctxt->disableSAX) &&
+                            (ctxt->sax->characters != NULL))
+                            ctxt->sax->characters(ctxt->userData,
+                                                  BAD_CAST "<", 1);
+                        NEXT;
                     } else {
                         /*
                          * check that the text sequence is complete

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -1,12 +1,36 @@
 
         NEWS file for libxml2
 
-The change log at 
-ChangeLog.html
- describes the recents commits
-to the GIT at 
-https://gitlab.gnome.org/GNOME/libxml2
- code base.Here is the list of public releases:
+v2.9.14: May 02 2022:
+   - Security:
+  [CVE-2022-29824] Integer overflow in xmlBuf and xmlBuffer
+  Fix potential double-free in xmlXPtrStringRangeFunction
+  Fix memory leak in xmlFindCharEncodingHandler
+  Normalize XPath strings in-place
+  Prevent integer-overflow in htmlSkipBlankChars() and xmlSkipBlankChars()
+    (David Kilzer)
+  Fix leak of xmlElementContent (David Kilzer)
+
+   - Bug fixes:
+  Fix parsing of subtracted regex character classes
+  Fix recursion check in xinclude.c
+  Reset last error in xmlCleanupGlobals
+  Fix certain combinations of regex range quantifiers
+  Fix range quantifier on subregex
+
+   - Improvements:
+  Fix recovery from invalid HTML start tags
+
+   - Build system, portability:
+  Define LFS macros before including system headers
+  Initialize XPath floating-point globals
+  configure: check for icu DEFS (James Hilliard)
+  configure.ac: produce tar.xz only (GNOME policy) (David Seifert)
+  CMakeLists.txt: Fix LIBXML_VERSION_NUMBER
+  Fix build with older Python versions
+  Fix --without-valid build
+
+
 v2.9.13: Feb 19 2022:
    - Security:
   [CVE-2022-23308] Use-after-free of ID and IDREF attributes

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README.md
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README.md
@@ -17,6 +17,99 @@ A mailing list xml@gnome.org is available. You can subscribe at
 
 This code is released under the MIT License, see the Copyright file.
 
+## Build instructions
+
+libxml2 can be built with GNU Autotools, CMake, or several other build
+systems in platform-specific subdirectories.
+
+### Autotools (for POSIX systems like Linux, BSD, macOS)
+
+If you build from a Git tree, you have to install Autotools and start
+by generating the configuration files with:
+
+    ./autogen.sh
+
+If you build from a source tarball, extract the archive with:
+
+    tar xf libxml2-xxx.tar.gz
+    cd libxml2-xxx
+
+To see a list of build options:
+
+    ./configure --help
+
+Also see the INSTALL file for additional instructions. Then you can
+configure and build the library:
+
+    ./configure [possible options]
+    make
+
+Now you can run the test suite with:
+
+    make check
+
+Please report test failures to the mailing list or bug tracker.
+
+Then you can install the library:
+
+    make install
+
+At that point you may have to rerun ldconfig or a similar utility to
+update your list of installed shared libs.
+
+### CMake (mainly for Windows)
+
+Another option for compiling libxml is using CMake:
+
+    cmake -E tar xf libxml2-xxx.tar.gz
+    cmake -S libxml2-xxx -B libxml2-xxx-build [possible options]
+    cmake --build libxml2-xxx-build
+    cmake --install libxml2-xxx-build
+
+Common CMake options include:
+
+    -D BUILD_SHARED_LIBS=OFF            # build static libraries
+    -D CMAKE_BUILD_TYPE=Release         # specify build type
+    -D CMAKE_INSTALL_PREFIX=/usr/local  # specify the install path
+    -D LIBXML2_WITH_ICONV=OFF           # disable iconv
+    -D LIBXML2_WITH_LZMA=OFF            # disable liblzma
+    -D LIBXML2_WITH_PYTHON=OFF          # disable Python
+    -D LIBXML2_WITH_ZLIB=OFF            # disable libz
+
+You can also open the libxml source directory with its CMakeLists.txt
+directly in various IDEs such as CLion, QtCreator, or Visual Studio.
+
+## Dependencies
+
+Libxml does not require any other libraries. A platform with somewhat
+recent POSIX support should be sufficient (please report any violation
+to this rule you may find).
+
+However, if found at configuration time, libxml will detect and use
+the following libraries:
+
+- [libz](https://zlib.net/), a highly portable and widely available
+  compression library.
+- [liblzma](https://tukaani.org/xz/), another compression library.
+- [libiconv](https://www.gnu.org/software/libiconv/), a character encoding
+  conversion library. The iconv function is part of POSIX.1-2001, so
+  libiconv isn't required on modern UNIX-like systems like Linux, BSD or
+  macOS.
+- [ICU](https://icu.unicode.org/), a Unicode library. Mainly useful as an
+  alternative to iconv on Windows. Unnecessary on most other systems.
+
+## Contributing
+
+The current version of the code can be found in GNOME's GitLab at 
+at <https://gitlab.gnome.org/GNOME/libxml2>. The best way to get involved
+is by creating issues and merge requests on GitLab. Alternatively, you can
+start discussions and send patches to the mailing list. If you want to
+work with patches, please format them with git-format-patch and use plain
+text attachments.
+
+All code must conform to C89 and pass the GitLab CI tests. Add regression
+tests if possible.
+
 ## Authors
 
 - Daniel Veillard
@@ -25,3 +118,4 @@ This code is released under the MIT License, see the Copyright file.
 - Igor Zlatkovic for the Windows port
 - Aleksey Sanin
 - Nick Wellnhofer
+

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/buf.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/buf.c
@@ -30,6 +30,10 @@
 #include <libxml/parserInternals.h> /* for XML_MAX_TEXT_LENGTH */
 #include "buf.h"
 
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t) -1)
+#endif
+
 #define WITH_BUFFER_COMPAT
 
 /**
@@ -156,6 +160,8 @@ xmlBufPtr
 xmlBufCreateSize(size_t size) {
     xmlBufPtr ret;
 
+    if (size == SIZE_MAX)
+        return(NULL);
     ret = (xmlBufPtr) xmlMalloc(sizeof(xmlBuf));
     if (ret == NULL) {
         xmlBufMemoryError(NULL, "creating buffer");
@@ -166,8 +172,8 @@ xmlBufCreateSize(size_t size) {
     ret->error = 0;
     ret->buffer = NULL;
     ret->alloc = xmlBufferAllocScheme;
-    ret->size = (size ? size+2 : 0);         /* +1 for ending null */
-    ret->compat_size = (int) ret->size;
+    ret->size = (size ? size + 1 : 0);         /* +1 for ending null */
+    ret->compat_size = (ret->size > INT_MAX ? INT_MAX : ret->size);
     if (ret->size){
         ret->content = (xmlChar *) xmlMallocAtomic(ret->size * sizeof(xmlChar));
         if (ret->content == NULL) {
@@ -442,23 +448,17 @@ xmlBufGrowInternal(xmlBufPtr buf, size_t len) {
     CHECK_COMPAT(buf)
 
     if (buf->alloc == XML_BUFFER_ALLOC_IMMUTABLE) return(0);
-    if (buf->use + len < buf->size)
+    if (len < buf->size - buf->use)
         return(buf->size - buf->use);
+    if (len > SIZE_MAX - buf->use)
+        return(0);
 
-    /*
-     * Windows has a BIG problem on realloc timing, so we try to double
-     * the buffer size (if that's enough) (bug 146697)
-     * Apparently BSD too, and it's probably best for linux too
-     * On an embedded system this may be something to change
-     */
-#if 1
-    if (buf->size > (size_t) len)
-        size = buf->size * 2;
-    else
-        size = buf->use + len + 100;
-#else
-    size = buf->use + len + 100;
-#endif
+    if (buf->size > (size_t) len) {
+        size = buf->size > SIZE_MAX / 2 ? SIZE_MAX : buf->size * 2;
+    } else {
+        size = buf->use + len;
+        size = size > SIZE_MAX - 100 ? SIZE_MAX : size + 100;
+    }
 
     if (buf->alloc == XML_BUFFER_ALLOC_BOUNDED) {
         /*
@@ -744,7 +744,7 @@ xmlBufIsEmpty(const xmlBufPtr buf)
 int
 xmlBufResize(xmlBufPtr buf, size_t size)
 {
-    unsigned int newSize;
+    size_t newSize;
     xmlChar* rebuf = NULL;
     size_t start_buf;
 
@@ -772,9 +772,13 @@ xmlBufResize(xmlBufPtr buf, size_t size)
         case XML_BUFFER_ALLOC_IO:
         case XML_BUFFER_ALLOC_DOUBLEIT:
             /*take care of empty case*/
-            newSize = (buf->size ? buf->size*2 : size + 10);
+            if (buf->size == 0) {
+                newSize = (size > SIZE_MAX - 10 ? SIZE_MAX : size + 10);
+            } else {
+                newSize = buf->size;
+            }
             while (size > newSize) {
-                if (newSize > UINT_MAX / 2) {
+                if (newSize > SIZE_MAX / 2) {
                     xmlBufMemoryError(buf, "growing buffer");
                     return 0;
                 }
@@ -782,15 +786,15 @@ xmlBufResize(xmlBufPtr buf, size_t size)
             }
             break;
         case XML_BUFFER_ALLOC_EXACT:
-            newSize = size+10;
+            newSize = (size > SIZE_MAX - 10 ? SIZE_MAX : size + 10);
             break;
         case XML_BUFFER_ALLOC_HYBRID:
             if (buf->use < BASE_BUFFER_SIZE)
                 newSize = size;
             else {
-                newSize = buf->size * 2;
+                newSize = buf->size;
                 while (size > newSize) {
-                    if (newSize > UINT_MAX / 2) {
+                    if (newSize > SIZE_MAX / 2) {
                         xmlBufMemoryError(buf, "growing buffer");
                         return 0;
                     }
@@ -800,7 +804,7 @@ xmlBufResize(xmlBufPtr buf, size_t size)
             break;
 
         default:
-            newSize = size+10;
+            newSize = (size > SIZE_MAX - 10 ? SIZE_MAX : size + 10);
             break;
     }
 
@@ -866,7 +870,7 @@ xmlBufResize(xmlBufPtr buf, size_t size)
  */
 int
 xmlBufAdd(xmlBufPtr buf, const xmlChar *str, int len) {
-    unsigned int needSize;
+    size_t needSize;
 
     if ((str == NULL) || (buf == NULL) || (buf->error))
         return -1;
@@ -888,8 +892,10 @@ xmlBufAdd(xmlBufPtr buf, const xmlChar *str, int len) {
     if (len < 0) return -1;
     if (len == 0) return 0;
 
-    needSize = buf->use + len + 2;
-    if (needSize > buf->size){
+    if ((size_t) len >= buf->size - buf->use) {
+        if ((size_t) len >= SIZE_MAX - buf->use)
+            return(-1);
+        needSize = buf->use + len + 1;
         if (buf->alloc == XML_BUFFER_ALLOC_BOUNDED) {
             /*
              * Used to provide parsing limits
@@ -1025,31 +1031,7 @@ xmlBufCat(xmlBufPtr buf, const xmlChar *str) {
  */
 int
 xmlBufCCat(xmlBufPtr buf, const char *str) {
-    const char *cur;
-
-    if ((buf == NULL) || (buf->error))
-        return(-1);
-    CHECK_COMPAT(buf)
-    if (buf->alloc == XML_BUFFER_ALLOC_IMMUTABLE) return -1;
-    if (str == NULL) {
-#ifdef DEBUG_BUFFER
-        xmlGenericError(xmlGenericErrorContext,
-                "xmlBufCCat: str == NULL\n");
-#endif
-        return -1;
-    }
-    for (cur = str;*cur != 0;cur++) {
-        if (buf->use  + 10 >= buf->size) {
-            if (!xmlBufResize(buf, buf->use+10)){
-                xmlBufMemoryError(buf, "growing buffer");
-                return XML_ERR_NO_MEMORY;
-            }
-        }
-        buf->content[buf->use++] = *cur;
-    }
-    buf->content[buf->use] = 0;
-    UPDATE_COMPAT(buf)
-    return 0;
+    return xmlBufCat(buf, (const xmlChar *) str);
 }
 
 /**

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.63])
 
 m4_define([MAJOR_VERSION], 2)
 m4_define([MINOR_VERSION], 9)
-m4_define([MICRO_VERSION], 13)
+m4_define([MICRO_VERSION], 14)
 
 AC_INIT([libxml2],[MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION])
 AC_CONFIG_SRCDIR([entities.c])
@@ -40,7 +40,7 @@ AC_SUBST(LIBXML_VERSION_EXTRA)
 
 VERSION=${LIBXML_VERSION}
 
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-xz])
 
 # Support silent build rules, requires at least automake-1.11. Disable
 # by either passing --disable-silent-rules to configure or passing V=1
@@ -1474,6 +1474,13 @@ else
     PKG_CHECK_MODULES([ICU],[icu-i18n],
         [have_libicu=yes],
         [have_libicu=no])
+
+    if test "x$have_libicu" = "xyes"; then
+        PKG_CHECK_VAR([ICU_DEFS], [icu-i18n], [DEFS])
+        if test "x$ICU_DEFS" != "x"; then
+            CPPFLAGS="$CPPFLAGS $ICU_DEFS"
+        fi
+    fi
 
     # If pkg-config failed, fall back to AC_CHECK_LIB. This
     # will not pick up the necessary LIBS flags for liblzma's

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/encoding.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/encoding.c
@@ -1738,6 +1738,10 @@ xmlFindCharEncodingHandler(const char *name) {
     } else if ((icv_in != (iconv_t) -1) || icv_out != (iconv_t) -1) {
             xmlEncodingErr(XML_ERR_INTERNAL_ERROR,
                     "iconv : problems with filters for '%s'\n", name);
+            if (icv_in != (iconv_t) -1)
+                iconv_close(icv_in);
+            else
+                iconv_close(icv_out);
     }
 #endif /* LIBXML_ICONV_ENABLED */
 #ifdef LIBXML_ICU_ENABLED

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
@@ -50,20 +50,6 @@ void xmlInitGlobals(void)
         xmlThrDefMutex = xmlNewMutex();
 }
 
-/**
- * xmlCleanupGlobals:
- *
- * Additional cleanup for multi-threading
- */
-void xmlCleanupGlobals(void)
-{
-    if (xmlThrDefMutex != NULL) {
-        xmlFreeMutex(xmlThrDefMutex);
-        xmlThrDefMutex = NULL;
-    }
-    __xmlGlobalInitMutexDestroy();
-}
-
 /************************************************************************
  *                                                                      *
  *      All the user accessible global variables of the library         *
@@ -575,6 +561,22 @@ xmlInitializeGlobalState(xmlGlobalStatePtr gs)
     memset(&gs->xmlLastError, 0, sizeof(xmlError));
 
     xmlMutexUnlock(xmlThrDefMutex);
+}
+
+/**
+ * xmlCleanupGlobals:
+ *
+ * Additional cleanup for multi-threading
+ */
+void xmlCleanupGlobals(void)
+{
+    xmlResetError(&xmlLastError);
+
+    if (xmlThrDefMutex != NULL) {
+        xmlFreeMutex(xmlThrDefMutex);
+        xmlThrDefMutex = NULL;
+    }
+    __xmlGlobalInitMutexDestroy();
 }
 
 /**

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.h
@@ -9,8 +9,10 @@
 #ifndef __XML_LIBXML_H__
 #define __XML_LIBXML_H__
 
-#include <libxml/xmlstring.h>
-
+/*
+ * These macros must be defined before including system headers.
+ * Do not add any #include directives above this block.
+ */
 #ifndef NO_LARGEFILE_SOURCE
 #ifndef _LARGEFILE_SOURCE
 #define _LARGEFILE_SOURCE
@@ -39,6 +41,7 @@
 #include "config.h"
 #include <libxml/xmlversion.h>
 #endif
+#include <libxml/xmlstring.h>
 
 #if defined(__Lynx__)
 #include <stdio.h> /* pull definition of size_t */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
@@ -2,7 +2,7 @@
 
 Summary: Library providing XML and HTML support
 Name: libxml2
-Version: 2.9.13
+Version: 2.9.14
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
@@ -204,6 +204,6 @@ rm -fr %{buildroot}
 %endif # with_python3
 
 %changelog
-* Tue Mar 22 2022 Daniel Veillard <veillard@redhat.com>
-- upstream release 2.9.13
+* Fri May 13 2022 Daniel Veillard <veillard@redhat.com>
+- upstream release 2.9.14
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
@@ -2208,7 +2208,8 @@ xmlSkipBlankChars(xmlParserCtxtPtr ctxt) {
                 ctxt->input->col++;
             }
             cur++;
-            res++;
+            if (res < INT_MAX)
+                res++;
             if (*cur == 0) {
                 ctxt->input->cur = cur;
                 xmlParserInputGrow(ctxt->input, INPUT_CHUNK);
@@ -2244,7 +2245,8 @@ xmlSkipBlankChars(xmlParserCtxtPtr ctxt) {
              * by the attachment of one leading and one following space (#x20)
              * character."
              */
-            res++;
+            if (res < INT_MAX)
+                res++;
         }
     }
     return(res);
@@ -14749,7 +14751,6 @@ xmlCleanupParser(void) {
     xmlSchemaCleanupTypes();
     xmlRelaxNGCleanupTypes();
 #endif
-    xmlResetLastError();
     xmlCleanupGlobals();
     xmlCleanupThreads(); /* must be last if called not from the main thread */
     xmlCleanupMemory();

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
@@ -7104,6 +7104,8 @@ xmlBufferPtr
 xmlBufferCreateSize(size_t size) {
     xmlBufferPtr ret;
 
+    if (size >= UINT_MAX)
+        return(NULL);
     ret = (xmlBufferPtr) xmlMalloc(sizeof(xmlBuffer));
     if (ret == NULL) {
         xmlTreeErrMemory("creating buffer");
@@ -7111,7 +7113,7 @@ xmlBufferCreateSize(size_t size) {
     }
     ret->use = 0;
     ret->alloc = xmlBufferAllocScheme;
-    ret->size = (size ? size+2 : 0);         /* +1 for ending null */
+    ret->size = (size ? size + 1 : 0);         /* +1 for ending null */
     if (ret->size){
         ret->content = (xmlChar *) xmlMallocAtomic(ret->size * sizeof(xmlChar));
         if (ret->content == NULL) {
@@ -7170,6 +7172,8 @@ xmlBufferCreateStatic(void *mem, size_t size) {
     xmlBufferPtr ret;
 
     if ((mem == NULL) || (size == 0))
+        return(NULL);
+    if (size > UINT_MAX)
         return(NULL);
 
     ret = (xmlBufferPtr) xmlMalloc(sizeof(xmlBuffer));
@@ -7318,28 +7322,23 @@ xmlBufferShrink(xmlBufferPtr buf, unsigned int len) {
  */
 int
 xmlBufferGrow(xmlBufferPtr buf, unsigned int len) {
-    int size;
+    unsigned int size;
     xmlChar *newbuf;
 
     if (buf == NULL) return(-1);
 
     if (buf->alloc == XML_BUFFER_ALLOC_IMMUTABLE) return(0);
-    if (len + buf->use < buf->size) return(0);
+    if (len < buf->size - buf->use)
+        return(0);
+    if (len > UINT_MAX - buf->use)
+        return(-1);
 
-    /*
-     * Windows has a BIG problem on realloc timing, so we try to double
-     * the buffer size (if that's enough) (bug 146697)
-     * Apparently BSD too, and it's probably best for linux too
-     * On an embedded system this may be something to change
-     */
-#if 1
-    if (buf->size > len)
-        size = buf->size * 2;
-    else
-        size = buf->use + len + 100;
-#else
-    size = buf->use + len + 100;
-#endif
+    if (buf->size > (size_t) len) {
+        size = buf->size > UINT_MAX / 2 ? UINT_MAX : buf->size * 2;
+    } else {
+        size = buf->use + len;
+        size = size > UINT_MAX - 100 ? UINT_MAX : size + 100;
+    }
 
     if ((buf->alloc == XML_BUFFER_ALLOC_IO) && (buf->contentIO != NULL)) {
         size_t start_buf = buf->content - buf->contentIO;
@@ -7466,7 +7465,10 @@ xmlBufferResize(xmlBufferPtr buf, unsigned int size)
         case XML_BUFFER_ALLOC_IO:
         case XML_BUFFER_ALLOC_DOUBLEIT:
             /*take care of empty case*/
-            newSize = (buf->size ? buf->size : size + 10);
+            if (buf->size == 0)
+                newSize = (size > UINT_MAX - 10 ? UINT_MAX : size + 10);
+            else
+                newSize = buf->size;
             while (size > newSize) {
                 if (newSize > UINT_MAX / 2) {
                     xmlTreeErrMemory("growing buffer");
@@ -7476,7 +7478,7 @@ xmlBufferResize(xmlBufferPtr buf, unsigned int size)
             }
             break;
         case XML_BUFFER_ALLOC_EXACT:
-            newSize = size+10;
+            newSize = (size > UINT_MAX - 10 ? UINT_MAX : size + 10);;
             break;
         case XML_BUFFER_ALLOC_HYBRID:
             if (buf->use < BASE_BUFFER_SIZE)
@@ -7494,7 +7496,7 @@ xmlBufferResize(xmlBufferPtr buf, unsigned int size)
             break;
 
         default:
-            newSize = size+10;
+            newSize = (size > UINT_MAX - 10 ? UINT_MAX : size + 10);;
             break;
     }
 
@@ -7580,8 +7582,10 @@ xmlBufferAdd(xmlBufferPtr buf, const xmlChar *str, int len) {
     if (len < 0) return -1;
     if (len == 0) return 0;
 
-    needSize = buf->use + len + 2;
-    if (needSize > buf->size){
+    if ((unsigned) len >= buf->size - buf->use) {
+        if ((unsigned) len >= UINT_MAX - buf->use)
+            return XML_ERR_NO_MEMORY;
+        needSize = buf->use + len + 1;
         if (!xmlBufferResize(buf, needSize)){
             xmlTreeErrMemory("growing buffer");
             return XML_ERR_NO_MEMORY;
@@ -7694,29 +7698,7 @@ xmlBufferCat(xmlBufferPtr buf, const xmlChar *str) {
  */
 int
 xmlBufferCCat(xmlBufferPtr buf, const char *str) {
-    const char *cur;
-
-    if (buf == NULL)
-        return(-1);
-    if (buf->alloc == XML_BUFFER_ALLOC_IMMUTABLE) return -1;
-    if (str == NULL) {
-#ifdef DEBUG_BUFFER
-        xmlGenericError(xmlGenericErrorContext,
-                "xmlBufferCCat: str == NULL\n");
-#endif
-        return -1;
-    }
-    for (cur = str;*cur != 0;cur++) {
-        if (buf->use  + 10 >= buf->size) {
-            if (!xmlBufferResize(buf, buf->use+10)){
-                xmlTreeErrMemory("growing buffer");
-                return XML_ERR_NO_MEMORY;
-            }
-        }
-        buf->content[buf->use++] = *cur;
-    }
-    buf->content[buf->use] = 0;
-    return 0;
+    return xmlBufferCat(buf, (const xmlChar *) str);
 }
 
 /**

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
@@ -27,13 +27,13 @@
 #include <libxml/globals.h>
 
 static xmlElementPtr xmlGetDtdElementDesc2(xmlDtdPtr dtd, const xmlChar *name,
-                               int create);
+                                   int create);
 /* #define DEBUG_VALID_ALGO */
 /* #define DEBUG_REGEXP_ALGO */
 
-#define TODO                                \
-    xmlGenericError(xmlGenericErrorContext,             \
-        "Unimplemented block at %s:%d\n",               \
+#define TODO                                                            \
+    xmlGenericError(xmlGenericErrorContext,                             \
+            "Unimplemented block at %s:%d\n",                           \
             __FILE__, __LINE__);
 
 #ifdef LIBXML_VALID_ENABLED
@@ -42,9 +42,9 @@ xmlValidateAttributeValueInternal(xmlDocPtr doc, xmlAttributeType type,
                                   const xmlChar *value);
 #endif
 /************************************************************************
- *                                  *
- *          Error handling routines             *
- *                                  *
+ *                                                                      *
+ *                      Error handling routines                         *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -64,14 +64,14 @@ xmlVErrMemory(xmlValidCtxtPtr ctxt, const char *extra)
     if (ctxt != NULL) {
         channel = ctxt->error;
         data = ctxt->userData;
-    /* Use the special values to detect if it is part of a parsing
-       context */
-    if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
-        (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
-        long delta = (char *) ctxt - (char *) ctxt->userData;
-        if ((delta > 0) && (delta < 250))
-        pctxt = ctxt->userData;
-    }
+        /* Use the special values to detect if it is part of a parsing
+           context */
+        if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
+            (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
+            long delta = (char *) ctxt - (char *) ctxt->userData;
+            if ((delta > 0) && (delta < 250))
+                pctxt = ctxt->userData;
+        }
     }
     if (extra)
         __xmlRaiseError(NULL, channel, data,
@@ -104,14 +104,14 @@ xmlErrValid(xmlValidCtxtPtr ctxt, xmlParserErrors error,
     if (ctxt != NULL) {
         channel = ctxt->error;
         data = ctxt->userData;
-    /* Use the special values to detect if it is part of a parsing
-       context */
-    if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
-        (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
-        long delta = (char *) ctxt - (char *) ctxt->userData;
-        if ((delta > 0) && (delta < 250))
-        pctxt = ctxt->userData;
-    }
+        /* Use the special values to detect if it is part of a parsing
+           context */
+        if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
+            (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
+            long delta = (char *) ctxt - (char *) ctxt->userData;
+            if ((delta > 0) && (delta < 250))
+                pctxt = ctxt->userData;
+        }
     }
     if (extra)
         __xmlRaiseError(NULL, channel, data,
@@ -151,14 +151,14 @@ xmlErrValidNode(xmlValidCtxtPtr ctxt,
     if (ctxt != NULL) {
         channel = ctxt->error;
         data = ctxt->userData;
-    /* Use the special values to detect if it is part of a parsing
-       context */
-    if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
-        (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
-        long delta = (char *) ctxt - (char *) ctxt->userData;
-        if ((delta > 0) && (delta < 250))
-        pctxt = ctxt->userData;
-    }
+        /* Use the special values to detect if it is part of a parsing
+           context */
+        if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
+            (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
+            long delta = (char *) ctxt - (char *) ctxt->userData;
+            if ((delta > 0) && (delta < 250))
+                pctxt = ctxt->userData;
+        }
     }
     __xmlRaiseError(schannel, channel, data, pctxt, node, XML_FROM_VALID, error,
                     XML_ERR_ERROR, NULL, 0,
@@ -194,14 +194,14 @@ xmlErrValidNodeNr(xmlValidCtxtPtr ctxt,
     if (ctxt != NULL) {
         channel = ctxt->error;
         data = ctxt->userData;
-    /* Use the special values to detect if it is part of a parsing
-       context */
-    if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
-        (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
-        long delta = (char *) ctxt - (char *) ctxt->userData;
-        if ((delta > 0) && (delta < 250))
-        pctxt = ctxt->userData;
-    }
+        /* Use the special values to detect if it is part of a parsing
+           context */
+        if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
+            (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
+            long delta = (char *) ctxt - (char *) ctxt->userData;
+            if ((delta > 0) && (delta < 250))
+                pctxt = ctxt->userData;
+        }
     }
     __xmlRaiseError(schannel, channel, data, pctxt, node, XML_FROM_VALID, error,
                     XML_ERR_ERROR, NULL, 0,
@@ -235,14 +235,14 @@ xmlErrValidWarning(xmlValidCtxtPtr ctxt,
     if (ctxt != NULL) {
         channel = ctxt->warning;
         data = ctxt->userData;
-    /* Use the special values to detect if it is part of a parsing
-       context */
-    if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
-        (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
-        long delta = (char *) ctxt - (char *) ctxt->userData;
-        if ((delta > 0) && (delta < 250))
-        pctxt = ctxt->userData;
-    }
+        /* Use the special values to detect if it is part of a parsing
+           context */
+        if ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
+            (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1)) {
+            long delta = (char *) ctxt - (char *) ctxt->userData;
+            if ((delta > 0) && (delta < 250))
+                pctxt = ctxt->userData;
+        }
     }
     __xmlRaiseError(schannel, channel, data, pctxt, node, XML_FROM_VALID, error,
                     XML_ERR_WARNING, NULL, 0,
@@ -264,52 +264,52 @@ xmlErrValidWarning(xmlValidCtxtPtr ctxt,
 
 
 typedef struct _xmlValidState {
-    xmlElementPtr    elemDecl;  /* pointer to the content model */
-    xmlNodePtr           node;      /* pointer to the current node */
-    xmlRegExecCtxtPtr    exec;      /* regexp runtime */
+    xmlElementPtr        elemDecl;      /* pointer to the content model */
+    xmlNodePtr           node;          /* pointer to the current node */
+    xmlRegExecCtxtPtr    exec;          /* regexp runtime */
 } _xmlValidState;
 
 
 static int
 vstateVPush(xmlValidCtxtPtr ctxt, xmlElementPtr elemDecl, xmlNodePtr node) {
     if ((ctxt->vstateMax == 0) || (ctxt->vstateTab == NULL)) {
-    ctxt->vstateMax = 10;
-    ctxt->vstateTab = (xmlValidState *) xmlMalloc(ctxt->vstateMax *
-                      sizeof(ctxt->vstateTab[0]));
+        ctxt->vstateMax = 10;
+        ctxt->vstateTab = (xmlValidState *) xmlMalloc(ctxt->vstateMax *
+                              sizeof(ctxt->vstateTab[0]));
         if (ctxt->vstateTab == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
-        return(-1);
-    }
+            xmlVErrMemory(ctxt, "malloc failed");
+            return(-1);
+        }
     }
 
     if (ctxt->vstateNr >= ctxt->vstateMax) {
         xmlValidState *tmp;
 
-    tmp = (xmlValidState *) xmlRealloc(ctxt->vstateTab,
-                 2 * ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
+        tmp = (xmlValidState *) xmlRealloc(ctxt->vstateTab,
+                     2 * ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
         if (tmp == NULL) {
-        xmlVErrMemory(ctxt, "realloc failed");
-        return(-1);
-    }
-    ctxt->vstateMax *= 2;
-    ctxt->vstateTab = tmp;
+            xmlVErrMemory(ctxt, "realloc failed");
+            return(-1);
+        }
+        ctxt->vstateMax *= 2;
+        ctxt->vstateTab = tmp;
     }
     ctxt->vstate = &ctxt->vstateTab[ctxt->vstateNr];
     ctxt->vstateTab[ctxt->vstateNr].elemDecl = elemDecl;
     ctxt->vstateTab[ctxt->vstateNr].node = node;
     if ((elemDecl != NULL) && (elemDecl->etype == XML_ELEMENT_TYPE_ELEMENT)) {
-    if (elemDecl->contModel == NULL)
-        xmlValidBuildContentModel(ctxt, elemDecl);
-    if (elemDecl->contModel != NULL) {
-        ctxt->vstateTab[ctxt->vstateNr].exec =
-        xmlRegNewExecCtxt(elemDecl->contModel, NULL, NULL);
-    } else {
-        ctxt->vstateTab[ctxt->vstateNr].exec = NULL;
-        xmlErrValidNode(ctxt, (xmlNodePtr) elemDecl,
-                        XML_ERR_INTERNAL_ERROR,
-                "Failed to build content model regexp for %s\n",
-                node->name, NULL, NULL);
-    }
+        if (elemDecl->contModel == NULL)
+            xmlValidBuildContentModel(ctxt, elemDecl);
+        if (elemDecl->contModel != NULL) {
+            ctxt->vstateTab[ctxt->vstateNr].exec =
+                xmlRegNewExecCtxt(elemDecl->contModel, NULL, NULL);
+        } else {
+            ctxt->vstateTab[ctxt->vstateNr].exec = NULL;
+            xmlErrValidNode(ctxt, (xmlNodePtr) elemDecl,
+                            XML_ERR_INTERNAL_ERROR,
+                            "Failed to build content model regexp for %s\n",
+                            node->name, NULL, NULL);
+        }
     }
     return(ctxt->vstateNr++);
 }
@@ -324,13 +324,13 @@ vstateVPop(xmlValidCtxtPtr ctxt) {
     ctxt->vstateTab[ctxt->vstateNr].elemDecl = NULL;
     ctxt->vstateTab[ctxt->vstateNr].node = NULL;
     if ((elemDecl != NULL) && (elemDecl->etype == XML_ELEMENT_TYPE_ELEMENT)) {
-    xmlRegFreeExecCtxt(ctxt->vstateTab[ctxt->vstateNr].exec);
+        xmlRegFreeExecCtxt(ctxt->vstateTab[ctxt->vstateNr].exec);
     }
     ctxt->vstateTab[ctxt->vstateNr].exec = NULL;
     if (ctxt->vstateNr >= 1)
-    ctxt->vstate = &ctxt->vstateTab[ctxt->vstateNr - 1];
+        ctxt->vstate = &ctxt->vstateTab[ctxt->vstateNr - 1];
     else
-    ctxt->vstate = NULL;
+        ctxt->vstate = NULL;
     return(ctxt->vstateNr);
 }
 
@@ -345,7 +345,7 @@ vstateVPop(xmlValidCtxtPtr ctxt) {
  * this is the content of a saved state for rollbacks
  */
 
-#define ROLLBACK_OR 0
+#define ROLLBACK_OR     0
 #define ROLLBACK_PARENT 1
 
 typedef struct _xmlValidState {
@@ -372,44 +372,44 @@ typedef struct _xmlValidState {
 
 static int
 vstateVPush(xmlValidCtxtPtr ctxt, xmlElementContentPtr cont,
-        xmlNodePtr node, unsigned char depth, long occurs,
-        unsigned char state) {
+            xmlNodePtr node, unsigned char depth, long occurs,
+            unsigned char state) {
     int i = ctxt->vstateNr - 1;
 
     if (ctxt->vstateNr > MAX_RECURSE) {
-    return(-1);
-    }
-    if (ctxt->vstateTab == NULL) {
-    ctxt->vstateMax = 8;
-    ctxt->vstateTab = (xmlValidState *) xmlMalloc(
-             ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
-    if (ctxt->vstateTab == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
         return(-1);
     }
+    if (ctxt->vstateTab == NULL) {
+        ctxt->vstateMax = 8;
+        ctxt->vstateTab = (xmlValidState *) xmlMalloc(
+                     ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
+        if (ctxt->vstateTab == NULL) {
+            xmlVErrMemory(ctxt, "malloc failed");
+            return(-1);
+        }
     }
     if (ctxt->vstateNr >= ctxt->vstateMax) {
         xmlValidState *tmp;
 
         tmp = (xmlValidState *) xmlRealloc(ctxt->vstateTab,
-                 2 * ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
+                     2 * ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
         if (tmp == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
-        return(-1);
-    }
-    ctxt->vstateMax *= 2;
-    ctxt->vstateTab = tmp;
-    ctxt->vstate = &ctxt->vstateTab[0];
+            xmlVErrMemory(ctxt, "malloc failed");
+            return(-1);
+        }
+        ctxt->vstateMax *= 2;
+        ctxt->vstateTab = tmp;
+        ctxt->vstate = &ctxt->vstateTab[0];
     }
     /*
      * Don't push on the stack a state already here
      */
     if ((i >= 0) && (ctxt->vstateTab[i].cont == cont) &&
-    (ctxt->vstateTab[i].node == node) &&
-    (ctxt->vstateTab[i].depth == depth) &&
-    (ctxt->vstateTab[i].occurs == occurs) &&
-    (ctxt->vstateTab[i].state == state))
-    return(ctxt->vstateNr);
+        (ctxt->vstateTab[i].node == node) &&
+        (ctxt->vstateTab[i].depth == depth) &&
+        (ctxt->vstateTab[i].occurs == occurs) &&
+        (ctxt->vstateTab[i].state == state))
+        return(ctxt->vstateNr);
     ctxt->vstateTab[ctxt->vstateNr].cont = cont;
     ctxt->vstateTab[ctxt->vstateNr].node = node;
     ctxt->vstateTab[ctxt->vstateNr].depth = depth;
@@ -442,7 +442,7 @@ nodeVPush(xmlValidCtxtPtr ctxt, xmlNodePtr value)
             (xmlNodePtr *) xmlMalloc(ctxt->nodeMax *
                                      sizeof(ctxt->nodeTab[0]));
         if (ctxt->nodeTab == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
+            xmlVErrMemory(ctxt, "malloc failed");
             ctxt->nodeMax = 0;
             return (0);
         }
@@ -450,13 +450,13 @@ nodeVPush(xmlValidCtxtPtr ctxt, xmlNodePtr value)
     if (ctxt->nodeNr >= ctxt->nodeMax) {
         xmlNodePtr *tmp;
         tmp = (xmlNodePtr *) xmlRealloc(ctxt->nodeTab,
-                  ctxt->nodeMax * 2 * sizeof(ctxt->nodeTab[0]));
+                              ctxt->nodeMax * 2 * sizeof(ctxt->nodeTab[0]));
         if (tmp == NULL) {
-        xmlVErrMemory(ctxt, "realloc failed");
+            xmlVErrMemory(ctxt, "realloc failed");
             return (0);
         }
         ctxt->nodeMax *= 2;
-    ctxt->nodeTab = tmp;
+        ctxt->nodeTab = tmp;
     }
     ctxt->nodeTab[ctxt->nodeNr] = value;
     ctxt->node = value;
@@ -483,85 +483,85 @@ nodeVPop(xmlValidCtxtPtr ctxt)
 static void
 xmlValidPrintNode(xmlNodePtr cur) {
     if (cur == NULL) {
-    xmlGenericError(xmlGenericErrorContext, "null");
-    return;
+        xmlGenericError(xmlGenericErrorContext, "null");
+        return;
     }
     switch (cur->type) {
-    case XML_ELEMENT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "%s ", cur->name);
-        break;
-    case XML_TEXT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "text ");
-        break;
-    case XML_CDATA_SECTION_NODE:
-        xmlGenericError(xmlGenericErrorContext, "cdata ");
-        break;
-    case XML_ENTITY_REF_NODE:
-        xmlGenericError(xmlGenericErrorContext, "&%s; ", cur->name);
-        break;
-    case XML_PI_NODE:
-        xmlGenericError(xmlGenericErrorContext, "pi(%s) ", cur->name);
-        break;
-    case XML_COMMENT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "comment ");
-        break;
-    case XML_ATTRIBUTE_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?attr? ");
-        break;
-    case XML_ENTITY_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?ent? ");
-        break;
-    case XML_DOCUMENT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?doc? ");
-        break;
-    case XML_DOCUMENT_TYPE_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?doctype? ");
-        break;
-    case XML_DOCUMENT_FRAG_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?frag? ");
-        break;
-    case XML_NOTATION_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?nota? ");
-        break;
-    case XML_HTML_DOCUMENT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?html? ");
-        break;
+        case XML_ELEMENT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "%s ", cur->name);
+            break;
+        case XML_TEXT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "text ");
+            break;
+        case XML_CDATA_SECTION_NODE:
+            xmlGenericError(xmlGenericErrorContext, "cdata ");
+            break;
+        case XML_ENTITY_REF_NODE:
+            xmlGenericError(xmlGenericErrorContext, "&%s; ", cur->name);
+            break;
+        case XML_PI_NODE:
+            xmlGenericError(xmlGenericErrorContext, "pi(%s) ", cur->name);
+            break;
+        case XML_COMMENT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "comment ");
+            break;
+        case XML_ATTRIBUTE_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?attr? ");
+            break;
+        case XML_ENTITY_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?ent? ");
+            break;
+        case XML_DOCUMENT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?doc? ");
+            break;
+        case XML_DOCUMENT_TYPE_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?doctype? ");
+            break;
+        case XML_DOCUMENT_FRAG_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?frag? ");
+            break;
+        case XML_NOTATION_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?nota? ");
+            break;
+        case XML_HTML_DOCUMENT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?html? ");
+            break;
 #ifdef LIBXML_DOCB_ENABLED
-    case XML_DOCB_DOCUMENT_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?docb? ");
-        break;
+        case XML_DOCB_DOCUMENT_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?docb? ");
+            break;
 #endif
-    case XML_DTD_NODE:
-        xmlGenericError(xmlGenericErrorContext, "?dtd? ");
-        break;
-    case XML_ELEMENT_DECL:
-        xmlGenericError(xmlGenericErrorContext, "?edecl? ");
-        break;
-    case XML_ATTRIBUTE_DECL:
-        xmlGenericError(xmlGenericErrorContext, "?adecl? ");
-        break;
-    case XML_ENTITY_DECL:
-        xmlGenericError(xmlGenericErrorContext, "?entdecl? ");
-        break;
-    case XML_NAMESPACE_DECL:
-        xmlGenericError(xmlGenericErrorContext, "?nsdecl? ");
-        break;
-    case XML_XINCLUDE_START:
-        xmlGenericError(xmlGenericErrorContext, "incstart ");
-        break;
-    case XML_XINCLUDE_END:
-        xmlGenericError(xmlGenericErrorContext, "incend ");
-        break;
+        case XML_DTD_NODE:
+            xmlGenericError(xmlGenericErrorContext, "?dtd? ");
+            break;
+        case XML_ELEMENT_DECL:
+            xmlGenericError(xmlGenericErrorContext, "?edecl? ");
+            break;
+        case XML_ATTRIBUTE_DECL:
+            xmlGenericError(xmlGenericErrorContext, "?adecl? ");
+            break;
+        case XML_ENTITY_DECL:
+            xmlGenericError(xmlGenericErrorContext, "?entdecl? ");
+            break;
+        case XML_NAMESPACE_DECL:
+            xmlGenericError(xmlGenericErrorContext, "?nsdecl? ");
+            break;
+        case XML_XINCLUDE_START:
+            xmlGenericError(xmlGenericErrorContext, "incstart ");
+            break;
+        case XML_XINCLUDE_END:
+            xmlGenericError(xmlGenericErrorContext, "incend ");
+            break;
     }
 }
 
 static void
 xmlValidPrintNodeList(xmlNodePtr cur) {
     if (cur == NULL)
-    xmlGenericError(xmlGenericErrorContext, "null ");
+        xmlGenericError(xmlGenericErrorContext, "null ");
     while (cur != NULL) {
-    xmlValidPrintNode(cur);
-    cur = cur->next;
+        xmlValidPrintNode(cur);
+        cur = cur->next;
     }
 }
 
@@ -581,26 +581,26 @@ static void
 xmlValidDebugState(xmlValidStatePtr state) {
     xmlGenericError(xmlGenericErrorContext, "(");
     if (state->cont == NULL)
-    xmlGenericError(xmlGenericErrorContext, "null,");
+        xmlGenericError(xmlGenericErrorContext, "null,");
     else
-    switch (state->cont->type) {
+        switch (state->cont->type) {
             case XML_ELEMENT_CONTENT_PCDATA:
-        xmlGenericError(xmlGenericErrorContext, "pcdata,");
-        break;
+                xmlGenericError(xmlGenericErrorContext, "pcdata,");
+                break;
             case XML_ELEMENT_CONTENT_ELEMENT:
-        xmlGenericError(xmlGenericErrorContext, "%s,",
-                    state->cont->name);
-        break;
+                xmlGenericError(xmlGenericErrorContext, "%s,",
+                                state->cont->name);
+                break;
             case XML_ELEMENT_CONTENT_SEQ:
-        xmlGenericError(xmlGenericErrorContext, "seq,");
-        break;
+                xmlGenericError(xmlGenericErrorContext, "seq,");
+                break;
             case XML_ELEMENT_CONTENT_OR:
-        xmlGenericError(xmlGenericErrorContext, "or,");
-        break;
-    }
+                xmlGenericError(xmlGenericErrorContext, "or,");
+                break;
+        }
     xmlValidPrintNode(state->node);
     xmlGenericError(xmlGenericErrorContext, ",%d,%X,%d)",
-        state->depth, state->occurs, state->state);
+            state->depth, state->occurs, state->state);
 }
 
 static void
@@ -610,9 +610,9 @@ xmlValidStateDebug(xmlValidCtxtPtr ctxt) {
     xmlGenericError(xmlGenericErrorContext, "state: ");
     xmlValidDebugState(ctxt->vstate);
     xmlGenericError(xmlGenericErrorContext, " stack: %d ",
-        ctxt->vstateNr - 1);
+            ctxt->vstateNr - 1);
     for (i = 0, j = ctxt->vstateNr - 1;(i < 3) && (j > 0);i++,j--)
-    xmlValidDebugState(&ctxt->vstateTab[j]);
+        xmlValidDebugState(&ctxt->vstateTab[j]);
     xmlGenericError(xmlGenericErrorContext, "\n");
 }
 
@@ -621,7 +621,7 @@ xmlValidStateDebug(xmlValidCtxtPtr ctxt) {
  *****/
 
 #define DEBUG_VALID_STATE(n,c) xmlValidStateDebug(ctxt);
-#define DEBUG_VALID_MSG(m)                  \
+#define DEBUG_VALID_MSG(m)                                      \
     xmlGenericError(xmlGenericErrorContext, "%s\n", m);
 
 #else
@@ -632,17 +632,17 @@ xmlValidStateDebug(xmlValidCtxtPtr ctxt) {
 /* TODO: use hash table for accesses to elem and attribute definitions */
 
 
-#define CHECK_DTD                       \
-   if (doc == NULL) return(0);                  \
-   else if ((doc->intSubset == NULL) &&             \
-        (doc->extSubset == NULL)) return(0)
+#define CHECK_DTD                                               \
+   if (doc == NULL) return(0);                                  \
+   else if ((doc->intSubset == NULL) &&                         \
+            (doc->extSubset == NULL)) return(0)
 
 #ifdef LIBXML_REGEXP_ENABLED
 
 /************************************************************************
- *                                  *
- *      Content model validation based on the regexps       *
- *                                  *
+ *                                                                      *
+ *              Content model validation based on the regexps           *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -657,145 +657,145 @@ xmlValidStateDebug(xmlValidCtxtPtr ctxt) {
  */
 static int
 xmlValidBuildAContentModel(xmlElementContentPtr content,
-                   xmlValidCtxtPtr ctxt,
-                   const xmlChar *name) {
+                           xmlValidCtxtPtr ctxt,
+                           const xmlChar *name) {
     if (content == NULL) {
-    xmlErrValidNode(ctxt, NULL, XML_ERR_INTERNAL_ERROR,
-            "Found NULL content in content model of %s\n",
-            name, NULL, NULL);
-    return(0);
+        xmlErrValidNode(ctxt, NULL, XML_ERR_INTERNAL_ERROR,
+                        "Found NULL content in content model of %s\n",
+                        name, NULL, NULL);
+        return(0);
     }
     switch (content->type) {
-    case XML_ELEMENT_CONTENT_PCDATA:
-        xmlErrValidNode(ctxt, NULL, XML_ERR_INTERNAL_ERROR,
-                "Found PCDATA in content model of %s\n",
-                    name, NULL, NULL);
-        return(0);
-        break;
-    case XML_ELEMENT_CONTENT_ELEMENT: {
-        xmlAutomataStatePtr oldstate = ctxt->state;
-        xmlChar fn[50];
-        xmlChar *fullname;
+        case XML_ELEMENT_CONTENT_PCDATA:
+            xmlErrValidNode(ctxt, NULL, XML_ERR_INTERNAL_ERROR,
+                            "Found PCDATA in content model of %s\n",
+                            name, NULL, NULL);
+            return(0);
+            break;
+        case XML_ELEMENT_CONTENT_ELEMENT: {
+            xmlAutomataStatePtr oldstate = ctxt->state;
+            xmlChar fn[50];
+            xmlChar *fullname;
 
-        fullname = xmlBuildQName(content->name, content->prefix, fn, 50);
-        if (fullname == NULL) {
-            xmlVErrMemory(ctxt, "Building content model");
-        return(0);
+            fullname = xmlBuildQName(content->name, content->prefix, fn, 50);
+            if (fullname == NULL) {
+                xmlVErrMemory(ctxt, "Building content model");
+                return(0);
+            }
+
+            switch (content->ocur) {
+                case XML_ELEMENT_CONTENT_ONCE:
+                    ctxt->state = xmlAutomataNewTransition(ctxt->am,
+                            ctxt->state, NULL, fullname, NULL);
+                    break;
+                case XML_ELEMENT_CONTENT_OPT:
+                    ctxt->state = xmlAutomataNewTransition(ctxt->am,
+                            ctxt->state, NULL, fullname, NULL);
+                    xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
+                    break;
+                case XML_ELEMENT_CONTENT_PLUS:
+                    ctxt->state = xmlAutomataNewTransition(ctxt->am,
+                            ctxt->state, NULL, fullname, NULL);
+                    xmlAutomataNewTransition(ctxt->am, ctxt->state,
+                                             ctxt->state, fullname, NULL);
+                    break;
+                case XML_ELEMENT_CONTENT_MULT:
+                    ctxt->state = xmlAutomataNewEpsilon(ctxt->am,
+                                            ctxt->state, NULL);
+                    xmlAutomataNewTransition(ctxt->am,
+                            ctxt->state, ctxt->state, fullname, NULL);
+                    break;
+            }
+            if ((fullname != fn) && (fullname != content->name))
+                xmlFree(fullname);
+            break;
         }
+        case XML_ELEMENT_CONTENT_SEQ: {
+            xmlAutomataStatePtr oldstate, oldend;
+            xmlElementContentOccur ocur;
 
-        switch (content->ocur) {
-        case XML_ELEMENT_CONTENT_ONCE:
-            ctxt->state = xmlAutomataNewTransition(ctxt->am,
-                ctxt->state, NULL, fullname, NULL);
+            /*
+             * Simply iterate over the content
+             */
+            oldstate = ctxt->state;
+            ocur = content->ocur;
+            if (ocur != XML_ELEMENT_CONTENT_ONCE) {
+                ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldstate, NULL);
+                oldstate = ctxt->state;
+            }
+            do {
+                xmlValidBuildAContentModel(content->c1, ctxt, name);
+                content = content->c2;
+            } while ((content->type == XML_ELEMENT_CONTENT_SEQ) &&
+                     (content->ocur == XML_ELEMENT_CONTENT_ONCE));
+            xmlValidBuildAContentModel(content, ctxt, name);
+            oldend = ctxt->state;
+            ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldend, NULL);
+            switch (ocur) {
+                case XML_ELEMENT_CONTENT_ONCE:
+                    break;
+                case XML_ELEMENT_CONTENT_OPT:
+                    xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
+                    break;
+                case XML_ELEMENT_CONTENT_MULT:
+                    xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
+                    xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
+                    break;
+                case XML_ELEMENT_CONTENT_PLUS:
+                    xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
+                    break;
+            }
             break;
-        case XML_ELEMENT_CONTENT_OPT:
-            ctxt->state = xmlAutomataNewTransition(ctxt->am,
-                ctxt->state, NULL, fullname, NULL);
-            xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
-            break;
-        case XML_ELEMENT_CONTENT_PLUS:
-            ctxt->state = xmlAutomataNewTransition(ctxt->am,
-                ctxt->state, NULL, fullname, NULL);
-            xmlAutomataNewTransition(ctxt->am, ctxt->state,
-                                 ctxt->state, fullname, NULL);
-            break;
-        case XML_ELEMENT_CONTENT_MULT:
-            ctxt->state = xmlAutomataNewEpsilon(ctxt->am,
+        }
+        case XML_ELEMENT_CONTENT_OR: {
+            xmlAutomataStatePtr oldstate, oldend;
+            xmlElementContentOccur ocur;
+
+            ocur = content->ocur;
+            if ((ocur == XML_ELEMENT_CONTENT_PLUS) ||
+                (ocur == XML_ELEMENT_CONTENT_MULT)) {
+                ctxt->state = xmlAutomataNewEpsilon(ctxt->am,
                         ctxt->state, NULL);
-            xmlAutomataNewTransition(ctxt->am,
-                ctxt->state, ctxt->state, fullname, NULL);
-            break;
-        }
-        if ((fullname != fn) && (fullname != content->name))
-        xmlFree(fullname);
-        break;
-    }
-    case XML_ELEMENT_CONTENT_SEQ: {
-        xmlAutomataStatePtr oldstate, oldend;
-        xmlElementContentOccur ocur;
+            }
+            oldstate = ctxt->state;
+            oldend = xmlAutomataNewState(ctxt->am);
 
-        /*
-         * Simply iterate over the content
-         */
-        oldstate = ctxt->state;
-        ocur = content->ocur;
-        if (ocur != XML_ELEMENT_CONTENT_ONCE) {
-        ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldstate, NULL);
-        oldstate = ctxt->state;
-        }
-        do {
-        xmlValidBuildAContentModel(content->c1, ctxt, name);
-        content = content->c2;
-        } while ((content->type == XML_ELEMENT_CONTENT_SEQ) &&
-             (content->ocur == XML_ELEMENT_CONTENT_ONCE));
-        xmlValidBuildAContentModel(content, ctxt, name);
-        oldend = ctxt->state;
-        ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldend, NULL);
-        switch (ocur) {
-        case XML_ELEMENT_CONTENT_ONCE:
-            break;
-        case XML_ELEMENT_CONTENT_OPT:
-            xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
-            break;
-        case XML_ELEMENT_CONTENT_MULT:
-            xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
-            xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
-            break;
-        case XML_ELEMENT_CONTENT_PLUS:
-            xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
-            break;
-        }
-        break;
-    }
-    case XML_ELEMENT_CONTENT_OR: {
-        xmlAutomataStatePtr oldstate, oldend;
-        xmlElementContentOccur ocur;
-
-        ocur = content->ocur;
-        if ((ocur == XML_ELEMENT_CONTENT_PLUS) ||
-        (ocur == XML_ELEMENT_CONTENT_MULT)) {
-        ctxt->state = xmlAutomataNewEpsilon(ctxt->am,
-            ctxt->state, NULL);
-        }
-        oldstate = ctxt->state;
-        oldend = xmlAutomataNewState(ctxt->am);
-
-        /*
-         * iterate over the subtypes and remerge the end with an
-         * epsilon transition
-         */
-        do {
-        ctxt->state = oldstate;
-        xmlValidBuildAContentModel(content->c1, ctxt, name);
-        xmlAutomataNewEpsilon(ctxt->am, ctxt->state, oldend);
-        content = content->c2;
-        } while ((content->type == XML_ELEMENT_CONTENT_OR) &&
-             (content->ocur == XML_ELEMENT_CONTENT_ONCE));
-        ctxt->state = oldstate;
-        xmlValidBuildAContentModel(content, ctxt, name);
-        xmlAutomataNewEpsilon(ctxt->am, ctxt->state, oldend);
-        ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldend, NULL);
-        switch (ocur) {
-        case XML_ELEMENT_CONTENT_ONCE:
-            break;
-        case XML_ELEMENT_CONTENT_OPT:
-            xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
-            break;
-        case XML_ELEMENT_CONTENT_MULT:
-            xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
-            xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
-            break;
-        case XML_ELEMENT_CONTENT_PLUS:
-            xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
+            /*
+             * iterate over the subtypes and remerge the end with an
+             * epsilon transition
+             */
+            do {
+                ctxt->state = oldstate;
+                xmlValidBuildAContentModel(content->c1, ctxt, name);
+                xmlAutomataNewEpsilon(ctxt->am, ctxt->state, oldend);
+                content = content->c2;
+            } while ((content->type == XML_ELEMENT_CONTENT_OR) &&
+                     (content->ocur == XML_ELEMENT_CONTENT_ONCE));
+            ctxt->state = oldstate;
+            xmlValidBuildAContentModel(content, ctxt, name);
+            xmlAutomataNewEpsilon(ctxt->am, ctxt->state, oldend);
+            ctxt->state = xmlAutomataNewEpsilon(ctxt->am, oldend, NULL);
+            switch (ocur) {
+                case XML_ELEMENT_CONTENT_ONCE:
+                    break;
+                case XML_ELEMENT_CONTENT_OPT:
+                    xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
+                    break;
+                case XML_ELEMENT_CONTENT_MULT:
+                    xmlAutomataNewEpsilon(ctxt->am, oldstate, ctxt->state);
+                    xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
+                    break;
+                case XML_ELEMENT_CONTENT_PLUS:
+                    xmlAutomataNewEpsilon(ctxt->am, oldend, oldstate);
+                    break;
+            }
             break;
         }
-        break;
-    }
-    default:
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-                    "ContentModel broken for element %s\n",
-            (const char *) name);
-        return(0);
+        default:
+            xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                        "ContentModel broken for element %s\n",
+                        (const char *) name);
+            return(0);
     }
     return(1);
 }
@@ -813,48 +813,48 @@ int
 xmlValidBuildContentModel(xmlValidCtxtPtr ctxt, xmlElementPtr elem) {
 
     if ((ctxt == NULL) || (elem == NULL))
-    return(0);
+        return(0);
     if (elem->type != XML_ELEMENT_DECL)
-    return(0);
+        return(0);
     if (elem->etype != XML_ELEMENT_TYPE_ELEMENT)
-    return(1);
+        return(1);
     /* TODO: should we rebuild in this case ? */
     if (elem->contModel != NULL) {
-    if (!xmlRegexpIsDeterminist(elem->contModel)) {
-        ctxt->valid = 0;
-        return(0);
-    }
-    return(1);
+        if (!xmlRegexpIsDeterminist(elem->contModel)) {
+            ctxt->valid = 0;
+            return(0);
+        }
+        return(1);
     }
 
     ctxt->am = xmlNewAutomata();
     if (ctxt->am == NULL) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) elem,
-                    XML_ERR_INTERNAL_ERROR,
-                    "Cannot create automata for element %s\n",
-                elem->name, NULL, NULL);
-    return(0);
+        xmlErrValidNode(ctxt, (xmlNodePtr) elem,
+                        XML_ERR_INTERNAL_ERROR,
+                        "Cannot create automata for element %s\n",
+                        elem->name, NULL, NULL);
+        return(0);
     }
     ctxt->state = xmlAutomataGetInitState(ctxt->am);
     xmlValidBuildAContentModel(elem->content, ctxt, elem->name);
     xmlAutomataSetFinalState(ctxt->am, ctxt->state);
     elem->contModel = xmlAutomataCompile(ctxt->am);
     if (xmlRegexpIsDeterminist(elem->contModel) != 1) {
-    char expr[5000];
-    expr[0] = 0;
-    xmlSnprintfElementContent(expr, 5000, elem->content, 1);
-    xmlErrValidNode(ctxt, (xmlNodePtr) elem,
-                    XML_DTD_CONTENT_NOT_DETERMINIST,
-           "Content model of %s is not determinist: %s\n",
-           elem->name, BAD_CAST expr, NULL);
+        char expr[5000];
+        expr[0] = 0;
+        xmlSnprintfElementContent(expr, 5000, elem->content, 1);
+        xmlErrValidNode(ctxt, (xmlNodePtr) elem,
+                        XML_DTD_CONTENT_NOT_DETERMINIST,
+               "Content model of %s is not determinist: %s\n",
+               elem->name, BAD_CAST expr, NULL);
 #ifdef DEBUG_REGEXP_ALGO
         xmlRegexpPrint(stderr, elem->contModel);
 #endif
         ctxt->valid = 0;
-    ctxt->state = NULL;
-    xmlFreeAutomata(ctxt->am);
-    ctxt->am = NULL;
-    return(0);
+        ctxt->state = NULL;
+        xmlFreeAutomata(ctxt->am);
+        ctxt->am = NULL;
+        return(0);
     }
     ctxt->state = NULL;
     xmlFreeAutomata(ctxt->am);
@@ -865,9 +865,9 @@ xmlValidBuildContentModel(xmlValidCtxtPtr ctxt, xmlElementPtr elem) {
 #endif /* LIBXML_REGEXP_ENABLED */
 
 /****************************************************************
- *                              *
- *  Util functions for data allocation/deallocation     *
- *                              *
+ *                                                              *
+ *      Util functions for data allocation/deallocation         *
+ *                                                              *
  ****************************************************************/
 
 /**
@@ -881,8 +881,8 @@ xmlValidCtxtPtr xmlNewValidCtxt(void) {
     xmlValidCtxtPtr ret;
 
     if ((ret = xmlMalloc(sizeof (xmlValidCtxt))) == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return (NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return (NULL);
     }
 
     (void) memset(ret, 0, sizeof (xmlValidCtxt));
@@ -927,55 +927,55 @@ xmlNewDocElementContent(xmlDocPtr doc, const xmlChar *name,
         dict = doc->dict;
 
     switch(type) {
-    case XML_ELEMENT_CONTENT_ELEMENT:
-        if (name == NULL) {
-            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "xmlNewElementContent : name == NULL !\n",
-            NULL);
-        }
-        break;
+        case XML_ELEMENT_CONTENT_ELEMENT:
+            if (name == NULL) {
+                xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                        "xmlNewElementContent : name == NULL !\n",
+                        NULL);
+            }
+            break;
         case XML_ELEMENT_CONTENT_PCDATA:
-    case XML_ELEMENT_CONTENT_SEQ:
-    case XML_ELEMENT_CONTENT_OR:
-        if (name != NULL) {
+        case XML_ELEMENT_CONTENT_SEQ:
+        case XML_ELEMENT_CONTENT_OR:
+            if (name != NULL) {
+                xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                        "xmlNewElementContent : name != NULL !\n",
+                        NULL);
+            }
+            break;
+        default:
             xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "xmlNewElementContent : name != NULL !\n",
-            NULL);
-        }
-        break;
-    default:
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ELEMENT content corrupted invalid type\n",
-            NULL);
-        return(NULL);
+                    "Internal: ELEMENT content corrupted invalid type\n",
+                    NULL);
+            return(NULL);
     }
     ret = (xmlElementContentPtr) xmlMalloc(sizeof(xmlElementContent));
     if (ret == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xmlElementContent));
     ret->type = type;
     ret->ocur = XML_ELEMENT_CONTENT_ONCE;
     if (name != NULL) {
         int l;
-    const xmlChar *tmp;
+        const xmlChar *tmp;
 
-    tmp = xmlSplitQName3(name, &l);
-    if (tmp == NULL) {
-        if (dict == NULL)
-        ret->name = xmlStrdup(name);
-        else
-            ret->name = xmlDictLookup(dict, name, -1);
-    } else {
-        if (dict == NULL) {
-        ret->prefix = xmlStrndup(name, l);
-        ret->name = xmlStrdup(tmp);
+        tmp = xmlSplitQName3(name, &l);
+        if (tmp == NULL) {
+            if (dict == NULL)
+                ret->name = xmlStrdup(name);
+            else
+                ret->name = xmlDictLookup(dict, name, -1);
         } else {
-            ret->prefix = xmlDictLookup(dict, name, l);
-        ret->name = xmlDictLookup(dict, tmp, -1);
+            if (dict == NULL) {
+                ret->prefix = xmlStrndup(name, l);
+                ret->name = xmlStrdup(tmp);
+            } else {
+                ret->prefix = xmlDictLookup(dict, name, l);
+                ret->name = xmlDictLookup(dict, tmp, -1);
+            }
         }
-    }
     }
     return(ret);
 }
@@ -1016,62 +1016,63 @@ xmlCopyDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
 
     ret = (xmlElementContentPtr) xmlMalloc(sizeof(xmlElementContent));
     if (ret == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xmlElementContent));
     ret->type = cur->type;
     ret->ocur = cur->ocur;
     if (cur->name != NULL) {
-    if (dict)
-        ret->name = xmlDictLookup(dict, cur->name, -1);
-    else
-        ret->name = xmlStrdup(cur->name);
+        if (dict)
+            ret->name = xmlDictLookup(dict, cur->name, -1);
+        else
+            ret->name = xmlStrdup(cur->name);
     }
 
     if (cur->prefix != NULL) {
-    if (dict)
-        ret->prefix = xmlDictLookup(dict, cur->prefix, -1);
-    else
-        ret->prefix = xmlStrdup(cur->prefix);
+        if (dict)
+            ret->prefix = xmlDictLookup(dict, cur->prefix, -1);
+        else
+            ret->prefix = xmlStrdup(cur->prefix);
     }
     if (cur->c1 != NULL)
         ret->c1 = xmlCopyDocElementContent(doc, cur->c1);
     if (ret->c1 != NULL)
-    ret->c1->parent = ret;
+        ret->c1->parent = ret;
     if (cur->c2 != NULL) {
         prev = ret;
-    cur = cur->c2;
-    while (cur != NULL) {
-        tmp = (xmlElementContentPtr) xmlMalloc(sizeof(xmlElementContent));
-        if (tmp == NULL) {
-        xmlVErrMemory(NULL, "malloc failed");
-        return(ret);
-        }
-        memset(tmp, 0, sizeof(xmlElementContent));
-        tmp->type = cur->type;
-        tmp->ocur = cur->ocur;
-        prev->c2 = tmp;
-        if (cur->name != NULL) {
-        if (dict)
-            tmp->name = xmlDictLookup(dict, cur->name, -1);
-        else
-            tmp->name = xmlStrdup(cur->name);
-        }
-
-        if (cur->prefix != NULL) {
-        if (dict)
-            tmp->prefix = xmlDictLookup(dict, cur->prefix, -1);
-        else
-            tmp->prefix = xmlStrdup(cur->prefix);
-        }
-        if (cur->c1 != NULL)
-            tmp->c1 = xmlCopyDocElementContent(doc,cur->c1);
-        if (tmp->c1 != NULL)
-        tmp->c1->parent = ret;
-        prev = tmp;
         cur = cur->c2;
-    }
+        while (cur != NULL) {
+            tmp = (xmlElementContentPtr) xmlMalloc(sizeof(xmlElementContent));
+            if (tmp == NULL) {
+                xmlVErrMemory(NULL, "malloc failed");
+                return(ret);
+            }
+            memset(tmp, 0, sizeof(xmlElementContent));
+            tmp->type = cur->type;
+            tmp->ocur = cur->ocur;
+            prev->c2 = tmp;
+            tmp->parent = prev;
+            if (cur->name != NULL) {
+                if (dict)
+                    tmp->name = xmlDictLookup(dict, cur->name, -1);
+                else
+                    tmp->name = xmlStrdup(cur->name);
+            }
+
+            if (cur->prefix != NULL) {
+                if (dict)
+                    tmp->prefix = xmlDictLookup(dict, cur->prefix, -1);
+                else
+                    tmp->prefix = xmlStrdup(cur->prefix);
+            }
+            if (cur->c1 != NULL)
+                tmp->c1 = xmlCopyDocElementContent(doc,cur->c1);
+            if (tmp->c1 != NULL)
+                tmp->c1->parent = ret;
+            prev = tmp;
+            cur = cur->c2;
+        }
     }
     return(ret);
 }
@@ -1115,27 +1116,27 @@ xmlFreeDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
             depth += 1;
         }
 
-    switch (cur->type) {
-        case XML_ELEMENT_CONTENT_PCDATA:
-        case XML_ELEMENT_CONTENT_ELEMENT:
-        case XML_ELEMENT_CONTENT_SEQ:
-        case XML_ELEMENT_CONTENT_OR:
-        break;
-        default:
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ELEMENT content corrupted invalid type\n",
-            NULL);
-        return;
-    }
-    if (dict) {
-        if ((cur->name != NULL) && (!xmlDictOwns(dict, cur->name)))
-            xmlFree((xmlChar *) cur->name);
-        if ((cur->prefix != NULL) && (!xmlDictOwns(dict, cur->prefix)))
-            xmlFree((xmlChar *) cur->prefix);
-    } else {
-        if (cur->name != NULL) xmlFree((xmlChar *) cur->name);
-        if (cur->prefix != NULL) xmlFree((xmlChar *) cur->prefix);
-    }
+        switch (cur->type) {
+            case XML_ELEMENT_CONTENT_PCDATA:
+            case XML_ELEMENT_CONTENT_ELEMENT:
+            case XML_ELEMENT_CONTENT_SEQ:
+            case XML_ELEMENT_CONTENT_OR:
+                break;
+            default:
+                xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                        "Internal: ELEMENT content corrupted invalid type\n",
+                        NULL);
+                return;
+        }
+        if (dict) {
+            if ((cur->name != NULL) && (!xmlDictOwns(dict, cur->name)))
+                xmlFree((xmlChar *) cur->name);
+            if ((cur->prefix != NULL) && (!xmlDictOwns(dict, cur->prefix)))
+                xmlFree((xmlChar *) cur->prefix);
+        } else {
+            if (cur->name != NULL) xmlFree((xmlChar *) cur->name);
+            if (cur->prefix != NULL) xmlFree((xmlChar *) cur->prefix);
+        }
         parent = cur->parent;
         if ((depth == 0) || (parent == NULL)) {
             xmlFree(cur);
@@ -1145,10 +1146,10 @@ xmlFreeDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
             parent->c1 = NULL;
         else
             parent->c2 = NULL;
-    xmlFree(cur);
+        xmlFree(cur);
 
         if (parent->c2 != NULL) {
-        cur = parent->c2;
+            cur = parent->c2;
         } else {
             depth -= 1;
             cur = parent;
@@ -1278,8 +1279,8 @@ xmlDumpElementContent(xmlBufferPtr buf, xmlElementContentPtr content) {
  */
 void
 xmlSprintfElementContent(char *buf ATTRIBUTE_UNUSED,
-                     xmlElementContentPtr content ATTRIBUTE_UNUSED,
-             int englob ATTRIBUTE_UNUSED) {
+                         xmlElementContentPtr content ATTRIBUTE_UNUSED,
+                         int englob ATTRIBUTE_UNUSED) {
 }
 #endif /* LIBXML_OUTPUT_ENABLED */
 
@@ -1300,95 +1301,95 @@ xmlSnprintfElementContent(char *buf, int size, xmlElementContentPtr content, int
     if (content == NULL) return;
     len = strlen(buf);
     if (size - len < 50) {
-    if ((size - len > 4) && (buf[len - 1] != '.'))
-        strcat(buf, " ...");
-    return;
+        if ((size - len > 4) && (buf[len - 1] != '.'))
+            strcat(buf, " ...");
+        return;
     }
     if (englob) strcat(buf, "(");
     switch (content->type) {
         case XML_ELEMENT_CONTENT_PCDATA:
             strcat(buf, "#PCDATA");
-        break;
-    case XML_ELEMENT_CONTENT_ELEMENT: {
+            break;
+        case XML_ELEMENT_CONTENT_ELEMENT: {
             int qnameLen = xmlStrlen(content->name);
 
-        if (content->prefix != NULL)
+            if (content->prefix != NULL)
                 qnameLen += xmlStrlen(content->prefix) + 1;
-        if (size - len < qnameLen + 10) {
-        strcat(buf, " ...");
-        return;
+            if (size - len < qnameLen + 10) {
+                strcat(buf, " ...");
+                return;
+            }
+            if (content->prefix != NULL) {
+                strcat(buf, (char *) content->prefix);
+                strcat(buf, ":");
+            }
+            if (content->name != NULL)
+                strcat(buf, (char *) content->name);
+            break;
         }
-        if (content->prefix != NULL) {
-        strcat(buf, (char *) content->prefix);
-        strcat(buf, ":");
-        }
-        if (content->name != NULL)
-        strcat(buf, (char *) content->name);
-        break;
-        }
-    case XML_ELEMENT_CONTENT_SEQ:
-        if ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
-            (content->c1->type == XML_ELEMENT_CONTENT_SEQ))
-        xmlSnprintfElementContent(buf, size, content->c1, 1);
-        else
-        xmlSnprintfElementContent(buf, size, content->c1, 0);
-        len = strlen(buf);
-        if (size - len < 50) {
-        if ((size - len > 4) && (buf[len - 1] != '.'))
-            strcat(buf, " ...");
-        return;
-        }
+        case XML_ELEMENT_CONTENT_SEQ:
+            if ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
+                (content->c1->type == XML_ELEMENT_CONTENT_SEQ))
+                xmlSnprintfElementContent(buf, size, content->c1, 1);
+            else
+                xmlSnprintfElementContent(buf, size, content->c1, 0);
+            len = strlen(buf);
+            if (size - len < 50) {
+                if ((size - len > 4) && (buf[len - 1] != '.'))
+                    strcat(buf, " ...");
+                return;
+            }
             strcat(buf, " , ");
-        if (((content->c2->type == XML_ELEMENT_CONTENT_OR) ||
-         (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE)) &&
-        (content->c2->type != XML_ELEMENT_CONTENT_ELEMENT))
-        xmlSnprintfElementContent(buf, size, content->c2, 1);
-        else
-        xmlSnprintfElementContent(buf, size, content->c2, 0);
-        break;
-    case XML_ELEMENT_CONTENT_OR:
-        if ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
-            (content->c1->type == XML_ELEMENT_CONTENT_SEQ))
-        xmlSnprintfElementContent(buf, size, content->c1, 1);
-        else
-        xmlSnprintfElementContent(buf, size, content->c1, 0);
-        len = strlen(buf);
-        if (size - len < 50) {
-        if ((size - len > 4) && (buf[len - 1] != '.'))
-            strcat(buf, " ...");
-        return;
-        }
+            if (((content->c2->type == XML_ELEMENT_CONTENT_OR) ||
+                 (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE)) &&
+                (content->c2->type != XML_ELEMENT_CONTENT_ELEMENT))
+                xmlSnprintfElementContent(buf, size, content->c2, 1);
+            else
+                xmlSnprintfElementContent(buf, size, content->c2, 0);
+            break;
+        case XML_ELEMENT_CONTENT_OR:
+            if ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
+                (content->c1->type == XML_ELEMENT_CONTENT_SEQ))
+                xmlSnprintfElementContent(buf, size, content->c1, 1);
+            else
+                xmlSnprintfElementContent(buf, size, content->c1, 0);
+            len = strlen(buf);
+            if (size - len < 50) {
+                if ((size - len > 4) && (buf[len - 1] != '.'))
+                    strcat(buf, " ...");
+                return;
+            }
             strcat(buf, " | ");
-        if (((content->c2->type == XML_ELEMENT_CONTENT_SEQ) ||
-         (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE)) &&
-        (content->c2->type != XML_ELEMENT_CONTENT_ELEMENT))
-        xmlSnprintfElementContent(buf, size, content->c2, 1);
-        else
-        xmlSnprintfElementContent(buf, size, content->c2, 0);
-        break;
+            if (((content->c2->type == XML_ELEMENT_CONTENT_SEQ) ||
+                 (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE)) &&
+                (content->c2->type != XML_ELEMENT_CONTENT_ELEMENT))
+                xmlSnprintfElementContent(buf, size, content->c2, 1);
+            else
+                xmlSnprintfElementContent(buf, size, content->c2, 0);
+            break;
     }
     if (size - strlen(buf) <= 2) return;
     if (englob)
         strcat(buf, ")");
     switch (content->ocur) {
         case XML_ELEMENT_CONTENT_ONCE:
-        break;
+            break;
         case XML_ELEMENT_CONTENT_OPT:
-        strcat(buf, "?");
-        break;
+            strcat(buf, "?");
+            break;
         case XML_ELEMENT_CONTENT_MULT:
-        strcat(buf, "*");
-        break;
+            strcat(buf, "*");
+            break;
         case XML_ELEMENT_CONTENT_PLUS:
-        strcat(buf, "+");
-        break;
+            strcat(buf, "+");
+            break;
     }
 }
 
 /****************************************************************
- *                              *
- *  Registration of DTD declarations            *
- *                              *
+ *                                                              *
+ *      Registration of DTD declarations                        *
+ *                                                              *
  ****************************************************************/
 
 /**
@@ -1403,12 +1404,12 @@ xmlFreeElement(xmlElementPtr elem) {
     xmlUnlinkNode((xmlNodePtr) elem);
     xmlFreeDocElementContent(elem->doc, elem->content);
     if (elem->name != NULL)
-    xmlFree((xmlChar *) elem->name);
+        xmlFree((xmlChar *) elem->name);
     if (elem->prefix != NULL)
-    xmlFree((xmlChar *) elem->prefix);
+        xmlFree((xmlChar *) elem->prefix);
 #ifdef LIBXML_REGEXP_ENABLED
     if (elem->contModel != NULL)
-    xmlRegFreeRegexp(elem->contModel);
+        xmlRegFreeRegexp(elem->contModel);
 #endif
     xmlFree(elem);
 }
@@ -1430,57 +1431,57 @@ xmlElementPtr
 xmlAddElementDecl(xmlValidCtxtPtr ctxt,
                   xmlDtdPtr dtd, const xmlChar *name,
                   xmlElementTypeVal type,
-          xmlElementContentPtr content) {
+                  xmlElementContentPtr content) {
     xmlElementPtr ret;
     xmlElementTablePtr table;
     xmlAttributePtr oldAttributes = NULL;
     xmlChar *ns, *uqname;
 
     if (dtd == NULL) {
-    return(NULL);
+        return(NULL);
     }
     if (name == NULL) {
-    return(NULL);
+        return(NULL);
     }
 
     switch (type) {
         case XML_ELEMENT_TYPE_EMPTY:
-        if (content != NULL) {
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-                "xmlAddElementDecl: content != NULL for EMPTY\n",
-            NULL);
-        return(NULL);
-        }
-        break;
-    case XML_ELEMENT_TYPE_ANY:
-        if (content != NULL) {
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-                "xmlAddElementDecl: content != NULL for ANY\n",
-            NULL);
-        return(NULL);
-        }
-        break;
-    case XML_ELEMENT_TYPE_MIXED:
-        if (content == NULL) {
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-                "xmlAddElementDecl: content == NULL for MIXED\n",
-            NULL);
-        return(NULL);
-        }
-        break;
-    case XML_ELEMENT_TYPE_ELEMENT:
-        if (content == NULL) {
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-                "xmlAddElementDecl: content == NULL for ELEMENT\n",
-            NULL);
-        return(NULL);
-        }
-        break;
-    default:
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-            "Internal: ELEMENT decl corrupted invalid type\n",
-            NULL);
-        return(NULL);
+            if (content != NULL) {
+                xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                        "xmlAddElementDecl: content != NULL for EMPTY\n",
+                        NULL);
+                return(NULL);
+            }
+            break;
+        case XML_ELEMENT_TYPE_ANY:
+            if (content != NULL) {
+                xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                        "xmlAddElementDecl: content != NULL for ANY\n",
+                        NULL);
+                return(NULL);
+            }
+            break;
+        case XML_ELEMENT_TYPE_MIXED:
+            if (content == NULL) {
+                xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                        "xmlAddElementDecl: content == NULL for MIXED\n",
+                        NULL);
+                return(NULL);
+            }
+            break;
+        case XML_ELEMENT_TYPE_ELEMENT:
+            if (content == NULL) {
+                xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                        "xmlAddElementDecl: content == NULL for ELEMENT\n",
+                        NULL);
+                return(NULL);
+            }
+            break;
+        default:
+            xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                    "Internal: ELEMENT decl corrupted invalid type\n",
+                    NULL);
+            return(NULL);
     }
 
     /*
@@ -1488,27 +1489,27 @@ xmlAddElementDecl(xmlValidCtxtPtr ctxt,
      */
     uqname = xmlSplitQName2(name, &ns);
     if (uqname != NULL)
-    name = uqname;
+        name = uqname;
 
     /*
      * Create the Element table if needed.
      */
     table = (xmlElementTablePtr) dtd->elements;
     if (table == NULL) {
-    xmlDictPtr dict = NULL;
+        xmlDictPtr dict = NULL;
 
-    if (dtd->doc != NULL)
-        dict = dtd->doc->dict;
+        if (dtd->doc != NULL)
+            dict = dtd->doc->dict;
         table = xmlHashCreateDict(0, dict);
-    dtd->elements = (void *) table;
+        dtd->elements = (void *) table;
     }
     if (table == NULL) {
-    xmlVErrMemory(ctxt,
+        xmlVErrMemory(ctxt,
             "xmlAddElementDecl: Table creation failed!\n");
-    if (uqname != NULL)
-        xmlFree(uqname);
-    if (ns != NULL)
-        xmlFree(ns);
+        if (uqname != NULL)
+            xmlFree(uqname);
+        if (ns != NULL)
+            xmlFree(ns);
         return(NULL);
     }
 
@@ -1517,13 +1518,13 @@ xmlAddElementDecl(xmlValidCtxtPtr ctxt,
      * internal subset.
      */
     if ((dtd->doc != NULL) && (dtd->doc->intSubset != NULL)) {
-    ret = xmlHashLookup2(dtd->doc->intSubset->elements, name, ns);
-    if ((ret != NULL) && (ret->etype == XML_ELEMENT_TYPE_UNDEFINED)) {
-        oldAttributes = ret->attributes;
-        ret->attributes = NULL;
-        xmlHashRemoveEntry2(dtd->doc->intSubset->elements, name, ns, NULL);
-        xmlFreeElement(ret);
-    }
+        ret = xmlHashLookup2(dtd->doc->intSubset->elements, name, ns);
+        if ((ret != NULL) && (ret->etype == XML_ELEMENT_TYPE_UNDEFINED)) {
+            oldAttributes = ret->attributes;
+            ret->attributes = NULL;
+            xmlHashRemoveEntry2(dtd->doc->intSubset->elements, name, ns, NULL);
+            xmlFreeElement(ret);
+        }
     }
 
     /*
@@ -1532,76 +1533,76 @@ xmlAddElementDecl(xmlValidCtxtPtr ctxt,
      */
     ret = xmlHashLookup2(table, name, ns);
     if (ret != NULL) {
-    if (ret->etype != XML_ELEMENT_TYPE_UNDEFINED) {
+        if (ret->etype != XML_ELEMENT_TYPE_UNDEFINED) {
 #ifdef LIBXML_VALID_ENABLED
-        /*
-         * The element is already defined in this DTD.
-         */
-        xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ELEM_REDEFINED,
-                        "Redefinition of element %s\n",
-                name, NULL, NULL);
+            /*
+             * The element is already defined in this DTD.
+             */
+            xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ELEM_REDEFINED,
+                            "Redefinition of element %s\n",
+                            name, NULL, NULL);
 #endif /* LIBXML_VALID_ENABLED */
-        if (uqname != NULL)
-        xmlFree(uqname);
+            if (uqname != NULL)
+                xmlFree(uqname);
             if (ns != NULL)
+                xmlFree(ns);
+            return(NULL);
+        }
+        if (ns != NULL) {
             xmlFree(ns);
-        return(NULL);
-    }
-    if (ns != NULL) {
-        xmlFree(ns);
-        ns = NULL;
-    }
+            ns = NULL;
+        }
     } else {
-    ret = (xmlElementPtr) xmlMalloc(sizeof(xmlElement));
-    if (ret == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
-        if (uqname != NULL)
-        xmlFree(uqname);
+        ret = (xmlElementPtr) xmlMalloc(sizeof(xmlElement));
+        if (ret == NULL) {
+            xmlVErrMemory(ctxt, "malloc failed");
+            if (uqname != NULL)
+                xmlFree(uqname);
             if (ns != NULL)
-            xmlFree(ns);
-        return(NULL);
-    }
-    memset(ret, 0, sizeof(xmlElement));
-    ret->type = XML_ELEMENT_DECL;
+                xmlFree(ns);
+            return(NULL);
+        }
+        memset(ret, 0, sizeof(xmlElement));
+        ret->type = XML_ELEMENT_DECL;
 
-    /*
-     * fill the structure.
-     */
-    ret->name = xmlStrdup(name);
-    if (ret->name == NULL) {
-        xmlVErrMemory(ctxt, "malloc failed");
-        if (uqname != NULL)
-        xmlFree(uqname);
-            if (ns != NULL)
-            xmlFree(ns);
-        xmlFree(ret);
-        return(NULL);
-    }
-    ret->prefix = ns;
-
-    /*
-     * Validity Check:
-     * Insertion must not fail
-     */
-    if (xmlHashAddEntry2(table, name, ns, ret)) {
-#ifdef LIBXML_VALID_ENABLED
         /*
-         * The element is already defined in this DTD.
+         * fill the structure.
          */
-        xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ELEM_REDEFINED,
-                        "Redefinition of element %s\n",
-                name, NULL, NULL);
+        ret->name = xmlStrdup(name);
+        if (ret->name == NULL) {
+            xmlVErrMemory(ctxt, "malloc failed");
+            if (uqname != NULL)
+                xmlFree(uqname);
+            if (ns != NULL)
+                xmlFree(ns);
+            xmlFree(ret);
+            return(NULL);
+        }
+        ret->prefix = ns;
+
+        /*
+         * Validity Check:
+         * Insertion must not fail
+         */
+        if (xmlHashAddEntry2(table, name, ns, ret)) {
+#ifdef LIBXML_VALID_ENABLED
+            /*
+             * The element is already defined in this DTD.
+             */
+            xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ELEM_REDEFINED,
+                            "Redefinition of element %s\n",
+                            name, NULL, NULL);
 #endif /* LIBXML_VALID_ENABLED */
-        xmlFreeElement(ret);
-        if (uqname != NULL)
-        xmlFree(uqname);
-        return(NULL);
-    }
-    /*
-     * For new element, may have attributes from earlier
-     * definition in internal subset
-     */
-    ret->attributes = oldAttributes;
+            xmlFreeElement(ret);
+            if (uqname != NULL)
+                xmlFree(uqname);
+            return(NULL);
+        }
+        /*
+         * For new element, may have attributes from earlier
+         * definition in internal subset
+         */
+        ret->attributes = oldAttributes;
     }
 
     /*
@@ -1616,11 +1617,11 @@ xmlAddElementDecl(xmlValidCtxtPtr ctxt,
     if ((ctxt != NULL) &&
         ((ctxt->finishDtd == XML_CTXT_FINISH_DTD_0) ||
          (ctxt->finishDtd == XML_CTXT_FINISH_DTD_1))) {
-    ret->content = content;
-    if (content != NULL)
-        content->parent = (xmlElementContentPtr) 1;
+        ret->content = content;
+        if (content != NULL)
+            content->parent = (xmlElementContentPtr) 1;
     } else {
-    ret->content = xmlCopyDocElementContent(dtd->doc, content);
+        ret->content = xmlCopyDocElementContent(dtd->doc, content);
     }
 
     /*
@@ -1629,14 +1630,14 @@ xmlAddElementDecl(xmlValidCtxtPtr ctxt,
     ret->parent = dtd;
     ret->doc = dtd->doc;
     if (dtd->last == NULL) {
-    dtd->children = dtd->last = (xmlNodePtr) ret;
+        dtd->children = dtd->last = (xmlNodePtr) ret;
     } else {
         dtd->last->next = (xmlNodePtr) ret;
-    ret->prev = dtd->last;
-    dtd->last = (xmlNodePtr) ret;
+        ret->prev = dtd->last;
+        dtd->last = (xmlNodePtr) ret;
     }
     if (uqname != NULL)
-    xmlFree(uqname);
+        xmlFree(uqname);
     return(ret);
 }
 
@@ -1672,20 +1673,20 @@ xmlCopyElement(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
 
     cur = (xmlElementPtr) xmlMalloc(sizeof(xmlElement));
     if (cur == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xmlElement));
     cur->type = XML_ELEMENT_DECL;
     cur->etype = elem->etype;
     if (elem->name != NULL)
-    cur->name = xmlStrdup(elem->name);
+        cur->name = xmlStrdup(elem->name);
     else
-    cur->name = NULL;
+        cur->name = NULL;
     if (elem->prefix != NULL)
-    cur->prefix = xmlStrdup(elem->prefix);
+        cur->prefix = xmlStrdup(elem->prefix);
     else
-    cur->prefix = NULL;
+        cur->prefix = NULL;
     cur->content = xmlCopyElementContent(elem->content);
     /* TODO : rebuild the attribute list on the copy */
     cur->attributes = NULL;
@@ -1720,50 +1721,50 @@ xmlDumpElementDecl(xmlBufferPtr buf, xmlElementPtr elem) {
     if ((buf == NULL) || (elem == NULL))
         return;
     switch (elem->etype) {
-    case XML_ELEMENT_TYPE_EMPTY:
-        xmlBufferWriteChar(buf, "<!ELEMENT ");
-        if (elem->prefix != NULL) {
-        xmlBufferWriteCHAR(buf, elem->prefix);
-        xmlBufferWriteChar(buf, ":");
-        }
-        xmlBufferWriteCHAR(buf, elem->name);
-        xmlBufferWriteChar(buf, " EMPTY>\n");
-        break;
-    case XML_ELEMENT_TYPE_ANY:
-        xmlBufferWriteChar(buf, "<!ELEMENT ");
-        if (elem->prefix != NULL) {
-        xmlBufferWriteCHAR(buf, elem->prefix);
-        xmlBufferWriteChar(buf, ":");
-        }
-        xmlBufferWriteCHAR(buf, elem->name);
-        xmlBufferWriteChar(buf, " ANY>\n");
-        break;
-    case XML_ELEMENT_TYPE_MIXED:
-        xmlBufferWriteChar(buf, "<!ELEMENT ");
-        if (elem->prefix != NULL) {
-        xmlBufferWriteCHAR(buf, elem->prefix);
-        xmlBufferWriteChar(buf, ":");
-        }
-        xmlBufferWriteCHAR(buf, elem->name);
-        xmlBufferWriteChar(buf, " ");
-        xmlDumpElementContent(buf, elem->content);
-        xmlBufferWriteChar(buf, ">\n");
-        break;
-    case XML_ELEMENT_TYPE_ELEMENT:
-        xmlBufferWriteChar(buf, "<!ELEMENT ");
-        if (elem->prefix != NULL) {
-        xmlBufferWriteCHAR(buf, elem->prefix);
-        xmlBufferWriteChar(buf, ":");
-        }
-        xmlBufferWriteCHAR(buf, elem->name);
-        xmlBufferWriteChar(buf, " ");
-        xmlDumpElementContent(buf, elem->content);
-        xmlBufferWriteChar(buf, ">\n");
-        break;
-    default:
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ELEMENT struct corrupted invalid type\n",
-            NULL);
+        case XML_ELEMENT_TYPE_EMPTY:
+            xmlBufferWriteChar(buf, "<!ELEMENT ");
+            if (elem->prefix != NULL) {
+                xmlBufferWriteCHAR(buf, elem->prefix);
+                xmlBufferWriteChar(buf, ":");
+            }
+            xmlBufferWriteCHAR(buf, elem->name);
+            xmlBufferWriteChar(buf, " EMPTY>\n");
+            break;
+        case XML_ELEMENT_TYPE_ANY:
+            xmlBufferWriteChar(buf, "<!ELEMENT ");
+            if (elem->prefix != NULL) {
+                xmlBufferWriteCHAR(buf, elem->prefix);
+                xmlBufferWriteChar(buf, ":");
+            }
+            xmlBufferWriteCHAR(buf, elem->name);
+            xmlBufferWriteChar(buf, " ANY>\n");
+            break;
+        case XML_ELEMENT_TYPE_MIXED:
+            xmlBufferWriteChar(buf, "<!ELEMENT ");
+            if (elem->prefix != NULL) {
+                xmlBufferWriteCHAR(buf, elem->prefix);
+                xmlBufferWriteChar(buf, ":");
+            }
+            xmlBufferWriteCHAR(buf, elem->name);
+            xmlBufferWriteChar(buf, " ");
+            xmlDumpElementContent(buf, elem->content);
+            xmlBufferWriteChar(buf, ">\n");
+            break;
+        case XML_ELEMENT_TYPE_ELEMENT:
+            xmlBufferWriteChar(buf, "<!ELEMENT ");
+            if (elem->prefix != NULL) {
+                xmlBufferWriteCHAR(buf, elem->prefix);
+                xmlBufferWriteChar(buf, ":");
+            }
+            xmlBufferWriteCHAR(buf, elem->name);
+            xmlBufferWriteChar(buf, " ");
+            xmlDumpElementContent(buf, elem->content);
+            xmlBufferWriteChar(buf, ">\n");
+            break;
+        default:
+            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "Internal: ELEMENT struct corrupted invalid type\n",
+                    NULL);
     }
 }
 
@@ -1811,7 +1812,7 @@ xmlCreateEnumeration(const xmlChar *name) {
 
     ret = (xmlEnumerationPtr) xmlMalloc(sizeof(xmlEnumeration));
     if (ret == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
+        xmlVErrMemory(NULL, "malloc failed");
         return(NULL);
     }
     memset(ret, 0, sizeof(xmlEnumeration));
@@ -1877,10 +1878,10 @@ xmlDumpEnumeration(xmlBufferPtr buf, xmlEnumerationPtr cur) {
 
     xmlBufferWriteCHAR(buf, cur->name);
     if (cur->next == NULL)
-    xmlBufferWriteChar(buf, ")");
+        xmlBufferWriteChar(buf, ")");
     else {
-    xmlBufferWriteChar(buf, " | ");
-    xmlDumpEnumeration(buf, cur->next);
+        xmlBufferWriteChar(buf, " | ");
+        xmlDumpEnumeration(buf, cur->next);
     }
 }
 #endif /* LIBXML_OUTPUT_ENABLED */
@@ -1906,13 +1907,13 @@ xmlScanIDAttributeDecl(xmlValidCtxtPtr ctxt, xmlElementPtr elem, int err) {
     cur = elem->attributes;
     while (cur != NULL) {
         if (cur->atype == XML_ATTRIBUTE_ID) {
-        ret ++;
-        if ((ret > 1) && (err))
-        xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_MULTIPLE_ID,
-           "Element %s has too many ID attributes defined : %s\n",
-               elem->name, cur->name, NULL);
-    }
-    cur = cur->nexth;
+            ret ++;
+            if ((ret > 1) && (err))
+                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_MULTIPLE_ID,
+               "Element %s has too many ID attributes defined : %s\n",
+                       elem->name, cur->name, NULL);
+        }
+        cur = cur->nexth;
     }
     return(ret);
 }
@@ -1930,31 +1931,31 @@ xmlFreeAttribute(xmlAttributePtr attr) {
 
     if (attr == NULL) return;
     if (attr->doc != NULL)
-    dict = attr->doc->dict;
+        dict = attr->doc->dict;
     else
-    dict = NULL;
+        dict = NULL;
     xmlUnlinkNode((xmlNodePtr) attr);
     if (attr->tree != NULL)
         xmlFreeEnumeration(attr->tree);
     if (dict) {
         if ((attr->elem != NULL) && (!xmlDictOwns(dict, attr->elem)))
-        xmlFree((xmlChar *) attr->elem);
+            xmlFree((xmlChar *) attr->elem);
         if ((attr->name != NULL) && (!xmlDictOwns(dict, attr->name)))
-        xmlFree((xmlChar *) attr->name);
+            xmlFree((xmlChar *) attr->name);
         if ((attr->prefix != NULL) && (!xmlDictOwns(dict, attr->prefix)))
-        xmlFree((xmlChar *) attr->prefix);
+            xmlFree((xmlChar *) attr->prefix);
         if ((attr->defaultValue != NULL) &&
-        (!xmlDictOwns(dict, attr->defaultValue)))
-        xmlFree((xmlChar *) attr->defaultValue);
+            (!xmlDictOwns(dict, attr->defaultValue)))
+            xmlFree((xmlChar *) attr->defaultValue);
     } else {
-    if (attr->elem != NULL)
-        xmlFree((xmlChar *) attr->elem);
-    if (attr->name != NULL)
-        xmlFree((xmlChar *) attr->name);
-    if (attr->defaultValue != NULL)
-        xmlFree((xmlChar *) attr->defaultValue);
-    if (attr->prefix != NULL)
-        xmlFree((xmlChar *) attr->prefix);
+        if (attr->elem != NULL)
+            xmlFree((xmlChar *) attr->elem);
+        if (attr->name != NULL)
+            xmlFree((xmlChar *) attr->name);
+        if (attr->defaultValue != NULL)
+            xmlFree((xmlChar *) attr->defaultValue);
+        if (attr->prefix != NULL)
+            xmlFree((xmlChar *) attr->prefix);
     }
     xmlFree(attr);
 }
@@ -1981,27 +1982,27 @@ xmlAttributePtr
 xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
                     xmlDtdPtr dtd, const xmlChar *elem,
                     const xmlChar *name, const xmlChar *ns,
-            xmlAttributeType type, xmlAttributeDefault def,
-            const xmlChar *defaultValue, xmlEnumerationPtr tree) {
+                    xmlAttributeType type, xmlAttributeDefault def,
+                    const xmlChar *defaultValue, xmlEnumerationPtr tree) {
     xmlAttributePtr ret;
     xmlAttributeTablePtr table;
     xmlElementPtr elemDef;
     xmlDictPtr dict = NULL;
 
     if (dtd == NULL) {
-    xmlFreeEnumeration(tree);
-    return(NULL);
+        xmlFreeEnumeration(tree);
+        return(NULL);
     }
     if (name == NULL) {
-    xmlFreeEnumeration(tree);
-    return(NULL);
+        xmlFreeEnumeration(tree);
+        return(NULL);
     }
     if (elem == NULL) {
-    xmlFreeEnumeration(tree);
-    return(NULL);
+        xmlFreeEnumeration(tree);
+        return(NULL);
     }
     if (dtd->doc != NULL)
-    dict = dtd->doc->dict;
+        dict = dtd->doc->dict;
 
 #ifdef LIBXML_VALID_ENABLED
     /*
@@ -2009,40 +2010,40 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
      */
     switch (type) {
         case XML_ATTRIBUTE_CDATA:
-        break;
+            break;
         case XML_ATTRIBUTE_ID:
-        break;
+            break;
         case XML_ATTRIBUTE_IDREF:
-        break;
+            break;
         case XML_ATTRIBUTE_IDREFS:
-        break;
+            break;
         case XML_ATTRIBUTE_ENTITY:
-        break;
+            break;
         case XML_ATTRIBUTE_ENTITIES:
-        break;
+            break;
         case XML_ATTRIBUTE_NMTOKEN:
-        break;
+            break;
         case XML_ATTRIBUTE_NMTOKENS:
-        break;
+            break;
         case XML_ATTRIBUTE_ENUMERATION:
-        break;
+            break;
         case XML_ATTRIBUTE_NOTATION:
-        break;
-    default:
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-            "Internal: ATTRIBUTE struct corrupted invalid type\n",
-            NULL);
-        xmlFreeEnumeration(tree);
-        return(NULL);
+            break;
+        default:
+            xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                    "Internal: ATTRIBUTE struct corrupted invalid type\n",
+                    NULL);
+            xmlFreeEnumeration(tree);
+            return(NULL);
     }
     if ((defaultValue != NULL) &&
         (!xmlValidateAttributeValueInternal(dtd->doc, type, defaultValue))) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ATTRIBUTE_DEFAULT,
-                    "Attribute %s of %s: invalid default value\n",
-                    elem, name, defaultValue);
-    defaultValue = NULL;
-    if (ctxt != NULL)
-        ctxt->valid = 0;
+        xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_ATTRIBUTE_DEFAULT,
+                        "Attribute %s of %s: invalid default value\n",
+                        elem, name, defaultValue);
+        defaultValue = NULL;
+        if (ctxt != NULL)
+            ctxt->valid = 0;
     }
 #endif /* LIBXML_VALID_ENABLED */
 
@@ -2051,13 +2052,13 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
      * already defined in the internal subset
      */
     if ((dtd->doc != NULL) && (dtd->doc->extSubset == dtd) &&
-    (dtd->doc->intSubset != NULL) &&
-    (dtd->doc->intSubset->attributes != NULL)) {
+        (dtd->doc->intSubset != NULL) &&
+        (dtd->doc->intSubset->attributes != NULL)) {
         ret = xmlHashLookup3(dtd->doc->intSubset->attributes, name, ns, elem);
-    if (ret != NULL) {
-        xmlFreeEnumeration(tree);
-        return(NULL);
-    }
+        if (ret != NULL) {
+            xmlFreeEnumeration(tree);
+            return(NULL);
+        }
     }
 
     /*
@@ -2066,21 +2067,21 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
     table = (xmlAttributeTablePtr) dtd->attributes;
     if (table == NULL) {
         table = xmlHashCreateDict(0, dict);
-    dtd->attributes = (void *) table;
+        dtd->attributes = (void *) table;
     }
     if (table == NULL) {
-    xmlVErrMemory(ctxt,
+        xmlVErrMemory(ctxt,
             "xmlAddAttributeDecl: Table creation failed!\n");
-    xmlFreeEnumeration(tree);
+        xmlFreeEnumeration(tree);
         return(NULL);
     }
 
 
     ret = (xmlAttributePtr) xmlMalloc(sizeof(xmlAttribute));
     if (ret == NULL) {
-    xmlVErrMemory(ctxt, "malloc failed");
-    xmlFreeEnumeration(tree);
-    return(NULL);
+        xmlVErrMemory(ctxt, "malloc failed");
+        xmlFreeEnumeration(tree);
+        return(NULL);
     }
     memset(ret, 0, sizeof(xmlAttribute));
     ret->type = XML_ATTRIBUTE_DECL;
@@ -2096,21 +2097,21 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
      */
     ret->doc = dtd->doc;
     if (dict) {
-    ret->name = xmlDictLookup(dict, name, -1);
-    ret->prefix = xmlDictLookup(dict, ns, -1);
-    ret->elem = xmlDictLookup(dict, elem, -1);
+        ret->name = xmlDictLookup(dict, name, -1);
+        ret->prefix = xmlDictLookup(dict, ns, -1);
+        ret->elem = xmlDictLookup(dict, elem, -1);
     } else {
-    ret->name = xmlStrdup(name);
-    ret->prefix = xmlStrdup(ns);
-    ret->elem = xmlStrdup(elem);
+        ret->name = xmlStrdup(name);
+        ret->prefix = xmlStrdup(ns);
+        ret->elem = xmlStrdup(elem);
     }
     ret->def = def;
     ret->tree = tree;
     if (defaultValue != NULL) {
         if (dict)
-        ret->defaultValue = xmlDictLookup(dict, defaultValue, -1);
-    else
-        ret->defaultValue = xmlStrdup(defaultValue);
+            ret->defaultValue = xmlDictLookup(dict, defaultValue, -1);
+        else
+            ret->defaultValue = xmlStrdup(defaultValue);
     }
 
     /*
@@ -2119,15 +2120,15 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
      */
     if (xmlHashAddEntry3(table, ret->name, ret->prefix, ret->elem, ret) < 0) {
 #ifdef LIBXML_VALID_ENABLED
-    /*
-     * The attribute is already defined in this DTD.
-     */
-    xmlErrValidWarning(ctxt, (xmlNodePtr) dtd, XML_DTD_ATTRIBUTE_REDEFINED,
-         "Attribute %s of element %s: already defined\n",
-         name, elem, NULL);
+        /*
+         * The attribute is already defined in this DTD.
+         */
+        xmlErrValidWarning(ctxt, (xmlNodePtr) dtd, XML_DTD_ATTRIBUTE_REDEFINED,
+                 "Attribute %s of element %s: already defined\n",
+                 name, elem, NULL);
 #endif /* LIBXML_VALID_ENABLED */
-    xmlFreeAttribute(ret);
-    return(NULL);
+        xmlFreeAttribute(ret);
+        return(NULL);
     }
 
     /*
@@ -2139,43 +2140,43 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
 
 #ifdef LIBXML_VALID_ENABLED
         if ((type == XML_ATTRIBUTE_ID) &&
-        (xmlScanIDAttributeDecl(NULL, elemDef, 1) != 0)) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_MULTIPLE_ID,
-       "Element %s has too may ID attributes defined : %s\n",
-           elem, name, NULL);
-        if (ctxt != NULL)
-        ctxt->valid = 0;
-    }
+            (xmlScanIDAttributeDecl(NULL, elemDef, 1) != 0)) {
+            xmlErrValidNode(ctxt, (xmlNodePtr) dtd, XML_DTD_MULTIPLE_ID,
+           "Element %s has too may ID attributes defined : %s\n",
+                   elem, name, NULL);
+            if (ctxt != NULL)
+                ctxt->valid = 0;
+        }
 #endif /* LIBXML_VALID_ENABLED */
 
-    /*
-     * Insert namespace default def first they need to be
-     * processed first.
-     */
-    if ((xmlStrEqual(ret->name, BAD_CAST "xmlns")) ||
-        ((ret->prefix != NULL &&
-         (xmlStrEqual(ret->prefix, BAD_CAST "xmlns"))))) {
-        ret->nexth = elemDef->attributes;
-        elemDef->attributes = ret;
-    } else {
-        xmlAttributePtr tmp = elemDef->attributes;
-
-        while ((tmp != NULL) &&
-           ((xmlStrEqual(tmp->name, BAD_CAST "xmlns")) ||
+        /*
+         * Insert namespace default def first they need to be
+         * processed first.
+         */
+        if ((xmlStrEqual(ret->name, BAD_CAST "xmlns")) ||
             ((ret->prefix != NULL &&
-             (xmlStrEqual(ret->prefix, BAD_CAST "xmlns")))))) {
-        if (tmp->nexth == NULL)
-            break;
-        tmp = tmp->nexth;
-        }
-        if (tmp != NULL) {
-        ret->nexth = tmp->nexth;
-            tmp->nexth = ret;
+             (xmlStrEqual(ret->prefix, BAD_CAST "xmlns"))))) {
+            ret->nexth = elemDef->attributes;
+            elemDef->attributes = ret;
         } else {
-        ret->nexth = elemDef->attributes;
-        elemDef->attributes = ret;
+            xmlAttributePtr tmp = elemDef->attributes;
+
+            while ((tmp != NULL) &&
+                   ((xmlStrEqual(tmp->name, BAD_CAST "xmlns")) ||
+                    ((ret->prefix != NULL &&
+                     (xmlStrEqual(ret->prefix, BAD_CAST "xmlns")))))) {
+                if (tmp->nexth == NULL)
+                    break;
+                tmp = tmp->nexth;
+            }
+            if (tmp != NULL) {
+                ret->nexth = tmp->nexth;
+                tmp->nexth = ret;
+            } else {
+                ret->nexth = elemDef->attributes;
+                elemDef->attributes = ret;
+            }
         }
-    }
     }
 
     /*
@@ -2183,11 +2184,11 @@ xmlAddAttributeDecl(xmlValidCtxtPtr ctxt,
      */
     ret->parent = dtd;
     if (dtd->last == NULL) {
-    dtd->children = dtd->last = (xmlNodePtr) ret;
+        dtd->children = dtd->last = (xmlNodePtr) ret;
     } else {
         dtd->last->next = (xmlNodePtr) ret;
-    ret->prev = dtd->last;
-    dtd->last = (xmlNodePtr) ret;
+        ret->prev = dtd->last;
+        dtd->last = (xmlNodePtr) ret;
     }
     return(ret);
 }
@@ -2224,8 +2225,8 @@ xmlCopyAttribute(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
 
     cur = (xmlAttributePtr) xmlMalloc(sizeof(xmlAttribute));
     if (cur == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xmlAttribute));
     cur->type = XML_ATTRIBUTE_DECL;
@@ -2233,13 +2234,13 @@ xmlCopyAttribute(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
     cur->def = attr->def;
     cur->tree = xmlCopyEnumeration(attr->tree);
     if (attr->elem != NULL)
-    cur->elem = xmlStrdup(attr->elem);
+        cur->elem = xmlStrdup(attr->elem);
     if (attr->name != NULL)
-    cur->name = xmlStrdup(attr->name);
+        cur->name = xmlStrdup(attr->name);
     if (attr->prefix != NULL)
-    cur->prefix = xmlStrdup(attr->prefix);
+        cur->prefix = xmlStrdup(attr->prefix);
     if (attr->defaultValue != NULL)
-    cur->defaultValue = xmlStrdup(attr->defaultValue);
+        cur->defaultValue = xmlStrdup(attr->defaultValue);
     return(cur);
 }
 
@@ -2274,68 +2275,68 @@ xmlDumpAttributeDecl(xmlBufferPtr buf, xmlAttributePtr attr) {
     xmlBufferWriteCHAR(buf, attr->elem);
     xmlBufferWriteChar(buf, " ");
     if (attr->prefix != NULL) {
-    xmlBufferWriteCHAR(buf, attr->prefix);
-    xmlBufferWriteChar(buf, ":");
+        xmlBufferWriteCHAR(buf, attr->prefix);
+        xmlBufferWriteChar(buf, ":");
     }
     xmlBufferWriteCHAR(buf, attr->name);
     switch (attr->atype) {
-    case XML_ATTRIBUTE_CDATA:
-        xmlBufferWriteChar(buf, " CDATA");
-        break;
-    case XML_ATTRIBUTE_ID:
-        xmlBufferWriteChar(buf, " ID");
-        break;
-    case XML_ATTRIBUTE_IDREF:
-        xmlBufferWriteChar(buf, " IDREF");
-        break;
-    case XML_ATTRIBUTE_IDREFS:
-        xmlBufferWriteChar(buf, " IDREFS");
-        break;
-    case XML_ATTRIBUTE_ENTITY:
-        xmlBufferWriteChar(buf, " ENTITY");
-        break;
-    case XML_ATTRIBUTE_ENTITIES:
-        xmlBufferWriteChar(buf, " ENTITIES");
-        break;
-    case XML_ATTRIBUTE_NMTOKEN:
-        xmlBufferWriteChar(buf, " NMTOKEN");
-        break;
-    case XML_ATTRIBUTE_NMTOKENS:
-        xmlBufferWriteChar(buf, " NMTOKENS");
-        break;
-    case XML_ATTRIBUTE_ENUMERATION:
-        xmlBufferWriteChar(buf, " (");
-        xmlDumpEnumeration(buf, attr->tree);
-        break;
-    case XML_ATTRIBUTE_NOTATION:
-        xmlBufferWriteChar(buf, " NOTATION (");
-        xmlDumpEnumeration(buf, attr->tree);
-        break;
-    default:
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ATTRIBUTE struct corrupted invalid type\n",
-            NULL);
+        case XML_ATTRIBUTE_CDATA:
+            xmlBufferWriteChar(buf, " CDATA");
+            break;
+        case XML_ATTRIBUTE_ID:
+            xmlBufferWriteChar(buf, " ID");
+            break;
+        case XML_ATTRIBUTE_IDREF:
+            xmlBufferWriteChar(buf, " IDREF");
+            break;
+        case XML_ATTRIBUTE_IDREFS:
+            xmlBufferWriteChar(buf, " IDREFS");
+            break;
+        case XML_ATTRIBUTE_ENTITY:
+            xmlBufferWriteChar(buf, " ENTITY");
+            break;
+        case XML_ATTRIBUTE_ENTITIES:
+            xmlBufferWriteChar(buf, " ENTITIES");
+            break;
+        case XML_ATTRIBUTE_NMTOKEN:
+            xmlBufferWriteChar(buf, " NMTOKEN");
+            break;
+        case XML_ATTRIBUTE_NMTOKENS:
+            xmlBufferWriteChar(buf, " NMTOKENS");
+            break;
+        case XML_ATTRIBUTE_ENUMERATION:
+            xmlBufferWriteChar(buf, " (");
+            xmlDumpEnumeration(buf, attr->tree);
+            break;
+        case XML_ATTRIBUTE_NOTATION:
+            xmlBufferWriteChar(buf, " NOTATION (");
+            xmlDumpEnumeration(buf, attr->tree);
+            break;
+        default:
+            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "Internal: ATTRIBUTE struct corrupted invalid type\n",
+                    NULL);
     }
     switch (attr->def) {
-    case XML_ATTRIBUTE_NONE:
-        break;
-    case XML_ATTRIBUTE_REQUIRED:
-        xmlBufferWriteChar(buf, " #REQUIRED");
-        break;
-    case XML_ATTRIBUTE_IMPLIED:
-        xmlBufferWriteChar(buf, " #IMPLIED");
-        break;
-    case XML_ATTRIBUTE_FIXED:
-        xmlBufferWriteChar(buf, " #FIXED");
-        break;
-    default:
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ATTRIBUTE struct corrupted invalid def\n",
-            NULL);
+        case XML_ATTRIBUTE_NONE:
+            break;
+        case XML_ATTRIBUTE_REQUIRED:
+            xmlBufferWriteChar(buf, " #REQUIRED");
+            break;
+        case XML_ATTRIBUTE_IMPLIED:
+            xmlBufferWriteChar(buf, " #IMPLIED");
+            break;
+        case XML_ATTRIBUTE_FIXED:
+            xmlBufferWriteChar(buf, " #FIXED");
+            break;
+        default:
+            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "Internal: ATTRIBUTE struct corrupted invalid def\n",
+                    NULL);
     }
     if (attr->defaultValue != NULL) {
-    xmlBufferWriteChar(buf, " ");
-    xmlBufferWriteQuotedString(buf, attr->defaultValue);
+        xmlBufferWriteChar(buf, " ");
+        xmlBufferWriteQuotedString(buf, attr->defaultValue);
     }
     xmlBufferWriteChar(buf, ">\n");
 }
@@ -2369,9 +2370,9 @@ xmlDumpAttributeTable(xmlBufferPtr buf, xmlAttributeTablePtr table) {
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *                                  *
- *              NOTATIONs               *
- *                                  *
+ *                                                                      *
+ *                              NOTATIONs                               *
+ *                                                                      *
  ************************************************************************/
 /**
  * xmlFreeNotation:
@@ -2383,11 +2384,11 @@ static void
 xmlFreeNotation(xmlNotationPtr nota) {
     if (nota == NULL) return;
     if (nota->name != NULL)
-    xmlFree((xmlChar *) nota->name);
+        xmlFree((xmlChar *) nota->name);
     if (nota->PublicID != NULL)
-    xmlFree((xmlChar *) nota->PublicID);
+        xmlFree((xmlChar *) nota->PublicID);
     if (nota->SystemID != NULL)
-    xmlFree((xmlChar *) nota->SystemID);
+        xmlFree((xmlChar *) nota->SystemID);
     xmlFree(nota);
 }
 
@@ -2406,19 +2407,19 @@ xmlFreeNotation(xmlNotationPtr nota) {
  */
 xmlNotationPtr
 xmlAddNotationDecl(xmlValidCtxtPtr ctxt, xmlDtdPtr dtd,
-               const xmlChar *name,
+                   const xmlChar *name,
                    const xmlChar *PublicID, const xmlChar *SystemID) {
     xmlNotationPtr ret;
     xmlNotationTablePtr table;
 
     if (dtd == NULL) {
-    return(NULL);
+        return(NULL);
     }
     if (name == NULL) {
-    return(NULL);
+        return(NULL);
     }
     if ((PublicID == NULL) && (SystemID == NULL)) {
-    return(NULL);
+        return(NULL);
     }
 
     /*
@@ -2426,22 +2427,22 @@ xmlAddNotationDecl(xmlValidCtxtPtr ctxt, xmlDtdPtr dtd,
      */
     table = (xmlNotationTablePtr) dtd->notations;
     if (table == NULL) {
-    xmlDictPtr dict = NULL;
-    if (dtd->doc != NULL)
-        dict = dtd->doc->dict;
+        xmlDictPtr dict = NULL;
+        if (dtd->doc != NULL)
+            dict = dtd->doc->dict;
 
         dtd->notations = table = xmlHashCreateDict(0, dict);
     }
     if (table == NULL) {
-    xmlVErrMemory(ctxt,
-        "xmlAddNotationDecl: Table creation failed!\n");
+        xmlVErrMemory(ctxt,
+                "xmlAddNotationDecl: Table creation failed!\n");
         return(NULL);
     }
 
     ret = (xmlNotationPtr) xmlMalloc(sizeof(xmlNotation));
     if (ret == NULL) {
-    xmlVErrMemory(ctxt, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(ctxt, "malloc failed");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xmlNotation));
 
@@ -2460,12 +2461,12 @@ xmlAddNotationDecl(xmlValidCtxtPtr ctxt, xmlDtdPtr dtd,
      */
     if (xmlHashAddEntry(table, name, ret)) {
 #ifdef LIBXML_VALID_ENABLED
-    xmlErrValid(NULL, XML_DTD_NOTATION_REDEFINED,
-            "xmlAddNotationDecl: %s already defined\n",
-            (const char *) name);
+        xmlErrValid(NULL, XML_DTD_NOTATION_REDEFINED,
+                    "xmlAddNotationDecl: %s already defined\n",
+                    (const char *) name);
 #endif /* LIBXML_VALID_ENABLED */
-    xmlFreeNotation(ret);
-    return(NULL);
+        xmlFreeNotation(ret);
+        return(NULL);
     }
     return(ret);
 }
@@ -2502,21 +2503,21 @@ xmlCopyNotation(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
 
     cur = (xmlNotationPtr) xmlMalloc(sizeof(xmlNotation));
     if (cur == NULL) {
-    xmlVErrMemory(NULL, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(NULL, "malloc failed");
+        return(NULL);
     }
     if (nota->name != NULL)
-    cur->name = xmlStrdup(nota->name);
+        cur->name = xmlStrdup(nota->name);
     else
-    cur->name = NULL;
+        cur->name = NULL;
     if (nota->PublicID != NULL)
-    cur->PublicID = xmlStrdup(nota->PublicID);
+        cur->PublicID = xmlStrdup(nota->PublicID);
     else
-    cur->PublicID = NULL;
+        cur->PublicID = NULL;
     if (nota->SystemID != NULL)
-    cur->SystemID = xmlStrdup(nota->SystemID);
+        cur->SystemID = xmlStrdup(nota->SystemID);
     else
-    cur->SystemID = NULL;
+        cur->SystemID = NULL;
     return(cur);
 }
 
@@ -2549,15 +2550,15 @@ xmlDumpNotationDecl(xmlBufferPtr buf, xmlNotationPtr nota) {
     xmlBufferWriteChar(buf, "<!NOTATION ");
     xmlBufferWriteCHAR(buf, nota->name);
     if (nota->PublicID != NULL) {
-    xmlBufferWriteChar(buf, " PUBLIC ");
-    xmlBufferWriteQuotedString(buf, nota->PublicID);
-    if (nota->SystemID != NULL) {
-        xmlBufferWriteChar(buf, " ");
-        xmlBufferWriteQuotedString(buf, nota->SystemID);
-    }
+        xmlBufferWriteChar(buf, " PUBLIC ");
+        xmlBufferWriteQuotedString(buf, nota->PublicID);
+        if (nota->SystemID != NULL) {
+            xmlBufferWriteChar(buf, " ");
+            xmlBufferWriteQuotedString(buf, nota->SystemID);
+        }
     } else {
-    xmlBufferWriteChar(buf, " SYSTEM ");
-    xmlBufferWriteQuotedString(buf, nota->SystemID);
+        xmlBufferWriteChar(buf, " SYSTEM ");
+        xmlBufferWriteQuotedString(buf, nota->SystemID);
     }
     xmlBufferWriteChar(buf, " >\n");
 }
@@ -2591,9 +2592,9 @@ xmlDumpNotationTable(xmlBufferPtr buf, xmlNotationTablePtr table) {
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *                                  *
- *              IDs                 *
- *                                  *
+ *                                                                      *
+ *                              IDs                                     *
+ *                                                                      *
  ************************************************************************/
 /**
  * DICT_FREE:
@@ -2602,10 +2603,10 @@ xmlDumpNotationTable(xmlBufferPtr buf, xmlNotationTablePtr table) {
  * Free a string if it is not owned by the "dict" dictionary in the
  * current scope
  */
-#define DICT_FREE(str)                      \
-    if ((str) && ((!dict) ||                \
-        (xmlDictOwns(dict, (const xmlChar *)(str)) == 0)))  \
-        xmlFree((char *)(str));
+#define DICT_FREE(str)                                          \
+        if ((str) && ((!dict) ||                                \
+            (xmlDictOwns(dict, (const xmlChar *)(str)) == 0)))  \
+            xmlFree((char *)(str));
 
 /**
  * xmlValidNormalizeString:
@@ -2625,13 +2626,13 @@ xmlValidNormalizeString(xmlChar *str) {
 
     while (*src == 0x20) src++;
     while (*src != 0) {
-    if (*src == 0x20) {
-        while (*src == 0x20) src++;
-        if (*src != 0)
-        *dst++ = 0x20;
-    } else {
-        *dst++ = *src++;
-    }
+        if (*src == 0x20) {
+            while (*src == 0x20) src++;
+            if (*src != 0)
+                *dst++ = 0x20;
+        } else {
+            *dst++ = *src++;
+        }
     }
     *dst = 0;
 }
@@ -2670,9 +2671,9 @@ xmlFreeID(xmlIDPtr id) {
         dict = id->doc->dict;
 
     if (id->value != NULL)
-    DICT_FREE(id->value)
+        DICT_FREE(id->value)
     if (id->name != NULL)
-    DICT_FREE(id->name)
+        DICT_FREE(id->name)
     xmlFree(id);
 }
 
@@ -2695,13 +2696,13 @@ xmlAddID(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
     xmlIDTablePtr table;
 
     if (doc == NULL) {
-    return(NULL);
+        return(NULL);
     }
     if ((value == NULL) || (value[0] == 0)) {
-    return(NULL);
+        return(NULL);
     }
     if (attr == NULL) {
-    return(NULL);
+        return(NULL);
     }
 
     /*
@@ -2712,15 +2713,15 @@ xmlAddID(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
         doc->ids = table = xmlHashCreateDict(0, doc->dict);
     }
     if (table == NULL) {
-    xmlVErrMemory(ctxt,
-        "xmlAddID: Table creation failed!\n");
+        xmlVErrMemory(ctxt,
+                "xmlAddID: Table creation failed!\n");
         return(NULL);
     }
 
     ret = (xmlIDPtr) xmlMalloc(sizeof(xmlID));
     if (ret == NULL) {
-    xmlVErrMemory(ctxt, "malloc failed");
-    return(NULL);
+        xmlVErrMemory(ctxt, "malloc failed");
+        return(NULL);
     }
 
     /*
@@ -2729,35 +2730,35 @@ xmlAddID(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
     ret->value = xmlStrdup(value);
     ret->doc = doc;
     if (xmlIsStreaming(ctxt)) {
-    /*
-     * Operating in streaming mode, attr is gonna disappear
-     */
-    if (doc->dict != NULL)
-        ret->name = xmlDictLookup(doc->dict, attr->name, -1);
-    else
-        ret->name = xmlStrdup(attr->name);
-    ret->attr = NULL;
+        /*
+         * Operating in streaming mode, attr is gonna disappear
+         */
+        if (doc->dict != NULL)
+            ret->name = xmlDictLookup(doc->dict, attr->name, -1);
+        else
+            ret->name = xmlStrdup(attr->name);
+        ret->attr = NULL;
     } else {
-    ret->attr = attr;
-    ret->name = NULL;
+        ret->attr = attr;
+        ret->name = NULL;
     }
     ret->lineno = xmlGetLineNo(attr->parent);
 
     if (xmlHashAddEntry(table, value, ret) < 0) {
 #ifdef LIBXML_VALID_ENABLED
-    /*
-     * The id is already defined in this DTD.
-     */
-    if (ctxt != NULL) {
-        xmlErrValidNode(ctxt, attr->parent, XML_DTD_ID_REDEFINED,
-                "ID %s already defined\n", value, NULL, NULL);
-    }
+        /*
+         * The id is already defined in this DTD.
+         */
+        if (ctxt != NULL) {
+            xmlErrValidNode(ctxt, attr->parent, XML_DTD_ID_REDEFINED,
+                            "ID %s already defined\n", value, NULL, NULL);
+        }
 #endif /* LIBXML_VALID_ENABLED */
-    xmlFreeID(ret);
-    return(NULL);
+        xmlFreeID(ret);
+        return(NULL);
     }
     if (attr != NULL)
-    attr->atype = XML_ATTRIBUTE_ID;
+        attr->atype = XML_ATTRIBUTE_ID;
     return(ret);
 }
 
@@ -2796,48 +2797,48 @@ xmlIsID(xmlDocPtr doc, xmlNodePtr elem, xmlAttrPtr attr) {
     if ((attr->ns != NULL) && (attr->ns->prefix != NULL) &&
         (!strcmp((char *) attr->name, "id")) &&
         (!strcmp((char *) attr->ns->prefix, "xml")))
-    return(1);
+        return(1);
     if (doc == NULL) return(0);
     if ((doc->intSubset == NULL) && (doc->extSubset == NULL) &&
         (doc->type != XML_HTML_DOCUMENT_NODE)) {
-    return(0);
+        return(0);
     } else if (doc->type == XML_HTML_DOCUMENT_NODE) {
         if ((xmlStrEqual(BAD_CAST "id", attr->name)) ||
-        ((xmlStrEqual(BAD_CAST "name", attr->name)) &&
-        ((elem == NULL) || (xmlStrEqual(elem->name, BAD_CAST "a")))))
-        return(1);
-    return(0);
+            ((xmlStrEqual(BAD_CAST "name", attr->name)) &&
+            ((elem == NULL) || (xmlStrEqual(elem->name, BAD_CAST "a")))))
+            return(1);
+        return(0);
     } else if (elem == NULL) {
-    return(0);
+        return(0);
     } else {
-    xmlAttributePtr attrDecl = NULL;
+        xmlAttributePtr attrDecl = NULL;
 
-    xmlChar felem[50], fattr[50];
-    xmlChar *fullelemname, *fullattrname;
+        xmlChar felem[50], fattr[50];
+        xmlChar *fullelemname, *fullattrname;
 
-    fullelemname = (elem->ns != NULL && elem->ns->prefix != NULL) ?
-        xmlBuildQName(elem->name, elem->ns->prefix, felem, 50) :
-        (xmlChar *)elem->name;
+        fullelemname = (elem->ns != NULL && elem->ns->prefix != NULL) ?
+            xmlBuildQName(elem->name, elem->ns->prefix, felem, 50) :
+            (xmlChar *)elem->name;
 
-    fullattrname = (attr->ns != NULL && attr->ns->prefix != NULL) ?
-        xmlBuildQName(attr->name, attr->ns->prefix, fattr, 50) :
-        (xmlChar *)attr->name;
+        fullattrname = (attr->ns != NULL && attr->ns->prefix != NULL) ?
+            xmlBuildQName(attr->name, attr->ns->prefix, fattr, 50) :
+            (xmlChar *)attr->name;
 
-    if (fullelemname != NULL && fullattrname != NULL) {
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullelemname,
-                                 fullattrname);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullelemname,
-                         fullattrname);
-    }
+        if (fullelemname != NULL && fullattrname != NULL) {
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullelemname,
+                                         fullattrname);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullelemname,
+                                             fullattrname);
+        }
 
-    if ((fullattrname != fattr) && (fullattrname != attr->name))
-        xmlFree(fullattrname);
-    if ((fullelemname != felem) && (fullelemname != elem->name))
-        xmlFree(fullelemname);
+        if ((fullattrname != fattr) && (fullattrname != attr->name))
+            xmlFree(fullattrname);
+        if ((fullelemname != felem) && (fullelemname != elem->name))
+            xmlFree(fullelemname);
 
         if ((attrDecl != NULL) && (attrDecl->atype == XML_ATTRIBUTE_ID))
-        return(1);
+            return(1);
     }
     return(0);
 }
@@ -2896,11 +2897,11 @@ xmlGetID(xmlDocPtr doc, const xmlChar *ID) {
     xmlIDPtr id;
 
     if (doc == NULL) {
-    return(NULL);
+        return(NULL);
     }
 
     if (ID == NULL) {
-    return(NULL);
+        return(NULL);
     }
 
     table = (xmlIDTablePtr) doc->ids;
@@ -2909,26 +2910,26 @@ xmlGetID(xmlDocPtr doc, const xmlChar *ID) {
 
     id = xmlHashLookup(table, ID);
     if (id == NULL)
-    return(NULL);
+        return(NULL);
     if (id->attr == NULL) {
-    /*
-     * We are operating on a stream, return a well known reference
-     * since the attribute node doesn't exist anymore
-     */
-    return((xmlAttrPtr) doc);
+        /*
+         * We are operating on a stream, return a well known reference
+         * since the attribute node doesn't exist anymore
+         */
+        return((xmlAttrPtr) doc);
     }
     return(id->attr);
 }
 
 /************************************************************************
- *                                  *
- *              Refs                    *
- *                                  *
+ *                                                                      *
+ *                              Refs                                    *
+ *                                                                      *
  ************************************************************************/
 typedef struct xmlRemoveMemo_t
 {
-    xmlListPtr l;
-    xmlAttrPtr ap;
+        xmlListPtr l;
+        xmlAttrPtr ap;
 } xmlRemoveMemo;
 
 typedef xmlRemoveMemo *xmlRemoveMemoPtr;
@@ -3042,14 +3043,14 @@ xmlAddRef(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
         doc->refs = table = xmlHashCreateDict(0, doc->dict);
     }
     if (table == NULL) {
-    xmlVErrMemory(ctxt,
+        xmlVErrMemory(ctxt,
             "xmlAddRef: Table creation failed!\n");
         return(NULL);
     }
 
     ret = (xmlRefPtr) xmlMalloc(sizeof(xmlRef));
     if (ret == NULL) {
-    xmlVErrMemory(ctxt, "malloc failed");
+        xmlVErrMemory(ctxt, "malloc failed");
         return(NULL);
     }
 
@@ -3058,14 +3059,14 @@ xmlAddRef(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
      */
     ret->value = xmlStrdup(value);
     if (xmlIsStreaming(ctxt)) {
-    /*
-     * Operating in streaming mode, attr is gonna disappear
-     */
-    ret->name = xmlStrdup(attr->name);
-    ret->attr = NULL;
+        /*
+         * Operating in streaming mode, attr is gonna disappear
+         */
+        ret->name = xmlStrdup(attr->name);
+        ret->attr = NULL;
     } else {
-    ret->name = NULL;
-    ret->attr = attr;
+        ret->name = NULL;
+        ret->attr = attr;
     }
     ret->lineno = xmlGetLineNo(attr->parent);
 
@@ -3078,32 +3079,32 @@ xmlAddRef(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
 
     if (NULL == (ref_list = xmlHashLookup(table, value))) {
         if (NULL == (ref_list = xmlListCreate(xmlFreeRef, xmlDummyCompare))) {
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "xmlAddRef: Reference list creation failed!\n",
-            NULL);
-        goto failed;
+            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "xmlAddRef: Reference list creation failed!\n",
+                    NULL);
+            goto failed;
         }
         if (xmlHashAddEntry(table, value, ref_list) < 0) {
             xmlListDelete(ref_list);
-        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "xmlAddRef: Reference list insertion failed!\n",
-            NULL);
-        goto failed;
+            xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "xmlAddRef: Reference list insertion failed!\n",
+                    NULL);
+            goto failed;
         }
     }
     if (xmlListAppend(ref_list, ret) != 0) {
-    xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "xmlAddRef: Reference list insertion failed!\n",
-            NULL);
+        xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
+                    "xmlAddRef: Reference list insertion failed!\n",
+                    NULL);
         goto failed;
     }
     return(ret);
 failed:
     if (ret != NULL) {
         if (ret->value != NULL)
-        xmlFree((char *)ret->value);
+            xmlFree((char *)ret->value);
         if (ret->name != NULL)
-        xmlFree((char *)ret->name);
+            xmlFree((char *)ret->name);
         xmlFree(ret);
     }
     return(NULL);
@@ -3138,7 +3139,7 @@ xmlIsRef(xmlDocPtr doc, xmlNodePtr elem, xmlAttrPtr attr) {
         return(0);
     if (doc == NULL) {
         doc = attr->doc;
-    if (doc == NULL) return(0);
+        if (doc == NULL) return(0);
     }
 
     if ((doc->intSubset == NULL) && (doc->extSubset == NULL)) {
@@ -3153,12 +3154,12 @@ xmlIsRef(xmlDocPtr doc, xmlNodePtr elem, xmlAttrPtr attr) {
         attrDecl = xmlGetDtdAttrDesc(doc->intSubset, elem->name, attr->name);
         if ((attrDecl == NULL) && (doc->extSubset != NULL))
             attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
-                                 elem->name, attr->name);
+                                         elem->name, attr->name);
 
-    if ((attrDecl != NULL) &&
-        (attrDecl->atype == XML_ATTRIBUTE_IDREF ||
-         attrDecl->atype == XML_ATTRIBUTE_IDREFS))
-    return(1);
+        if ((attrDecl != NULL) &&
+            (attrDecl->atype == XML_ATTRIBUTE_IDREF ||
+             attrDecl->atype == XML_ATTRIBUTE_IDREFS))
+        return(1);
     }
     return(0);
 }
@@ -3248,9 +3249,9 @@ xmlGetRefs(xmlDocPtr doc, const xmlChar *ID) {
 }
 
 /************************************************************************
- *                                  *
- *      Routines for validity checking              *
- *                                  *
+ *                                                                      *
+ *              Routines for validity checking                          *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -3271,7 +3272,7 @@ xmlGetDtdElementDesc(xmlDtdPtr dtd, const xmlChar *name) {
 
     if ((dtd == NULL) || (name == NULL)) return(NULL);
     if (dtd->elements == NULL)
-    return(NULL);
+        return(NULL);
     table = (xmlElementTablePtr) dtd->elements;
 
     uqname = xmlSplitQName2(name, &prefix);
@@ -3301,25 +3302,25 @@ xmlGetDtdElementDesc2(xmlDtdPtr dtd, const xmlChar *name, int create) {
 
     if (dtd == NULL) return(NULL);
     if (dtd->elements == NULL) {
-    xmlDictPtr dict = NULL;
+        xmlDictPtr dict = NULL;
 
-    if (dtd->doc != NULL)
-        dict = dtd->doc->dict;
+        if (dtd->doc != NULL)
+            dict = dtd->doc->dict;
 
-    if (!create)
-        return(NULL);
-    /*
-     * Create the Element table if needed.
-     */
-    table = (xmlElementTablePtr) dtd->elements;
-    if (table == NULL) {
-        table = xmlHashCreateDict(0, dict);
-        dtd->elements = (void *) table;
-    }
-    if (table == NULL) {
-        xmlVErrMemory(NULL, "element table allocation failed");
-        return(NULL);
-    }
+        if (!create)
+            return(NULL);
+        /*
+         * Create the Element table if needed.
+         */
+        table = (xmlElementTablePtr) dtd->elements;
+        if (table == NULL) {
+            table = xmlHashCreateDict(0, dict);
+            dtd->elements = (void *) table;
+        }
+        if (table == NULL) {
+            xmlVErrMemory(NULL, "element table allocation failed");
+            return(NULL);
+        }
     }
     table = (xmlElementTablePtr) dtd->elements;
 
@@ -3328,22 +3329,22 @@ xmlGetDtdElementDesc2(xmlDtdPtr dtd, const xmlChar *name, int create) {
         name = uqname;
     cur = xmlHashLookup2(table, name, prefix);
     if ((cur == NULL) && (create)) {
-    cur = (xmlElementPtr) xmlMalloc(sizeof(xmlElement));
-    if (cur == NULL) {
-        xmlVErrMemory(NULL, "malloc failed");
-        return(NULL);
-    }
-    memset(cur, 0, sizeof(xmlElement));
-    cur->type = XML_ELEMENT_DECL;
+        cur = (xmlElementPtr) xmlMalloc(sizeof(xmlElement));
+        if (cur == NULL) {
+            xmlVErrMemory(NULL, "malloc failed");
+            return(NULL);
+        }
+        memset(cur, 0, sizeof(xmlElement));
+        cur->type = XML_ELEMENT_DECL;
 
-    /*
-     * fill the structure.
-     */
-    cur->name = xmlStrdup(name);
-    cur->prefix = xmlStrdup(prefix);
-    cur->etype = XML_ELEMENT_TYPE_UNDEFINED;
+        /*
+         * fill the structure.
+         */
+        cur->name = xmlStrdup(name);
+        cur->prefix = xmlStrdup(prefix);
+        cur->etype = XML_ELEMENT_TYPE_UNDEFINED;
 
-    xmlHashAddEntry2(table, name, prefix, cur);
+        xmlHashAddEntry2(table, name, prefix, cur);
     }
     if (prefix != NULL) xmlFree(prefix);
     if (uqname != NULL) xmlFree(uqname);
@@ -3363,7 +3364,7 @@ xmlGetDtdElementDesc2(xmlDtdPtr dtd, const xmlChar *name, int create) {
 
 xmlElementPtr
 xmlGetDtdQElementDesc(xmlDtdPtr dtd, const xmlChar *name,
-                  const xmlChar *prefix) {
+                      const xmlChar *prefix) {
     xmlElementTablePtr table;
 
     if (dtd == NULL) return(NULL);
@@ -3396,16 +3397,16 @@ xmlGetDtdAttrDesc(xmlDtdPtr dtd, const xmlChar *elem, const xmlChar *name) {
 
     table = (xmlAttributeTablePtr) dtd->attributes;
     if (table == NULL)
-    return(NULL);
+        return(NULL);
 
     uqname = xmlSplitQName2(name, &prefix);
 
     if (uqname != NULL) {
-    cur = xmlHashLookup3(table, uqname, prefix, elem);
-    if (prefix != NULL) xmlFree(prefix);
-    if (uqname != NULL) xmlFree(uqname);
+        cur = xmlHashLookup3(table, uqname, prefix, elem);
+        if (prefix != NULL) xmlFree(prefix);
+        if (uqname != NULL) xmlFree(uqname);
     } else
-    cur = xmlHashLookup3(table, name, NULL, elem);
+        cur = xmlHashLookup3(table, name, NULL, elem);
     return(cur);
 }
 
@@ -3424,7 +3425,7 @@ xmlGetDtdAttrDesc(xmlDtdPtr dtd, const xmlChar *elem, const xmlChar *name) {
 
 xmlAttributePtr
 xmlGetDtdQAttrDesc(xmlDtdPtr dtd, const xmlChar *elem, const xmlChar *name,
-              const xmlChar *prefix) {
+                  const xmlChar *prefix) {
     xmlAttributeTablePtr table;
 
     if (dtd == NULL) return(NULL);
@@ -3477,13 +3478,13 @@ xmlValidateNotationUse(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
 
     notaDecl = xmlGetDtdNotationDesc(doc->intSubset, notationName);
     if ((notaDecl == NULL) && (doc->extSubset != NULL))
-    notaDecl = xmlGetDtdNotationDesc(doc->extSubset, notationName);
+        notaDecl = xmlGetDtdNotationDesc(doc->extSubset, notationName);
 
     if ((notaDecl == NULL) && (ctxt != NULL)) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) doc, XML_DTD_UNKNOWN_NOTATION,
-                    "NOTATION %s is not declared\n",
-                notationName, NULL, NULL);
-    return(0);
+        xmlErrValidNode(ctxt, (xmlNodePtr) doc, XML_DTD_UNKNOWN_NOTATION,
+                        "NOTATION %s is not declared\n",
+                        notationName, NULL, NULL);
+        return(0);
     }
     return(1);
 }
@@ -3508,21 +3509,21 @@ xmlIsMixedElement(xmlDocPtr doc, const xmlChar *name) {
 
     elemDecl = xmlGetDtdElementDesc(doc->intSubset, name);
     if ((elemDecl == NULL) && (doc->extSubset != NULL))
-    elemDecl = xmlGetDtdElementDesc(doc->extSubset, name);
+        elemDecl = xmlGetDtdElementDesc(doc->extSubset, name);
     if (elemDecl == NULL) return(-1);
     switch (elemDecl->etype) {
-    case XML_ELEMENT_TYPE_UNDEFINED:
-        return(-1);
-    case XML_ELEMENT_TYPE_ELEMENT:
-        return(0);
+        case XML_ELEMENT_TYPE_UNDEFINED:
+            return(-1);
+        case XML_ELEMENT_TYPE_ELEMENT:
+            return(0);
         case XML_ELEMENT_TYPE_EMPTY:
-        /*
-         * return 1 for EMPTY since we want VC error to pop up
-         * on <empty>     </empty> for example
-         */
-    case XML_ELEMENT_TYPE_ANY:
-    case XML_ELEMENT_TYPE_MIXED:
-        return(1);
+            /*
+             * return 1 for EMPTY since we want VC error to pop up
+             * on <empty>     </empty> for example
+             */
+        case XML_ELEMENT_TYPE_ANY:
+        case XML_ELEMENT_TYPE_MIXED:
+            return(1);
     }
     return(1);
 }
@@ -3533,28 +3534,28 @@ static int
 xmlIsDocNameStartChar(xmlDocPtr doc, int c) {
     if ((doc == NULL) || (doc->properties & XML_DOC_OLD10) == 0) {
         /*
-     * Use the new checks of production [4] [4a] amd [5] of the
-     * Update 5 of XML-1.0
-     */
-    if (((c >= 'a') && (c <= 'z')) ||
-        ((c >= 'A') && (c <= 'Z')) ||
-        (c == '_') || (c == ':') ||
-        ((c >= 0xC0) && (c <= 0xD6)) ||
-        ((c >= 0xD8) && (c <= 0xF6)) ||
-        ((c >= 0xF8) && (c <= 0x2FF)) ||
-        ((c >= 0x370) && (c <= 0x37D)) ||
-        ((c >= 0x37F) && (c <= 0x1FFF)) ||
-        ((c >= 0x200C) && (c <= 0x200D)) ||
-        ((c >= 0x2070) && (c <= 0x218F)) ||
-        ((c >= 0x2C00) && (c <= 0x2FEF)) ||
-        ((c >= 0x3001) && (c <= 0xD7FF)) ||
-        ((c >= 0xF900) && (c <= 0xFDCF)) ||
-        ((c >= 0xFDF0) && (c <= 0xFFFD)) ||
-        ((c >= 0x10000) && (c <= 0xEFFFF)))
-        return(1);
+         * Use the new checks of production [4] [4a] amd [5] of the
+         * Update 5 of XML-1.0
+         */
+        if (((c >= 'a') && (c <= 'z')) ||
+            ((c >= 'A') && (c <= 'Z')) ||
+            (c == '_') || (c == ':') ||
+            ((c >= 0xC0) && (c <= 0xD6)) ||
+            ((c >= 0xD8) && (c <= 0xF6)) ||
+            ((c >= 0xF8) && (c <= 0x2FF)) ||
+            ((c >= 0x370) && (c <= 0x37D)) ||
+            ((c >= 0x37F) && (c <= 0x1FFF)) ||
+            ((c >= 0x200C) && (c <= 0x200D)) ||
+            ((c >= 0x2070) && (c <= 0x218F)) ||
+            ((c >= 0x2C00) && (c <= 0x2FEF)) ||
+            ((c >= 0x3001) && (c <= 0xD7FF)) ||
+            ((c >= 0xF900) && (c <= 0xFDCF)) ||
+            ((c >= 0xFDF0) && (c <= 0xFFFD)) ||
+            ((c >= 0x10000) && (c <= 0xEFFFF)))
+            return(1);
     } else {
         if (IS_LETTER(c) || (c == '_') || (c == ':'))
-        return(1);
+            return(1);
     }
     return(0);
 }
@@ -3563,36 +3564,36 @@ static int
 xmlIsDocNameChar(xmlDocPtr doc, int c) {
     if ((doc == NULL) || (doc->properties & XML_DOC_OLD10) == 0) {
         /*
-     * Use the new checks of production [4] [4a] amd [5] of the
-     * Update 5 of XML-1.0
-     */
-    if (((c >= 'a') && (c <= 'z')) ||
-        ((c >= 'A') && (c <= 'Z')) ||
-        ((c >= '0') && (c <= '9')) || /* !start */
-        (c == '_') || (c == ':') ||
-        (c == '-') || (c == '.') || (c == 0xB7) || /* !start */
-        ((c >= 0xC0) && (c <= 0xD6)) ||
-        ((c >= 0xD8) && (c <= 0xF6)) ||
-        ((c >= 0xF8) && (c <= 0x2FF)) ||
-        ((c >= 0x300) && (c <= 0x36F)) || /* !start */
-        ((c >= 0x370) && (c <= 0x37D)) ||
-        ((c >= 0x37F) && (c <= 0x1FFF)) ||
-        ((c >= 0x200C) && (c <= 0x200D)) ||
-        ((c >= 0x203F) && (c <= 0x2040)) || /* !start */
-        ((c >= 0x2070) && (c <= 0x218F)) ||
-        ((c >= 0x2C00) && (c <= 0x2FEF)) ||
-        ((c >= 0x3001) && (c <= 0xD7FF)) ||
-        ((c >= 0xF900) && (c <= 0xFDCF)) ||
-        ((c >= 0xFDF0) && (c <= 0xFFFD)) ||
-        ((c >= 0x10000) && (c <= 0xEFFFF)))
-         return(1);
+         * Use the new checks of production [4] [4a] amd [5] of the
+         * Update 5 of XML-1.0
+         */
+        if (((c >= 'a') && (c <= 'z')) ||
+            ((c >= 'A') && (c <= 'Z')) ||
+            ((c >= '0') && (c <= '9')) || /* !start */
+            (c == '_') || (c == ':') ||
+            (c == '-') || (c == '.') || (c == 0xB7) || /* !start */
+            ((c >= 0xC0) && (c <= 0xD6)) ||
+            ((c >= 0xD8) && (c <= 0xF6)) ||
+            ((c >= 0xF8) && (c <= 0x2FF)) ||
+            ((c >= 0x300) && (c <= 0x36F)) || /* !start */
+            ((c >= 0x370) && (c <= 0x37D)) ||
+            ((c >= 0x37F) && (c <= 0x1FFF)) ||
+            ((c >= 0x200C) && (c <= 0x200D)) ||
+            ((c >= 0x203F) && (c <= 0x2040)) || /* !start */
+            ((c >= 0x2070) && (c <= 0x218F)) ||
+            ((c >= 0x2C00) && (c <= 0x2FEF)) ||
+            ((c >= 0x3001) && (c <= 0xD7FF)) ||
+            ((c >= 0xF900) && (c <= 0xFDCF)) ||
+            ((c >= 0xFDF0) && (c <= 0xFFFD)) ||
+            ((c >= 0x10000) && (c <= 0xEFFFF)))
+             return(1);
     } else {
         if ((IS_LETTER(c)) || (IS_DIGIT(c)) ||
             (c == '.') || (c == '-') ||
-        (c == '_') || (c == ':') ||
-        (IS_COMBINING(c)) ||
-        (IS_EXTENDER(c)))
-        return(1);
+            (c == '_') || (c == ':') ||
+            (IS_COMBINING(c)) ||
+            (IS_EXTENDER(c)))
+            return(1);
     }
     return(0);
 }
@@ -3617,13 +3618,13 @@ xmlValidateNameValueInternal(xmlDocPtr doc, const xmlChar *value) {
     val = xmlStringCurrentChar(NULL, cur, &len);
     cur += len;
     if (!xmlIsDocNameStartChar(doc, val))
-    return(0);
+        return(0);
 
     val = xmlStringCurrentChar(NULL, cur, &len);
     cur += len;
     while (xmlIsDocNameChar(doc, val)) {
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
+        val = xmlStringCurrentChar(NULL, cur, &len);
+        cur += len;
     }
 
     if (val != 0) return(0);
@@ -3666,32 +3667,32 @@ xmlValidateNamesValueInternal(xmlDocPtr doc, const xmlChar *value) {
     cur += len;
 
     if (!xmlIsDocNameStartChar(doc, val))
-    return(0);
-
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
-    while (xmlIsDocNameChar(doc, val)) {
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
-    }
-
-    /* Should not test IS_BLANK(val) here -- see erratum E20*/
-    while (val == 0x20) {
-    while (val == 0x20) {
-        val = xmlStringCurrentChar(NULL, cur, &len);
-        cur += len;
-    }
-
-    if (!xmlIsDocNameStartChar(doc, val))
         return(0);
 
     val = xmlStringCurrentChar(NULL, cur, &len);
     cur += len;
-
     while (xmlIsDocNameChar(doc, val)) {
         val = xmlStringCurrentChar(NULL, cur, &len);
         cur += len;
     }
+
+    /* Should not test IS_BLANK(val) here -- see erratum E20*/
+    while (val == 0x20) {
+        while (val == 0x20) {
+            val = xmlStringCurrentChar(NULL, cur, &len);
+            cur += len;
+        }
+
+        if (!xmlIsDocNameStartChar(doc, val))
+            return(0);
+
+        val = xmlStringCurrentChar(NULL, cur, &len);
+        cur += len;
+
+        while (xmlIsDocNameChar(doc, val)) {
+            val = xmlStringCurrentChar(NULL, cur, &len);
+            cur += len;
+        }
     }
 
     if (val != 0) return(0);
@@ -3736,13 +3737,13 @@ xmlValidateNmtokenValueInternal(xmlDocPtr doc, const xmlChar *value) {
     cur += len;
 
     if (!xmlIsDocNameChar(doc, val))
-    return(0);
+        return(0);
 
     val = xmlStringCurrentChar(NULL, cur, &len);
     cur += len;
     while (xmlIsDocNameChar(doc, val)) {
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
+        val = xmlStringCurrentChar(NULL, cur, &len);
+        cur += len;
     }
 
     if (val != 0) return(0);
@@ -3789,36 +3790,36 @@ xmlValidateNmtokensValueInternal(xmlDocPtr doc, const xmlChar *value) {
     cur += len;
 
     while (IS_BLANK(val)) {
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
-    }
-
-    if (!xmlIsDocNameChar(doc, val))
-    return(0);
-
-    while (xmlIsDocNameChar(doc, val)) {
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
-    }
-
-    /* Should not test IS_BLANK(val) here -- see erratum E20*/
-    while (val == 0x20) {
-    while (val == 0x20) {
         val = xmlStringCurrentChar(NULL, cur, &len);
         cur += len;
     }
-    if (val == 0) return(1);
 
     if (!xmlIsDocNameChar(doc, val))
         return(0);
 
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    cur += len;
-
     while (xmlIsDocNameChar(doc, val)) {
         val = xmlStringCurrentChar(NULL, cur, &len);
         cur += len;
     }
+
+    /* Should not test IS_BLANK(val) here -- see erratum E20*/
+    while (val == 0x20) {
+        while (val == 0x20) {
+            val = xmlStringCurrentChar(NULL, cur, &len);
+            cur += len;
+        }
+        if (val == 0) return(1);
+
+        if (!xmlIsDocNameChar(doc, val))
+            return(0);
+
+        val = xmlStringCurrentChar(NULL, cur, &len);
+        cur += len;
+
+        while (xmlIsDocNameChar(doc, val)) {
+            val = xmlStringCurrentChar(NULL, cur, &len);
+            cur += len;
+        }
     }
 
     if (val != 0) return(0);
@@ -3880,21 +3881,21 @@ static int
 xmlValidateAttributeValueInternal(xmlDocPtr doc, xmlAttributeType type,
                                   const xmlChar *value) {
     switch (type) {
-    case XML_ATTRIBUTE_ENTITIES:
-    case XML_ATTRIBUTE_IDREFS:
-        return(xmlValidateNamesValueInternal(doc, value));
-    case XML_ATTRIBUTE_ENTITY:
-    case XML_ATTRIBUTE_IDREF:
-    case XML_ATTRIBUTE_ID:
-    case XML_ATTRIBUTE_NOTATION:
-        return(xmlValidateNameValueInternal(doc, value));
-    case XML_ATTRIBUTE_NMTOKENS:
-    case XML_ATTRIBUTE_ENUMERATION:
-        return(xmlValidateNmtokensValueInternal(doc, value));
-    case XML_ATTRIBUTE_NMTOKEN:
-        return(xmlValidateNmtokenValueInternal(doc, value));
+        case XML_ATTRIBUTE_ENTITIES:
+        case XML_ATTRIBUTE_IDREFS:
+            return(xmlValidateNamesValueInternal(doc, value));
+        case XML_ATTRIBUTE_ENTITY:
+        case XML_ATTRIBUTE_IDREF:
+        case XML_ATTRIBUTE_ID:
+        case XML_ATTRIBUTE_NOTATION:
+            return(xmlValidateNameValueInternal(doc, value));
+        case XML_ATTRIBUTE_NMTOKENS:
+        case XML_ATTRIBUTE_ENUMERATION:
+            return(xmlValidateNmtokensValueInternal(doc, value));
+        case XML_ATTRIBUTE_NMTOKEN:
+            return(xmlValidateNmtokenValueInternal(doc, value));
         case XML_ATTRIBUTE_CDATA:
-        break;
+            break;
     }
     return(1);
 }
@@ -3962,88 +3963,88 @@ xmlValidateAttributeValue2(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
       const xmlChar *name, xmlAttributeType type, const xmlChar *value) {
     int ret = 1;
     switch (type) {
-    case XML_ATTRIBUTE_IDREFS:
-    case XML_ATTRIBUTE_IDREF:
-    case XML_ATTRIBUTE_ID:
-    case XML_ATTRIBUTE_NMTOKENS:
-    case XML_ATTRIBUTE_ENUMERATION:
-    case XML_ATTRIBUTE_NMTOKEN:
+        case XML_ATTRIBUTE_IDREFS:
+        case XML_ATTRIBUTE_IDREF:
+        case XML_ATTRIBUTE_ID:
+        case XML_ATTRIBUTE_NMTOKENS:
+        case XML_ATTRIBUTE_ENUMERATION:
+        case XML_ATTRIBUTE_NMTOKEN:
         case XML_ATTRIBUTE_CDATA:
-        break;
-    case XML_ATTRIBUTE_ENTITY: {
-        xmlEntityPtr ent;
-
-        ent = xmlGetDocEntity(doc, value);
-        /* yeah it's a bit messy... */
-        if ((ent == NULL) && (doc->standalone == 1)) {
-        doc->standalone = 0;
-        ent = xmlGetDocEntity(doc, value);
-        }
-        if (ent == NULL) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) doc,
-                XML_DTD_UNKNOWN_ENTITY,
-   "ENTITY attribute %s reference an unknown entity \"%s\"\n",
-               name, value, NULL);
-        ret = 0;
-        } else if (ent->etype != XML_EXTERNAL_GENERAL_UNPARSED_ENTITY) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) doc,
-                XML_DTD_ENTITY_TYPE,
-   "ENTITY attribute %s reference an entity \"%s\" of wrong type\n",
-               name, value, NULL);
-        ret = 0;
-        }
-        break;
-        }
-    case XML_ATTRIBUTE_ENTITIES: {
-        xmlChar *dup, *nam = NULL, *cur, save;
-        xmlEntityPtr ent;
-
-        dup = xmlStrdup(value);
-        if (dup == NULL)
-        return(0);
-        cur = dup;
-        while (*cur != 0) {
-        nam = cur;
-        while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
-        save = *cur;
-        *cur = 0;
-        ent = xmlGetDocEntity(doc, nam);
-        if (ent == NULL) {
-            xmlErrValidNode(ctxt, (xmlNodePtr) doc,
-                    XML_DTD_UNKNOWN_ENTITY,
-       "ENTITIES attribute %s reference an unknown entity \"%s\"\n",
-               name, nam, NULL);
-            ret = 0;
-        } else if (ent->etype != XML_EXTERNAL_GENERAL_UNPARSED_ENTITY) {
-            xmlErrValidNode(ctxt, (xmlNodePtr) doc,
-                    XML_DTD_ENTITY_TYPE,
-       "ENTITIES attribute %s reference an entity \"%s\" of wrong type\n",
-               name, nam, NULL);
-            ret = 0;
-        }
-        if (save == 0)
             break;
-        *cur = save;
-        while (IS_BLANK_CH(*cur)) cur++;
+        case XML_ATTRIBUTE_ENTITY: {
+            xmlEntityPtr ent;
+
+            ent = xmlGetDocEntity(doc, value);
+            /* yeah it's a bit messy... */
+            if ((ent == NULL) && (doc->standalone == 1)) {
+                doc->standalone = 0;
+                ent = xmlGetDocEntity(doc, value);
+            }
+            if (ent == NULL) {
+                xmlErrValidNode(ctxt, (xmlNodePtr) doc,
+                                XML_DTD_UNKNOWN_ENTITY,
+   "ENTITY attribute %s reference an unknown entity \"%s\"\n",
+                       name, value, NULL);
+                ret = 0;
+            } else if (ent->etype != XML_EXTERNAL_GENERAL_UNPARSED_ENTITY) {
+                xmlErrValidNode(ctxt, (xmlNodePtr) doc,
+                                XML_DTD_ENTITY_TYPE,
+   "ENTITY attribute %s reference an entity \"%s\" of wrong type\n",
+                       name, value, NULL);
+                ret = 0;
+            }
+            break;
         }
-        xmlFree(dup);
-        break;
-    }
-    case XML_ATTRIBUTE_NOTATION: {
-        xmlNotationPtr nota;
+        case XML_ATTRIBUTE_ENTITIES: {
+            xmlChar *dup, *nam = NULL, *cur, save;
+            xmlEntityPtr ent;
 
-        nota = xmlGetDtdNotationDesc(doc->intSubset, value);
-        if ((nota == NULL) && (doc->extSubset != NULL))
-        nota = xmlGetDtdNotationDesc(doc->extSubset, value);
+            dup = xmlStrdup(value);
+            if (dup == NULL)
+                return(0);
+            cur = dup;
+            while (*cur != 0) {
+                nam = cur;
+                while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
+                save = *cur;
+                *cur = 0;
+                ent = xmlGetDocEntity(doc, nam);
+                if (ent == NULL) {
+                    xmlErrValidNode(ctxt, (xmlNodePtr) doc,
+                                    XML_DTD_UNKNOWN_ENTITY,
+       "ENTITIES attribute %s reference an unknown entity \"%s\"\n",
+                           name, nam, NULL);
+                    ret = 0;
+                } else if (ent->etype != XML_EXTERNAL_GENERAL_UNPARSED_ENTITY) {
+                    xmlErrValidNode(ctxt, (xmlNodePtr) doc,
+                                    XML_DTD_ENTITY_TYPE,
+       "ENTITIES attribute %s reference an entity \"%s\" of wrong type\n",
+                           name, nam, NULL);
+                    ret = 0;
+                }
+                if (save == 0)
+                    break;
+                *cur = save;
+                while (IS_BLANK_CH(*cur)) cur++;
+            }
+            xmlFree(dup);
+            break;
+        }
+        case XML_ATTRIBUTE_NOTATION: {
+            xmlNotationPtr nota;
 
-        if (nota == NULL) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) doc,
-                        XML_DTD_UNKNOWN_NOTATION,
+            nota = xmlGetDtdNotationDesc(doc->intSubset, value);
+            if ((nota == NULL) && (doc->extSubset != NULL))
+                nota = xmlGetDtdNotationDesc(doc->extSubset, value);
+
+            if (nota == NULL) {
+                xmlErrValidNode(ctxt, (xmlNodePtr) doc,
+                                XML_DTD_UNKNOWN_NOTATION,
        "NOTATION attribute %s reference an unknown notation \"%s\"\n",
-               name, value, NULL);
-        ret = 0;
-        }
-        break;
+                       name, value, NULL);
+                ret = 0;
+            }
+            break;
         }
     }
     return(ret);
@@ -4075,7 +4076,7 @@ xmlValidateAttributeValue2(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
 
 xmlChar *
 xmlValidCtxtNormalizeAttributeValue(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
-         xmlNodePtr elem, const xmlChar *name, const xmlChar *value) {
+             xmlNodePtr elem, const xmlChar *name, const xmlChar *value) {
     xmlChar *ret;
     xmlAttributePtr attrDecl = NULL;
     int extsubset = 0;
@@ -4086,43 +4087,43 @@ xmlValidCtxtNormalizeAttributeValue(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     if (value == NULL) return(NULL);
 
     if ((elem->ns != NULL) && (elem->ns->prefix != NULL)) {
-    xmlChar fn[50];
-    xmlChar *fullname;
+        xmlChar fn[50];
+        xmlChar *fullname;
 
-    fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
-    if (fullname == NULL)
-        return(NULL);
-    attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname, name);
-    if ((attrDecl == NULL) && (doc->extSubset != NULL)) {
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullname, name);
-        if (attrDecl != NULL)
-        extsubset = 1;
-    }
-    if ((fullname != fn) && (fullname != elem->name))
-        xmlFree(fullname);
+        fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
+        if (fullname == NULL)
+            return(NULL);
+        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname, name);
+        if ((attrDecl == NULL) && (doc->extSubset != NULL)) {
+            attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullname, name);
+            if (attrDecl != NULL)
+                extsubset = 1;
+        }
+        if ((fullname != fn) && (fullname != elem->name))
+            xmlFree(fullname);
     }
     if ((attrDecl == NULL) && (doc->intSubset != NULL))
-    attrDecl = xmlGetDtdAttrDesc(doc->intSubset, elem->name, name);
+        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, elem->name, name);
     if ((attrDecl == NULL) && (doc->extSubset != NULL)) {
-    attrDecl = xmlGetDtdAttrDesc(doc->extSubset, elem->name, name);
-    if (attrDecl != NULL)
-        extsubset = 1;
+        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, elem->name, name);
+        if (attrDecl != NULL)
+            extsubset = 1;
     }
 
     if (attrDecl == NULL)
-    return(NULL);
+        return(NULL);
     if (attrDecl->atype == XML_ATTRIBUTE_CDATA)
-    return(NULL);
+        return(NULL);
 
     ret = xmlStrdup(value);
     if (ret == NULL)
-    return(NULL);
+        return(NULL);
     xmlValidNormalizeString(ret);
     if ((doc->standalone) && (extsubset == 1) && (!xmlStrEqual(value, ret))) {
-    xmlErrValidNode(ctxt, elem, XML_DTD_NOT_STANDALONE,
+        xmlErrValidNode(ctxt, elem, XML_DTD_NOT_STANDALONE,
 "standalone: %s on %s value had to be normalized based on external subset declaration\n",
-           name, elem->name, NULL);
-    ctxt->valid = 0;
+               name, elem->name, NULL);
+        ctxt->valid = 0;
     }
     return(ret);
 }
@@ -4148,7 +4149,7 @@ xmlValidCtxtNormalizeAttributeValue(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
 
 xmlChar *
 xmlValidNormalizeAttributeValue(xmlDocPtr doc, xmlNodePtr elem,
-                    const xmlChar *name, const xmlChar *value) {
+                                const xmlChar *name, const xmlChar *value) {
     xmlChar *ret;
     xmlAttributePtr attrDecl = NULL;
 
@@ -4158,34 +4159,34 @@ xmlValidNormalizeAttributeValue(xmlDocPtr doc, xmlNodePtr elem,
     if (value == NULL) return(NULL);
 
     if ((elem->ns != NULL) && (elem->ns->prefix != NULL)) {
-    xmlChar fn[50];
-    xmlChar *fullname;
+        xmlChar fn[50];
+        xmlChar *fullname;
 
-    fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
-    if (fullname == NULL)
-        return(NULL);
-    if ((fullname != fn) && (fullname != elem->name))
-        xmlFree(fullname);
+        fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
+        if (fullname == NULL)
+            return(NULL);
+        if ((fullname != fn) && (fullname != elem->name))
+            xmlFree(fullname);
     }
     attrDecl = xmlGetDtdAttrDesc(doc->intSubset, elem->name, name);
     if ((attrDecl == NULL) && (doc->extSubset != NULL))
-    attrDecl = xmlGetDtdAttrDesc(doc->extSubset, elem->name, name);
+        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, elem->name, name);
 
     if (attrDecl == NULL)
-    return(NULL);
+        return(NULL);
     if (attrDecl->atype == XML_ATTRIBUTE_CDATA)
-    return(NULL);
+        return(NULL);
 
     ret = xmlStrdup(value);
     if (ret == NULL)
-    return(NULL);
+        return(NULL);
     xmlValidNormalizeString(ret);
     return(ret);
 }
 
 static void
 xmlValidateAttributeIdCallback(void *payload, void *data,
-                           const xmlChar *name ATTRIBUTE_UNUSED) {
+                               const xmlChar *name ATTRIBUTE_UNUSED) {
     xmlAttributePtr attr = (xmlAttributePtr) payload;
     int *count = (int *) data;
     if (attr->atype == XML_ATTRIBUTE_ID) (*count)++;
@@ -4220,85 +4221,85 @@ xmlValidateAttributeDecl(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     /* Attribute Default Legal */
     /* Enumeration */
     if (attr->defaultValue != NULL) {
-    val = xmlValidateAttributeValueInternal(doc, attr->atype,
-                                            attr->defaultValue);
-    if (val == 0) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ATTRIBUTE_DEFAULT,
-           "Syntax of default value for attribute %s of %s is not valid\n",
-               attr->name, attr->elem, NULL);
-    }
+        val = xmlValidateAttributeValueInternal(doc, attr->atype,
+                                                attr->defaultValue);
+        if (val == 0) {
+            xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ATTRIBUTE_DEFAULT,
+               "Syntax of default value for attribute %s of %s is not valid\n",
+                   attr->name, attr->elem, NULL);
+        }
         ret &= val;
     }
 
     /* ID Attribute Default */
     if ((attr->atype == XML_ATTRIBUTE_ID)&&
         (attr->def != XML_ATTRIBUTE_IMPLIED) &&
-    (attr->def != XML_ATTRIBUTE_REQUIRED)) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ID_FIXED,
+        (attr->def != XML_ATTRIBUTE_REQUIRED)) {
+        xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ID_FIXED,
           "ID attribute %s of %s is not valid must be #IMPLIED or #REQUIRED\n",
-           attr->name, attr->elem, NULL);
-    ret = 0;
+               attr->name, attr->elem, NULL);
+        ret = 0;
     }
 
     /* One ID per Element Type */
     if (attr->atype == XML_ATTRIBUTE_ID) {
         int nbId;
 
-    /* the trick is that we parse DtD as their own internal subset */
+        /* the trick is that we parse DtD as their own internal subset */
         xmlElementPtr elem = xmlGetDtdElementDesc(doc->intSubset,
-                                              attr->elem);
-    if (elem != NULL) {
-        nbId = xmlScanIDAttributeDecl(NULL, elem, 0);
-    } else {
-        xmlAttributeTablePtr table;
-
-        /*
-         * The attribute may be declared in the internal subset and the
-         * element in the external subset.
-         */
-        nbId = 0;
-        if (doc->intSubset != NULL) {
-        table = (xmlAttributeTablePtr) doc->intSubset->attributes;
-        xmlHashScan3(table, NULL, NULL, attr->elem,
-                 xmlValidateAttributeIdCallback, &nbId);
-        }
-    }
-    if (nbId > 1) {
-
-        xmlErrValidNodeNr(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
-       "Element %s has %d ID attribute defined in the internal subset : %s\n",
-           attr->elem, nbId, attr->name);
-    } else if (doc->extSubset != NULL) {
-        int extId = 0;
-        elem = xmlGetDtdElementDesc(doc->extSubset, attr->elem);
+                                                  attr->elem);
         if (elem != NULL) {
-        extId = xmlScanIDAttributeDecl(NULL, elem, 0);
+            nbId = xmlScanIDAttributeDecl(NULL, elem, 0);
+        } else {
+            xmlAttributeTablePtr table;
+
+            /*
+             * The attribute may be declared in the internal subset and the
+             * element in the external subset.
+             */
+            nbId = 0;
+            if (doc->intSubset != NULL) {
+                table = (xmlAttributeTablePtr) doc->intSubset->attributes;
+                xmlHashScan3(table, NULL, NULL, attr->elem,
+                             xmlValidateAttributeIdCallback, &nbId);
+            }
         }
-        if (extId > 1) {
-        xmlErrValidNodeNr(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
+        if (nbId > 1) {
+
+            xmlErrValidNodeNr(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
+       "Element %s has %d ID attribute defined in the internal subset : %s\n",
+                   attr->elem, nbId, attr->name);
+        } else if (doc->extSubset != NULL) {
+            int extId = 0;
+            elem = xmlGetDtdElementDesc(doc->extSubset, attr->elem);
+            if (elem != NULL) {
+                extId = xmlScanIDAttributeDecl(NULL, elem, 0);
+            }
+            if (extId > 1) {
+                xmlErrValidNodeNr(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
        "Element %s has %d ID attribute defined in the external subset : %s\n",
-               attr->elem, extId, attr->name);
-        } else if (extId + nbId > 1) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
+                       attr->elem, extId, attr->name);
+            } else if (extId + nbId > 1) {
+                xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ID_SUBSET,
 "Element %s has ID attributes defined in the internal and external subset : %s\n",
-               attr->elem, attr->name, NULL);
+                       attr->elem, attr->name, NULL);
+            }
         }
-    }
     }
 
     /* Validity Constraint: Enumeration */
     if ((attr->defaultValue != NULL) && (attr->tree != NULL)) {
         xmlEnumerationPtr tree = attr->tree;
-    while (tree != NULL) {
-        if (xmlStrEqual(tree->name, attr->defaultValue)) break;
-        tree = tree->next;
-    }
-    if (tree == NULL) {
-        xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ATTRIBUTE_VALUE,
+        while (tree != NULL) {
+            if (xmlStrEqual(tree->name, attr->defaultValue)) break;
+            tree = tree->next;
+        }
+        if (tree == NULL) {
+            xmlErrValidNode(ctxt, (xmlNodePtr) attr, XML_DTD_ATTRIBUTE_VALUE,
 "Default value \"%s\" for attribute %s of %s is not among the enumerated set\n",
-           attr->defaultValue, attr->name, attr->elem);
-        ret = 0;
-    }
+                   attr->defaultValue, attr->name, attr->elem);
+            ret = 0;
+        }
     }
 
     return(ret);
@@ -4339,80 +4340,80 @@ xmlValidateElementDecl(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
 
     /* No Duplicate Types */
     if (elem->etype == XML_ELEMENT_TYPE_MIXED) {
-    xmlElementContentPtr cur, next;
+        xmlElementContentPtr cur, next;
         const xmlChar *name;
 
-    cur = elem->content;
-    while (cur != NULL) {
-        if (cur->type != XML_ELEMENT_CONTENT_OR) break;
-        if (cur->c1 == NULL) break;
-        if (cur->c1->type == XML_ELEMENT_CONTENT_ELEMENT) {
-        name = cur->c1->name;
-        next = cur->c2;
-        while (next != NULL) {
-            if (next->type == XML_ELEMENT_CONTENT_ELEMENT) {
-                if ((xmlStrEqual(next->name, name)) &&
-                (xmlStrEqual(next->prefix, cur->c1->prefix))) {
-                if (cur->c1->prefix == NULL) {
-                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
-           "Definition of %s has duplicate references of %s\n",
-                       elem->name, name, NULL);
-                } else {
-                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
-           "Definition of %s has duplicate references of %s:%s\n",
-                       elem->name, cur->c1->prefix, name);
+        cur = elem->content;
+        while (cur != NULL) {
+            if (cur->type != XML_ELEMENT_CONTENT_OR) break;
+            if (cur->c1 == NULL) break;
+            if (cur->c1->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                name = cur->c1->name;
+                next = cur->c2;
+                while (next != NULL) {
+                    if (next->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                        if ((xmlStrEqual(next->name, name)) &&
+                            (xmlStrEqual(next->prefix, cur->c1->prefix))) {
+                            if (cur->c1->prefix == NULL) {
+                                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
+                   "Definition of %s has duplicate references of %s\n",
+                                       elem->name, name, NULL);
+                            } else {
+                                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
+                   "Definition of %s has duplicate references of %s:%s\n",
+                                       elem->name, cur->c1->prefix, name);
+                            }
+                            ret = 0;
+                        }
+                        break;
+                    }
+                    if (next->c1 == NULL) break;
+                    if (next->c1->type != XML_ELEMENT_CONTENT_ELEMENT) break;
+                    if ((xmlStrEqual(next->c1->name, name)) &&
+                        (xmlStrEqual(next->c1->prefix, cur->c1->prefix))) {
+                        if (cur->c1->prefix == NULL) {
+                            xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
+               "Definition of %s has duplicate references to %s\n",
+                                   elem->name, name, NULL);
+                        } else {
+                            xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
+               "Definition of %s has duplicate references to %s:%s\n",
+                                   elem->name, cur->c1->prefix, name);
+                        }
+                        ret = 0;
+                    }
+                    next = next->c2;
                 }
-                ret = 0;
             }
-            break;
-            }
-            if (next->c1 == NULL) break;
-            if (next->c1->type != XML_ELEMENT_CONTENT_ELEMENT) break;
-            if ((xmlStrEqual(next->c1->name, name)) &&
-                (xmlStrEqual(next->c1->prefix, cur->c1->prefix))) {
-            if (cur->c1->prefix == NULL) {
-                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
-           "Definition of %s has duplicate references to %s\n",
-                   elem->name, name, NULL);
-            } else {
-                xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_CONTENT_ERROR,
-           "Definition of %s has duplicate references to %s:%s\n",
-                   elem->name, cur->c1->prefix, name);
-            }
-            ret = 0;
-            }
-            next = next->c2;
+            cur = cur->c2;
         }
-        }
-        cur = cur->c2;
-    }
     }
 
     /* VC: Unique Element Type Declaration */
     tst = xmlGetDtdElementDesc(doc->intSubset, elem->name);
     if ((tst != NULL ) && (tst != elem) &&
-    ((tst->prefix == elem->prefix) ||
-     (xmlStrEqual(tst->prefix, elem->prefix))) &&
-    (tst->etype != XML_ELEMENT_TYPE_UNDEFINED)) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_ELEM_REDEFINED,
-                    "Redefinition of element %s\n",
-               elem->name, NULL, NULL);
-    ret = 0;
+        ((tst->prefix == elem->prefix) ||
+         (xmlStrEqual(tst->prefix, elem->prefix))) &&
+        (tst->etype != XML_ELEMENT_TYPE_UNDEFINED)) {
+        xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_ELEM_REDEFINED,
+                        "Redefinition of element %s\n",
+                       elem->name, NULL, NULL);
+        ret = 0;
     }
     tst = xmlGetDtdElementDesc(doc->extSubset, elem->name);
     if ((tst != NULL ) && (tst != elem) &&
-    ((tst->prefix == elem->prefix) ||
-     (xmlStrEqual(tst->prefix, elem->prefix))) &&
-    (tst->etype != XML_ELEMENT_TYPE_UNDEFINED)) {
-    xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_ELEM_REDEFINED,
-                    "Redefinition of element %s\n",
-               elem->name, NULL, NULL);
-    ret = 0;
+        ((tst->prefix == elem->prefix) ||
+         (xmlStrEqual(tst->prefix, elem->prefix))) &&
+        (tst->etype != XML_ELEMENT_TYPE_UNDEFINED)) {
+        xmlErrValidNode(ctxt, (xmlNodePtr) elem, XML_DTD_ELEM_REDEFINED,
+                        "Redefinition of element %s\n",
+                       elem->name, NULL, NULL);
+        ret = 0;
     }
     /* One ID per Element Type
      * already done when registering the attribute
     if (xmlScanIDAttributeDecl(ctxt, elem) > 1) {
-    ret = 0;
+        ret = 0;
     } */
     return(ret);
 }
@@ -4455,81 +4456,81 @@ xmlValidateOneAttribute(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     if ((attr == NULL) || (attr->name == NULL)) return(0);
 
     if ((elem->ns != NULL) && (elem->ns->prefix != NULL)) {
-    xmlChar fn[50];
-    xmlChar *fullname;
+        xmlChar fn[50];
+        xmlChar *fullname;
 
-    fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
-    if (fullname == NULL)
-        return(0);
-    if (attr->ns != NULL) {
-        attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, fullname,
-                                  attr->name, attr->ns->prefix);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, fullname,
-                          attr->name, attr->ns->prefix);
-    } else {
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname, attr->name);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
-                         fullname, attr->name);
-    }
-    if ((fullname != fn) && (fullname != elem->name))
-        xmlFree(fullname);
+        fullname = xmlBuildQName(elem->name, elem->ns->prefix, fn, 50);
+        if (fullname == NULL)
+            return(0);
+        if (attr->ns != NULL) {
+            attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, fullname,
+                                          attr->name, attr->ns->prefix);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, fullname,
+                                              attr->name, attr->ns->prefix);
+        } else {
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname, attr->name);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
+                                             fullname, attr->name);
+        }
+        if ((fullname != fn) && (fullname != elem->name))
+            xmlFree(fullname);
     }
     if (attrDecl == NULL) {
-    if (attr->ns != NULL) {
-        attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, elem->name,
-                                  attr->name, attr->ns->prefix);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, elem->name,
-                          attr->name, attr->ns->prefix);
-    } else {
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset,
-                                 elem->name, attr->name);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
-                         elem->name, attr->name);
-    }
+        if (attr->ns != NULL) {
+            attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, elem->name,
+                                          attr->name, attr->ns->prefix);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, elem->name,
+                                              attr->name, attr->ns->prefix);
+        } else {
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset,
+                                         elem->name, attr->name);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
+                                             elem->name, attr->name);
+        }
     }
 
 
     /* Validity Constraint: Attribute Value Type */
     if (attrDecl == NULL) {
-    xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
-           "No declaration for attribute %s of element %s\n",
-           attr->name, elem->name, NULL);
-    return(0);
+        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
+               "No declaration for attribute %s of element %s\n",
+               attr->name, elem->name, NULL);
+        return(0);
     }
     attr->atype = attrDecl->atype;
 
     val = xmlValidateAttributeValueInternal(doc, attrDecl->atype, value);
     if (val == 0) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
-       "Syntax of value for attribute %s of %s is not valid\n",
-           attr->name, elem->name, NULL);
+            xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
+           "Syntax of value for attribute %s of %s is not valid\n",
+               attr->name, elem->name, NULL);
         ret = 0;
     }
 
     /* Validity constraint: Fixed Attribute Default */
     if (attrDecl->def == XML_ATTRIBUTE_FIXED) {
-    if (!xmlStrEqual(value, attrDecl->defaultValue)) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
-       "Value for attribute %s of %s is different from default \"%s\"\n",
-           attr->name, elem->name, attrDecl->defaultValue);
-        ret = 0;
-    }
+        if (!xmlStrEqual(value, attrDecl->defaultValue)) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
+           "Value for attribute %s of %s is different from default \"%s\"\n",
+                   attr->name, elem->name, attrDecl->defaultValue);
+            ret = 0;
+        }
     }
 
     /* Validity Constraint: ID uniqueness */
     if (attrDecl->atype == XML_ATTRIBUTE_ID) {
         if (xmlAddID(ctxt, doc, value, attr) == NULL)
-        ret = 0;
+            ret = 0;
     }
 
     if ((attrDecl->atype == XML_ATTRIBUTE_IDREF) ||
-    (attrDecl->atype == XML_ATTRIBUTE_IDREFS)) {
+        (attrDecl->atype == XML_ATTRIBUTE_IDREFS)) {
         if (xmlAddRef(ctxt, doc, value, attr) == NULL)
-        ret = 0;
+            ret = 0;
     }
 
     /* Validity Constraint: Notation Attributes */
@@ -4538,57 +4539,57 @@ xmlValidateOneAttribute(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
         xmlNotationPtr nota;
 
         /* First check that the given NOTATION was declared */
-    nota = xmlGetDtdNotationDesc(doc->intSubset, value);
-    if (nota == NULL)
-        nota = xmlGetDtdNotationDesc(doc->extSubset, value);
+        nota = xmlGetDtdNotationDesc(doc->intSubset, value);
+        if (nota == NULL)
+            nota = xmlGetDtdNotationDesc(doc->extSubset, value);
 
-    if (nota == NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
+        if (nota == NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
        "Value \"%s\" for attribute %s of %s is not a declared Notation\n",
-           value, attr->name, elem->name);
-        ret = 0;
+                   value, attr->name, elem->name);
+            ret = 0;
         }
 
-    /* Second, verify that it's among the list */
-    while (tree != NULL) {
-        if (xmlStrEqual(tree->name, value)) break;
-        tree = tree->next;
-    }
-    if (tree == NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
+        /* Second, verify that it's among the list */
+        while (tree != NULL) {
+            if (xmlStrEqual(tree->name, value)) break;
+            tree = tree->next;
+        }
+        if (tree == NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
 "Value \"%s\" for attribute %s of %s is not among the enumerated notations\n",
-           value, attr->name, elem->name);
-        ret = 0;
-    }
+                   value, attr->name, elem->name);
+            ret = 0;
+        }
     }
 
     /* Validity Constraint: Enumeration */
     if (attrDecl->atype == XML_ATTRIBUTE_ENUMERATION) {
         xmlEnumerationPtr tree = attrDecl->tree;
-    while (tree != NULL) {
-        if (xmlStrEqual(tree->name, value)) break;
-        tree = tree->next;
-    }
-    if (tree == NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
+        while (tree != NULL) {
+            if (xmlStrEqual(tree->name, value)) break;
+            tree = tree->next;
+        }
+        if (tree == NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
        "Value \"%s\" for attribute %s of %s is not among the enumerated set\n",
-           value, attr->name, elem->name);
-        ret = 0;
-    }
+                   value, attr->name, elem->name);
+            ret = 0;
+        }
     }
 
     /* Fixed Attribute Default */
     if ((attrDecl->def == XML_ATTRIBUTE_FIXED) &&
         (!xmlStrEqual(attrDecl->defaultValue, value))) {
-    xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
-       "Value for attribute %s of %s must be \"%s\"\n",
-           attr->name, elem->name, attrDecl->defaultValue);
+        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
+           "Value for attribute %s of %s must be \"%s\"\n",
+               attr->name, elem->name, attrDecl->defaultValue);
         ret = 0;
     }
 
     /* Extra check for the attribute value */
     ret &= xmlValidateAttributeValue2(ctxt, doc, attr->name,
-                      attrDecl->atype, value);
+                                      attrDecl->atype, value);
 
     return(ret);
 }
@@ -4632,89 +4633,89 @@ xmlNodePtr elem, const xmlChar *prefix, xmlNsPtr ns, const xmlChar *value) {
     if ((ns == NULL) || (ns->href == NULL)) return(0);
 
     if (prefix != NULL) {
-    xmlChar fn[50];
-    xmlChar *fullname;
+        xmlChar fn[50];
+        xmlChar *fullname;
 
-    fullname = xmlBuildQName(elem->name, prefix, fn, 50);
-    if (fullname == NULL) {
-        xmlVErrMemory(ctxt, "Validating namespace");
-        return(0);
-    }
-    if (ns->prefix != NULL) {
-        attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, fullname,
-                                  ns->prefix, BAD_CAST "xmlns");
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, fullname,
-                      ns->prefix, BAD_CAST "xmlns");
-    } else {
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname,
-                                 BAD_CAST "xmlns");
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullname,
-                             BAD_CAST "xmlns");
-    }
-    if ((fullname != fn) && (fullname != elem->name))
-        xmlFree(fullname);
+        fullname = xmlBuildQName(elem->name, prefix, fn, 50);
+        if (fullname == NULL) {
+            xmlVErrMemory(ctxt, "Validating namespace");
+            return(0);
+        }
+        if (ns->prefix != NULL) {
+            attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, fullname,
+                                          ns->prefix, BAD_CAST "xmlns");
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, fullname,
+                                          ns->prefix, BAD_CAST "xmlns");
+        } else {
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset, fullname,
+                                         BAD_CAST "xmlns");
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset, fullname,
+                                         BAD_CAST "xmlns");
+        }
+        if ((fullname != fn) && (fullname != elem->name))
+            xmlFree(fullname);
     }
     if (attrDecl == NULL) {
-    if (ns->prefix != NULL) {
-        attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, elem->name,
-                                  ns->prefix, BAD_CAST "xmlns");
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, elem->name,
-                          ns->prefix, BAD_CAST "xmlns");
-    } else {
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset,
-                                 elem->name, BAD_CAST "xmlns");
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
-                         elem->name, BAD_CAST "xmlns");
-    }
+        if (ns->prefix != NULL) {
+            attrDecl = xmlGetDtdQAttrDesc(doc->intSubset, elem->name,
+                                          ns->prefix, BAD_CAST "xmlns");
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdQAttrDesc(doc->extSubset, elem->name,
+                                              ns->prefix, BAD_CAST "xmlns");
+        } else {
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset,
+                                         elem->name, BAD_CAST "xmlns");
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset,
+                                             elem->name, BAD_CAST "xmlns");
+        }
     }
 
 
     /* Validity Constraint: Attribute Value Type */
     if (attrDecl == NULL) {
-    if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
-           "No declaration for attribute xmlns:%s of element %s\n",
-           ns->prefix, elem->name, NULL);
-    } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
-           "No declaration for attribute xmlns of element %s\n",
-           elem->name, NULL, NULL);
-    }
-    return(0);
+        if (ns->prefix != NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
+                   "No declaration for attribute xmlns:%s of element %s\n",
+                   ns->prefix, elem->name, NULL);
+        } else {
+            xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ATTRIBUTE,
+                   "No declaration for attribute xmlns of element %s\n",
+                   elem->name, NULL, NULL);
+        }
+        return(0);
     }
 
     val = xmlValidateAttributeValueInternal(doc, attrDecl->atype, value);
     if (val == 0) {
-    if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_DEFAULT,
-           "Syntax of value for attribute xmlns:%s of %s is not valid\n",
-           ns->prefix, elem->name, NULL);
-    } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_DEFAULT,
-           "Syntax of value for attribute xmlns of %s is not valid\n",
-           elem->name, NULL, NULL);
-    }
+        if (ns->prefix != NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_DEFAULT,
+               "Syntax of value for attribute xmlns:%s of %s is not valid\n",
+                   ns->prefix, elem->name, NULL);
+        } else {
+            xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_DEFAULT,
+               "Syntax of value for attribute xmlns of %s is not valid\n",
+                   elem->name, NULL, NULL);
+        }
         ret = 0;
     }
 
     /* Validity constraint: Fixed Attribute Default */
     if (attrDecl->def == XML_ATTRIBUTE_FIXED) {
-    if (!xmlStrEqual(value, attrDecl->defaultValue)) {
-        if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
+        if (!xmlStrEqual(value, attrDecl->defaultValue)) {
+            if (ns->prefix != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
        "Value for attribute xmlns:%s of %s is different from default \"%s\"\n",
-               ns->prefix, elem->name, attrDecl->defaultValue);
-        } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
+                       ns->prefix, elem->name, attrDecl->defaultValue);
+            } else {
+                xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_DEFAULT,
        "Value for attribute xmlns of %s is different from default \"%s\"\n",
-               elem->name, attrDecl->defaultValue, NULL);
+                       elem->name, attrDecl->defaultValue, NULL);
+            }
+            ret = 0;
         }
-        ret = 0;
-    }
     }
 
     /*
@@ -4726,13 +4727,13 @@ xmlNodePtr elem, const xmlChar *prefix, xmlNsPtr ns, const xmlChar *value) {
     /* Validity Constraint: ID uniqueness */
     if (attrDecl->atype == XML_ATTRIBUTE_ID) {
         if (xmlAddID(ctxt, doc, value, (xmlAttrPtr) ns) == NULL)
-        ret = 0;
+            ret = 0;
     }
 
     if ((attrDecl->atype == XML_ATTRIBUTE_IDREF) ||
-    (attrDecl->atype == XML_ATTRIBUTE_IDREFS)) {
+        (attrDecl->atype == XML_ATTRIBUTE_IDREFS)) {
         if (xmlAddRef(ctxt, doc, value, (xmlAttrPtr) ns) == NULL)
-        ret = 0;
+            ret = 0;
     }
 #endif
 
@@ -4742,85 +4743,85 @@ xmlNodePtr elem, const xmlChar *prefix, xmlNsPtr ns, const xmlChar *value) {
         xmlNotationPtr nota;
 
         /* First check that the given NOTATION was declared */
-    nota = xmlGetDtdNotationDesc(doc->intSubset, value);
-    if (nota == NULL)
-        nota = xmlGetDtdNotationDesc(doc->extSubset, value);
+        nota = xmlGetDtdNotationDesc(doc->intSubset, value);
+        if (nota == NULL)
+            nota = xmlGetDtdNotationDesc(doc->extSubset, value);
 
-    if (nota == NULL) {
-        if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
+        if (nota == NULL) {
+            if (ns->prefix != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
        "Value \"%s\" for attribute xmlns:%s of %s is not a declared Notation\n",
-               value, ns->prefix, elem->name);
-        } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
+                       value, ns->prefix, elem->name);
+            } else {
+                xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_NOTATION,
        "Value \"%s\" for attribute xmlns of %s is not a declared Notation\n",
-               value, elem->name, NULL);
-        }
-        ret = 0;
+                       value, elem->name, NULL);
+            }
+            ret = 0;
         }
 
-    /* Second, verify that it's among the list */
-    while (tree != NULL) {
-        if (xmlStrEqual(tree->name, value)) break;
-        tree = tree->next;
-    }
-    if (tree == NULL) {
-        if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
-"Value \"%s\" for attribute xmlns:%s of %s is not among the enumerated notations\n",
-               value, ns->prefix, elem->name);
-        } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
-"Value \"%s\" for attribute xmlns of %s is not among the enumerated notations\n",
-               value, elem->name, NULL);
+        /* Second, verify that it's among the list */
+        while (tree != NULL) {
+            if (xmlStrEqual(tree->name, value)) break;
+            tree = tree->next;
         }
-        ret = 0;
-    }
+        if (tree == NULL) {
+            if (ns->prefix != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
+"Value \"%s\" for attribute xmlns:%s of %s is not among the enumerated notations\n",
+                       value, ns->prefix, elem->name);
+            } else {
+                xmlErrValidNode(ctxt, elem, XML_DTD_NOTATION_VALUE,
+"Value \"%s\" for attribute xmlns of %s is not among the enumerated notations\n",
+                       value, elem->name, NULL);
+            }
+            ret = 0;
+        }
     }
 
     /* Validity Constraint: Enumeration */
     if (attrDecl->atype == XML_ATTRIBUTE_ENUMERATION) {
         xmlEnumerationPtr tree = attrDecl->tree;
-    while (tree != NULL) {
-        if (xmlStrEqual(tree->name, value)) break;
-        tree = tree->next;
-    }
-    if (tree == NULL) {
-        if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
-"Value \"%s\" for attribute xmlns:%s of %s is not among the enumerated set\n",
-               value, ns->prefix, elem->name);
-        } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
-"Value \"%s\" for attribute xmlns of %s is not among the enumerated set\n",
-               value, elem->name, NULL);
+        while (tree != NULL) {
+            if (xmlStrEqual(tree->name, value)) break;
+            tree = tree->next;
         }
-        ret = 0;
-    }
+        if (tree == NULL) {
+            if (ns->prefix != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
+"Value \"%s\" for attribute xmlns:%s of %s is not among the enumerated set\n",
+                       value, ns->prefix, elem->name);
+            } else {
+                xmlErrValidNode(ctxt, elem, XML_DTD_ATTRIBUTE_VALUE,
+"Value \"%s\" for attribute xmlns of %s is not among the enumerated set\n",
+                       value, elem->name, NULL);
+            }
+            ret = 0;
+        }
     }
 
     /* Fixed Attribute Default */
     if ((attrDecl->def == XML_ATTRIBUTE_FIXED) &&
         (!xmlStrEqual(attrDecl->defaultValue, value))) {
-    if (ns->prefix != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
-           "Value for attribute xmlns:%s of %s must be \"%s\"\n",
-           ns->prefix, elem->name, attrDecl->defaultValue);
-    } else {
-        xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
-           "Value for attribute xmlns of %s must be \"%s\"\n",
-           elem->name, attrDecl->defaultValue, NULL);
-    }
+        if (ns->prefix != NULL) {
+            xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
+                   "Value for attribute xmlns:%s of %s must be \"%s\"\n",
+                   ns->prefix, elem->name, attrDecl->defaultValue);
+        } else {
+            xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
+                   "Value for attribute xmlns of %s must be \"%s\"\n",
+                   elem->name, attrDecl->defaultValue, NULL);
+        }
         ret = 0;
     }
 
     /* Extra check for the attribute value */
     if (ns->prefix != NULL) {
-    ret &= xmlValidateAttributeValue2(ctxt, doc, ns->prefix,
-                      attrDecl->atype, value);
+        ret &= xmlValidateAttributeValue2(ctxt, doc, ns->prefix,
+                                          attrDecl->atype, value);
     } else {
-    ret &= xmlValidateAttributeValue2(ctxt, doc, BAD_CAST "xmlns",
-                      attrDecl->atype, value);
+        ret &= xmlValidateAttributeValue2(ctxt, doc, BAD_CAST "xmlns",
+                                          attrDecl->atype, value);
     }
 
     return(ret);
@@ -4840,24 +4841,24 @@ xmlNodePtr elem, const xmlChar *prefix, xmlNsPtr ns, const xmlChar *value) {
 static xmlNodePtr
 xmlValidateSkipIgnorable(xmlNodePtr child) {
     while (child != NULL) {
-    switch (child->type) {
-        /* These things are ignored (skipped) during validation.  */
-        case XML_PI_NODE:
-        case XML_COMMENT_NODE:
-        case XML_XINCLUDE_START:
-        case XML_XINCLUDE_END:
-        child = child->next;
-        break;
-        case XML_TEXT_NODE:
-        if (xmlIsBlankNode(child))
-            child = child->next;
-        else
-            return(child);
-        break;
-        /* keep current node */
-        default:
-        return(child);
-    }
+        switch (child->type) {
+            /* These things are ignored (skipped) during validation.  */
+            case XML_PI_NODE:
+            case XML_COMMENT_NODE:
+            case XML_XINCLUDE_START:
+            case XML_XINCLUDE_END:
+                child = child->next;
+                break;
+            case XML_TEXT_NODE:
+                if (xmlIsBlankNode(child))
+                    child = child->next;
+                else
+                    return(child);
+                break;
+            /* keep current node */
+            default:
+                return(child);
+        }
     }
     return(child);
 }
@@ -4880,15 +4881,15 @@ xmlValidateElementType(xmlValidCtxtPtr ctxt) {
 
     NODE = xmlValidateSkipIgnorable(NODE);
     if ((NODE == NULL) && (CONT == NULL))
-    return(1);
+        return(1);
     if ((NODE == NULL) &&
-    ((CONT->ocur == XML_ELEMENT_CONTENT_MULT) ||
-     (CONT->ocur == XML_ELEMENT_CONTENT_OPT))) {
-    return(1);
+        ((CONT->ocur == XML_ELEMENT_CONTENT_MULT) ||
+         (CONT->ocur == XML_ELEMENT_CONTENT_OPT))) {
+        return(1);
     }
     if (CONT == NULL) return(-1);
     if ((NODE != NULL) && (NODE->type == XML_ENTITY_REF_NODE))
-    return(-2);
+        return(-2);
 
     /*
      * We arrive here when more states need to be examined
@@ -4900,10 +4901,10 @@ cont:
      * epsilon transition, go directly to the analysis phase
      */
     if (STATE == ROLLBACK_PARENT) {
-    DEBUG_VALID_MSG("restored parent branch");
-    DEBUG_VALID_STATE(NODE, CONT)
-    ret = 1;
-    goto analyze;
+        DEBUG_VALID_MSG("restored parent branch");
+        DEBUG_VALID_STATE(NODE, CONT)
+        ret = 1;
+        goto analyze;
     }
 
     DEBUG_VALID_STATE(NODE, CONT)
@@ -4912,14 +4913,14 @@ cont:
      * of handling epsilon transition in NFAs.
      */
     if ((CONT != NULL) &&
-    ((CONT->parent == NULL) ||
-     (CONT->parent->type != XML_ELEMENT_CONTENT_OR)) &&
-    ((CONT->ocur == XML_ELEMENT_CONTENT_MULT) ||
-     (CONT->ocur == XML_ELEMENT_CONTENT_OPT) ||
-     ((CONT->ocur == XML_ELEMENT_CONTENT_PLUS) && (OCCURRENCE)))) {
-    DEBUG_VALID_MSG("saving parent branch");
-    if (vstateVPush(ctxt, CONT, NODE, DEPTH, OCCURS, ROLLBACK_PARENT) < 0)
-        return(0);
+        ((CONT->parent == NULL) ||
+         (CONT->parent->type != XML_ELEMENT_CONTENT_OR)) &&
+        ((CONT->ocur == XML_ELEMENT_CONTENT_MULT) ||
+         (CONT->ocur == XML_ELEMENT_CONTENT_OPT) ||
+         ((CONT->ocur == XML_ELEMENT_CONTENT_PLUS) && (OCCURRENCE)))) {
+        DEBUG_VALID_MSG("saving parent branch");
+        if (vstateVPush(ctxt, CONT, NODE, DEPTH, OCCURS, ROLLBACK_PARENT) < 0)
+            return(0);
     }
 
 
@@ -4927,306 +4928,306 @@ cont:
      * Check first if the content matches
      */
     switch (CONT->type) {
-    case XML_ELEMENT_CONTENT_PCDATA:
-        if (NODE == NULL) {
-        DEBUG_VALID_MSG("pcdata failed no node");
-        ret = 0;
-        break;
-        }
-        if (NODE->type == XML_TEXT_NODE) {
-        DEBUG_VALID_MSG("pcdata found, skip to next");
-        /*
-         * go to next element in the content model
-         * skipping ignorable elems
-         */
-        do {
-            NODE = NODE->next;
-            NODE = xmlValidateSkipIgnorable(NODE);
-            if ((NODE != NULL) &&
-            (NODE->type == XML_ENTITY_REF_NODE))
-            return(-2);
-        } while ((NODE != NULL) &&
-             ((NODE->type != XML_ELEMENT_NODE) &&
-              (NODE->type != XML_TEXT_NODE) &&
-              (NODE->type != XML_CDATA_SECTION_NODE)));
+        case XML_ELEMENT_CONTENT_PCDATA:
+            if (NODE == NULL) {
+                DEBUG_VALID_MSG("pcdata failed no node");
+                ret = 0;
+                break;
+            }
+            if (NODE->type == XML_TEXT_NODE) {
+                DEBUG_VALID_MSG("pcdata found, skip to next");
+                /*
+                 * go to next element in the content model
+                 * skipping ignorable elems
+                 */
+                do {
+                    NODE = NODE->next;
+                    NODE = xmlValidateSkipIgnorable(NODE);
+                    if ((NODE != NULL) &&
+                        (NODE->type == XML_ENTITY_REF_NODE))
+                        return(-2);
+                } while ((NODE != NULL) &&
+                         ((NODE->type != XML_ELEMENT_NODE) &&
+                          (NODE->type != XML_TEXT_NODE) &&
+                          (NODE->type != XML_CDATA_SECTION_NODE)));
                 ret = 1;
-        break;
-        } else {
-        DEBUG_VALID_MSG("pcdata failed");
-        ret = 0;
-        break;
-        }
-        break;
-    case XML_ELEMENT_CONTENT_ELEMENT:
-        if (NODE == NULL) {
-        DEBUG_VALID_MSG("element failed no node");
-        ret = 0;
-        break;
-        }
-        ret = ((NODE->type == XML_ELEMENT_NODE) &&
-           (xmlStrEqual(NODE->name, CONT->name)));
-        if (ret == 1) {
-        if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
-            ret = (CONT->prefix == NULL);
-        } else if (CONT->prefix == NULL) {
-            ret = 0;
-        } else {
-            ret = xmlStrEqual(NODE->ns->prefix, CONT->prefix);
-        }
-        }
-        if (ret == 1) {
-        DEBUG_VALID_MSG("element found, skip to next");
-        /*
-         * go to next element in the content model
-         * skipping ignorable elems
-         */
-        do {
-            NODE = NODE->next;
-            NODE = xmlValidateSkipIgnorable(NODE);
-            if ((NODE != NULL) &&
-            (NODE->type == XML_ENTITY_REF_NODE))
-            return(-2);
-        } while ((NODE != NULL) &&
-             ((NODE->type != XML_ELEMENT_NODE) &&
-              (NODE->type != XML_TEXT_NODE) &&
-              (NODE->type != XML_CDATA_SECTION_NODE)));
-        } else {
-        DEBUG_VALID_MSG("element failed");
-        ret = 0;
-        break;
-        }
-        break;
-    case XML_ELEMENT_CONTENT_OR:
-        /*
-         * Small optimization.
-         */
-        if (CONT->c1->type == XML_ELEMENT_CONTENT_ELEMENT) {
-        if ((NODE == NULL) ||
-            (!xmlStrEqual(NODE->name, CONT->c1->name))) {
-            DEPTH++;
-            CONT = CONT->c2;
-            goto cont;
-        }
-        if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
-            ret = (CONT->c1->prefix == NULL);
-        } else if (CONT->c1->prefix == NULL) {
-            ret = 0;
-        } else {
-            ret = xmlStrEqual(NODE->ns->prefix, CONT->c1->prefix);
-        }
-        if (ret == 0) {
-            DEPTH++;
-            CONT = CONT->c2;
-            goto cont;
-        }
-        }
+                break;
+            } else {
+                DEBUG_VALID_MSG("pcdata failed");
+                ret = 0;
+                break;
+            }
+            break;
+        case XML_ELEMENT_CONTENT_ELEMENT:
+            if (NODE == NULL) {
+                DEBUG_VALID_MSG("element failed no node");
+                ret = 0;
+                break;
+            }
+            ret = ((NODE->type == XML_ELEMENT_NODE) &&
+                   (xmlStrEqual(NODE->name, CONT->name)));
+            if (ret == 1) {
+                if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
+                    ret = (CONT->prefix == NULL);
+                } else if (CONT->prefix == NULL) {
+                    ret = 0;
+                } else {
+                    ret = xmlStrEqual(NODE->ns->prefix, CONT->prefix);
+                }
+            }
+            if (ret == 1) {
+                DEBUG_VALID_MSG("element found, skip to next");
+                /*
+                 * go to next element in the content model
+                 * skipping ignorable elems
+                 */
+                do {
+                    NODE = NODE->next;
+                    NODE = xmlValidateSkipIgnorable(NODE);
+                    if ((NODE != NULL) &&
+                        (NODE->type == XML_ENTITY_REF_NODE))
+                        return(-2);
+                } while ((NODE != NULL) &&
+                         ((NODE->type != XML_ELEMENT_NODE) &&
+                          (NODE->type != XML_TEXT_NODE) &&
+                          (NODE->type != XML_CDATA_SECTION_NODE)));
+            } else {
+                DEBUG_VALID_MSG("element failed");
+                ret = 0;
+                break;
+            }
+            break;
+        case XML_ELEMENT_CONTENT_OR:
+            /*
+             * Small optimization.
+             */
+            if (CONT->c1->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                if ((NODE == NULL) ||
+                    (!xmlStrEqual(NODE->name, CONT->c1->name))) {
+                    DEPTH++;
+                    CONT = CONT->c2;
+                    goto cont;
+                }
+                if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
+                    ret = (CONT->c1->prefix == NULL);
+                } else if (CONT->c1->prefix == NULL) {
+                    ret = 0;
+                } else {
+                    ret = xmlStrEqual(NODE->ns->prefix, CONT->c1->prefix);
+                }
+                if (ret == 0) {
+                    DEPTH++;
+                    CONT = CONT->c2;
+                    goto cont;
+                }
+            }
 
-        /*
-         * save the second branch 'or' branch
-         */
-        DEBUG_VALID_MSG("saving 'or' branch");
-        if (vstateVPush(ctxt, CONT->c2, NODE, (unsigned char)(DEPTH + 1),
-                OCCURS, ROLLBACK_OR) < 0)
-        return(-1);
-        DEPTH++;
-        CONT = CONT->c1;
-        goto cont;
-    case XML_ELEMENT_CONTENT_SEQ:
-        /*
-         * Small optimization.
-         */
-        if ((CONT->c1->type == XML_ELEMENT_CONTENT_ELEMENT) &&
-        ((CONT->c1->ocur == XML_ELEMENT_CONTENT_OPT) ||
-         (CONT->c1->ocur == XML_ELEMENT_CONTENT_MULT))) {
-        if ((NODE == NULL) ||
-            (!xmlStrEqual(NODE->name, CONT->c1->name))) {
+            /*
+             * save the second branch 'or' branch
+             */
+            DEBUG_VALID_MSG("saving 'or' branch");
+            if (vstateVPush(ctxt, CONT->c2, NODE, (unsigned char)(DEPTH + 1),
+                            OCCURS, ROLLBACK_OR) < 0)
+                return(-1);
             DEPTH++;
-            CONT = CONT->c2;
+            CONT = CONT->c1;
             goto cont;
-        }
-        if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
-            ret = (CONT->c1->prefix == NULL);
-        } else if (CONT->c1->prefix == NULL) {
-            ret = 0;
-        } else {
-            ret = xmlStrEqual(NODE->ns->prefix, CONT->c1->prefix);
-        }
-        if (ret == 0) {
+        case XML_ELEMENT_CONTENT_SEQ:
+            /*
+             * Small optimization.
+             */
+            if ((CONT->c1->type == XML_ELEMENT_CONTENT_ELEMENT) &&
+                ((CONT->c1->ocur == XML_ELEMENT_CONTENT_OPT) ||
+                 (CONT->c1->ocur == XML_ELEMENT_CONTENT_MULT))) {
+                if ((NODE == NULL) ||
+                    (!xmlStrEqual(NODE->name, CONT->c1->name))) {
+                    DEPTH++;
+                    CONT = CONT->c2;
+                    goto cont;
+                }
+                if ((NODE->ns == NULL) || (NODE->ns->prefix == NULL)) {
+                    ret = (CONT->c1->prefix == NULL);
+                } else if (CONT->c1->prefix == NULL) {
+                    ret = 0;
+                } else {
+                    ret = xmlStrEqual(NODE->ns->prefix, CONT->c1->prefix);
+                }
+                if (ret == 0) {
+                    DEPTH++;
+                    CONT = CONT->c2;
+                    goto cont;
+                }
+            }
             DEPTH++;
-            CONT = CONT->c2;
+            CONT = CONT->c1;
             goto cont;
-        }
-        }
-        DEPTH++;
-        CONT = CONT->c1;
-        goto cont;
     }
 
     /*
      * At this point handle going up in the tree
      */
     if (ret == -1) {
-    DEBUG_VALID_MSG("error found returning");
-    return(ret);
+        DEBUG_VALID_MSG("error found returning");
+        return(ret);
     }
 analyze:
     while (CONT != NULL) {
-    /*
-     * First do the analysis depending on the occurrence model at
-     * this level.
-     */
-    if (ret == 0) {
-        switch (CONT->ocur) {
-        xmlNodePtr cur;
-
-        case XML_ELEMENT_CONTENT_ONCE:
-            cur = ctxt->vstate->node;
-            DEBUG_VALID_MSG("Once branch failed, rollback");
-            if (vstateVPop(ctxt) < 0 ) {
-            DEBUG_VALID_MSG("exhaustion, failed");
-            return(0);
-            }
-            if (cur != ctxt->vstate->node)
-            determinist = -3;
-            goto cont;
-        case XML_ELEMENT_CONTENT_PLUS:
-            if (OCCURRENCE == 0) {
-            cur = ctxt->vstate->node;
-            DEBUG_VALID_MSG("Plus branch failed, rollback");
-            if (vstateVPop(ctxt) < 0 ) {
-                DEBUG_VALID_MSG("exhaustion, failed");
-                return(0);
-            }
-            if (cur != ctxt->vstate->node)
-                determinist = -3;
-            goto cont;
-            }
-            DEBUG_VALID_MSG("Plus branch found");
-            ret = 1;
-            break;
-        case XML_ELEMENT_CONTENT_MULT:
-#ifdef DEBUG_VALID_ALGO
-            if (OCCURRENCE == 0) {
-            DEBUG_VALID_MSG("Mult branch failed");
-            } else {
-            DEBUG_VALID_MSG("Mult branch found");
-            }
-#endif
-            ret = 1;
-            break;
-        case XML_ELEMENT_CONTENT_OPT:
-            DEBUG_VALID_MSG("Option branch failed");
-            ret = 1;
-            break;
-        }
-    } else {
-        switch (CONT->ocur) {
-        case XML_ELEMENT_CONTENT_OPT:
-            DEBUG_VALID_MSG("Option branch succeeded");
-            ret = 1;
-            break;
-        case XML_ELEMENT_CONTENT_ONCE:
-            DEBUG_VALID_MSG("Once branch succeeded");
-            ret = 1;
-            break;
-        case XML_ELEMENT_CONTENT_PLUS:
-            if (STATE == ROLLBACK_PARENT) {
-            DEBUG_VALID_MSG("Plus branch rollback");
-            ret = 1;
-            break;
-            }
-            if (NODE == NULL) {
-            DEBUG_VALID_MSG("Plus branch exhausted");
-            ret = 1;
-            break;
-            }
-            DEBUG_VALID_MSG("Plus branch succeeded, continuing");
-            SET_OCCURRENCE;
-            goto cont;
-        case XML_ELEMENT_CONTENT_MULT:
-            if (STATE == ROLLBACK_PARENT) {
-            DEBUG_VALID_MSG("Mult branch rollback");
-            ret = 1;
-            break;
-            }
-            if (NODE == NULL) {
-            DEBUG_VALID_MSG("Mult branch exhausted");
-            ret = 1;
-            break;
-            }
-            DEBUG_VALID_MSG("Mult branch succeeded, continuing");
-            /* SET_OCCURRENCE; */
-            goto cont;
-        }
-    }
-    STATE = 0;
-
-    /*
-     * Then act accordingly at the parent level
-     */
-    RESET_OCCURRENCE;
-    if (CONT->parent == NULL)
-        break;
-
-    switch (CONT->parent->type) {
-        case XML_ELEMENT_CONTENT_PCDATA:
-        DEBUG_VALID_MSG("Error: parent pcdata");
-        return(-1);
-        case XML_ELEMENT_CONTENT_ELEMENT:
-        DEBUG_VALID_MSG("Error: parent element");
-        return(-1);
-        case XML_ELEMENT_CONTENT_OR:
-        if (ret == 1) {
-            DEBUG_VALID_MSG("Or succeeded");
-            CONT = CONT->parent;
-            DEPTH--;
-        } else {
-            DEBUG_VALID_MSG("Or failed");
-            CONT = CONT->parent;
-            DEPTH--;
-        }
-        break;
-        case XML_ELEMENT_CONTENT_SEQ:
+        /*
+         * First do the analysis depending on the occurrence model at
+         * this level.
+         */
         if (ret == 0) {
-            DEBUG_VALID_MSG("Sequence failed");
-            CONT = CONT->parent;
-            DEPTH--;
-        } else if (CONT == CONT->parent->c1) {
-            DEBUG_VALID_MSG("Sequence testing 2nd branch");
-            CONT = CONT->parent->c2;
-            goto cont;
+            switch (CONT->ocur) {
+                xmlNodePtr cur;
+
+                case XML_ELEMENT_CONTENT_ONCE:
+                    cur = ctxt->vstate->node;
+                    DEBUG_VALID_MSG("Once branch failed, rollback");
+                    if (vstateVPop(ctxt) < 0 ) {
+                        DEBUG_VALID_MSG("exhaustion, failed");
+                        return(0);
+                    }
+                    if (cur != ctxt->vstate->node)
+                        determinist = -3;
+                    goto cont;
+                case XML_ELEMENT_CONTENT_PLUS:
+                    if (OCCURRENCE == 0) {
+                        cur = ctxt->vstate->node;
+                        DEBUG_VALID_MSG("Plus branch failed, rollback");
+                        if (vstateVPop(ctxt) < 0 ) {
+                            DEBUG_VALID_MSG("exhaustion, failed");
+                            return(0);
+                        }
+                        if (cur != ctxt->vstate->node)
+                            determinist = -3;
+                        goto cont;
+                    }
+                    DEBUG_VALID_MSG("Plus branch found");
+                    ret = 1;
+                    break;
+                case XML_ELEMENT_CONTENT_MULT:
+#ifdef DEBUG_VALID_ALGO
+                    if (OCCURRENCE == 0) {
+                        DEBUG_VALID_MSG("Mult branch failed");
+                    } else {
+                        DEBUG_VALID_MSG("Mult branch found");
+                    }
+#endif
+                    ret = 1;
+                    break;
+                case XML_ELEMENT_CONTENT_OPT:
+                    DEBUG_VALID_MSG("Option branch failed");
+                    ret = 1;
+                    break;
+            }
         } else {
-            DEBUG_VALID_MSG("Sequence succeeded");
-            CONT = CONT->parent;
-            DEPTH--;
+            switch (CONT->ocur) {
+                case XML_ELEMENT_CONTENT_OPT:
+                    DEBUG_VALID_MSG("Option branch succeeded");
+                    ret = 1;
+                    break;
+                case XML_ELEMENT_CONTENT_ONCE:
+                    DEBUG_VALID_MSG("Once branch succeeded");
+                    ret = 1;
+                    break;
+                case XML_ELEMENT_CONTENT_PLUS:
+                    if (STATE == ROLLBACK_PARENT) {
+                        DEBUG_VALID_MSG("Plus branch rollback");
+                        ret = 1;
+                        break;
+                    }
+                    if (NODE == NULL) {
+                        DEBUG_VALID_MSG("Plus branch exhausted");
+                        ret = 1;
+                        break;
+                    }
+                    DEBUG_VALID_MSG("Plus branch succeeded, continuing");
+                    SET_OCCURRENCE;
+                    goto cont;
+                case XML_ELEMENT_CONTENT_MULT:
+                    if (STATE == ROLLBACK_PARENT) {
+                        DEBUG_VALID_MSG("Mult branch rollback");
+                        ret = 1;
+                        break;
+                    }
+                    if (NODE == NULL) {
+                        DEBUG_VALID_MSG("Mult branch exhausted");
+                        ret = 1;
+                        break;
+                    }
+                    DEBUG_VALID_MSG("Mult branch succeeded, continuing");
+                    /* SET_OCCURRENCE; */
+                    goto cont;
+            }
         }
-    }
+        STATE = 0;
+
+        /*
+         * Then act accordingly at the parent level
+         */
+        RESET_OCCURRENCE;
+        if (CONT->parent == NULL)
+            break;
+
+        switch (CONT->parent->type) {
+            case XML_ELEMENT_CONTENT_PCDATA:
+                DEBUG_VALID_MSG("Error: parent pcdata");
+                return(-1);
+            case XML_ELEMENT_CONTENT_ELEMENT:
+                DEBUG_VALID_MSG("Error: parent element");
+                return(-1);
+            case XML_ELEMENT_CONTENT_OR:
+                if (ret == 1) {
+                    DEBUG_VALID_MSG("Or succeeded");
+                    CONT = CONT->parent;
+                    DEPTH--;
+                } else {
+                    DEBUG_VALID_MSG("Or failed");
+                    CONT = CONT->parent;
+                    DEPTH--;
+                }
+                break;
+            case XML_ELEMENT_CONTENT_SEQ:
+                if (ret == 0) {
+                    DEBUG_VALID_MSG("Sequence failed");
+                    CONT = CONT->parent;
+                    DEPTH--;
+                } else if (CONT == CONT->parent->c1) {
+                    DEBUG_VALID_MSG("Sequence testing 2nd branch");
+                    CONT = CONT->parent->c2;
+                    goto cont;
+                } else {
+                    DEBUG_VALID_MSG("Sequence succeeded");
+                    CONT = CONT->parent;
+                    DEPTH--;
+                }
+        }
     }
     if (NODE != NULL) {
-    xmlNodePtr cur;
+        xmlNodePtr cur;
 
-    cur = ctxt->vstate->node;
-    DEBUG_VALID_MSG("Failed, remaining input, rollback");
-    if (vstateVPop(ctxt) < 0 ) {
-        DEBUG_VALID_MSG("exhaustion, failed");
-        return(0);
-    }
-    if (cur != ctxt->vstate->node)
-        determinist = -3;
-    goto cont;
+        cur = ctxt->vstate->node;
+        DEBUG_VALID_MSG("Failed, remaining input, rollback");
+        if (vstateVPop(ctxt) < 0 ) {
+            DEBUG_VALID_MSG("exhaustion, failed");
+            return(0);
+        }
+        if (cur != ctxt->vstate->node)
+            determinist = -3;
+        goto cont;
     }
     if (ret == 0) {
-    xmlNodePtr cur;
+        xmlNodePtr cur;
 
-    cur = ctxt->vstate->node;
-    DEBUG_VALID_MSG("Failure, rollback");
-    if (vstateVPop(ctxt) < 0 ) {
-        DEBUG_VALID_MSG("exhaustion, failed");
-        return(0);
-    }
-    if (cur != ctxt->vstate->node)
-        determinist = -3;
-    goto cont;
+        cur = ctxt->vstate->node;
+        DEBUG_VALID_MSG("Failure, rollback");
+        if (vstateVPop(ctxt) < 0 ) {
+            DEBUG_VALID_MSG("exhaustion, failed");
+            return(0);
+        }
+        if (cur != ctxt->vstate->node)
+            determinist = -3;
+        goto cont;
     }
     return(determinist);
 }
@@ -5251,68 +5252,68 @@ xmlSnprintfElements(char *buf, int size, xmlNodePtr node, int glob) {
     if (glob) strcat(buf, "(");
     cur = node;
     while (cur != NULL) {
-    len = strlen(buf);
-    if (size - len < 50) {
-        if ((size - len > 4) && (buf[len - 1] != '.'))
-        strcat(buf, " ...");
-        return;
-    }
-        switch (cur->type) {
-            case XML_ELEMENT_NODE:
-        if ((cur->ns != NULL) && (cur->ns->prefix != NULL)) {
-            if (size - len < xmlStrlen(cur->ns->prefix) + 10) {
+        len = strlen(buf);
+        if (size - len < 50) {
             if ((size - len > 4) && (buf[len - 1] != '.'))
                 strcat(buf, " ...");
             return;
-            }
-            strcat(buf, (char *) cur->ns->prefix);
-            strcat(buf, ":");
         }
+        switch (cur->type) {
+            case XML_ELEMENT_NODE:
+                if ((cur->ns != NULL) && (cur->ns->prefix != NULL)) {
+                    if (size - len < xmlStrlen(cur->ns->prefix) + 10) {
+                        if ((size - len > 4) && (buf[len - 1] != '.'))
+                            strcat(buf, " ...");
+                        return;
+                    }
+                    strcat(buf, (char *) cur->ns->prefix);
+                    strcat(buf, ":");
+                }
                 if (size - len < xmlStrlen(cur->name) + 10) {
-            if ((size - len > 4) && (buf[len - 1] != '.'))
-            strcat(buf, " ...");
-            return;
-        }
-            strcat(buf, (char *) cur->name);
-        if (cur->next != NULL)
-            strcat(buf, " ");
-        break;
+                    if ((size - len > 4) && (buf[len - 1] != '.'))
+                        strcat(buf, " ...");
+                    return;
+                }
+                strcat(buf, (char *) cur->name);
+                if (cur->next != NULL)
+                    strcat(buf, " ");
+                break;
             case XML_TEXT_NODE:
-        if (xmlIsBlankNode(cur))
-            break;
+                if (xmlIsBlankNode(cur))
+                    break;
                 /* Falls through. */
             case XML_CDATA_SECTION_NODE:
             case XML_ENTITY_REF_NODE:
-            strcat(buf, "CDATA");
-        if (cur->next != NULL)
-            strcat(buf, " ");
-        break;
+                strcat(buf, "CDATA");
+                if (cur->next != NULL)
+                    strcat(buf, " ");
+                break;
             case XML_ATTRIBUTE_NODE:
             case XML_DOCUMENT_NODE:
 #ifdef LIBXML_DOCB_ENABLED
-        case XML_DOCB_DOCUMENT_NODE:
+            case XML_DOCB_DOCUMENT_NODE:
 #endif
-        case XML_HTML_DOCUMENT_NODE:
+            case XML_HTML_DOCUMENT_NODE:
             case XML_DOCUMENT_TYPE_NODE:
             case XML_DOCUMENT_FRAG_NODE:
             case XML_NOTATION_NODE:
-        case XML_NAMESPACE_DECL:
-            strcat(buf, "???");
-        if (cur->next != NULL)
-            strcat(buf, " ");
-        break;
+            case XML_NAMESPACE_DECL:
+                strcat(buf, "???");
+                if (cur->next != NULL)
+                    strcat(buf, " ");
+                break;
             case XML_ENTITY_NODE:
             case XML_PI_NODE:
             case XML_DTD_NODE:
             case XML_COMMENT_NODE:
-        case XML_ELEMENT_DECL:
-        case XML_ATTRIBUTE_DECL:
-        case XML_ENTITY_DECL:
-        case XML_XINCLUDE_START:
-        case XML_XINCLUDE_END:
-        break;
-    }
-    cur = cur->next;
+            case XML_ELEMENT_DECL:
+            case XML_ATTRIBUTE_DECL:
+            case XML_ENTITY_DECL:
+            case XML_XINCLUDE_START:
+            case XML_XINCLUDE_END:
+                break;
+        }
+        cur = cur->next;
     }
     if (glob) strcat(buf, ")");
 }
@@ -5342,87 +5343,87 @@ xmlValidateElementContent(xmlValidCtxtPtr ctxt, xmlNodePtr child,
     const xmlChar *name;
 
     if ((elemDecl == NULL) || (parent == NULL) || (ctxt == NULL))
-    return(-1);
+        return(-1);
     cont = elemDecl->content;
     name = elemDecl->name;
 
 #ifdef LIBXML_REGEXP_ENABLED
     /* Build the regexp associated to the content model */
     if (elemDecl->contModel == NULL)
-    ret = xmlValidBuildContentModel(ctxt, elemDecl);
+        ret = xmlValidBuildContentModel(ctxt, elemDecl);
     if (elemDecl->contModel == NULL) {
-    return(-1);
-    } else {
-    xmlRegExecCtxtPtr exec;
-
-    if (!xmlRegexpIsDeterminist(elemDecl->contModel)) {
         return(-1);
-    }
-    ctxt->nodeMax = 0;
-    ctxt->nodeNr = 0;
-    ctxt->nodeTab = NULL;
-    exec = xmlRegNewExecCtxt(elemDecl->contModel, NULL, NULL);
-    if (exec != NULL) {
-        cur = child;
-        while (cur != NULL) {
-        switch (cur->type) {
-            case XML_ENTITY_REF_NODE:
-            /*
-             * Push the current node to be able to roll back
-             * and process within the entity
-             */
-            if ((cur->children != NULL) &&
-                (cur->children->children != NULL)) {
-                nodeVPush(ctxt, cur);
-                cur = cur->children->children;
-                continue;
-            }
-            break;
-            case XML_TEXT_NODE:
-            if (xmlIsBlankNode(cur))
-                break;
-            ret = 0;
-            goto fail;
-            case XML_CDATA_SECTION_NODE:
-            /* TODO */
-            ret = 0;
-            goto fail;
-            case XML_ELEMENT_NODE:
-            if ((cur->ns != NULL) && (cur->ns->prefix != NULL)) {
-                xmlChar fn[50];
-                xmlChar *fullname;
+    } else {
+        xmlRegExecCtxtPtr exec;
 
-                fullname = xmlBuildQName(cur->name,
-                                     cur->ns->prefix, fn, 50);
-                if (fullname == NULL) {
-                ret = -1;
-                goto fail;
-                }
+        if (!xmlRegexpIsDeterminist(elemDecl->contModel)) {
+            return(-1);
+        }
+        ctxt->nodeMax = 0;
+        ctxt->nodeNr = 0;
+        ctxt->nodeTab = NULL;
+        exec = xmlRegNewExecCtxt(elemDecl->contModel, NULL, NULL);
+        if (exec != NULL) {
+            cur = child;
+            while (cur != NULL) {
+                switch (cur->type) {
+                    case XML_ENTITY_REF_NODE:
+                        /*
+                         * Push the current node to be able to roll back
+                         * and process within the entity
+                         */
+                        if ((cur->children != NULL) &&
+                            (cur->children->children != NULL)) {
+                            nodeVPush(ctxt, cur);
+                            cur = cur->children->children;
+                            continue;
+                        }
+                        break;
+                    case XML_TEXT_NODE:
+                        if (xmlIsBlankNode(cur))
+                            break;
+                        ret = 0;
+                        goto fail;
+                    case XML_CDATA_SECTION_NODE:
+                        /* TODO */
+                        ret = 0;
+                        goto fail;
+                    case XML_ELEMENT_NODE:
+                        if ((cur->ns != NULL) && (cur->ns->prefix != NULL)) {
+                            xmlChar fn[50];
+                            xmlChar *fullname;
+
+                            fullname = xmlBuildQName(cur->name,
+                                                     cur->ns->prefix, fn, 50);
+                            if (fullname == NULL) {
+                                ret = -1;
+                                goto fail;
+                            }
                             ret = xmlRegExecPushString(exec, fullname, NULL);
-                if ((fullname != fn) && (fullname != cur->name))
-                xmlFree(fullname);
-            } else {
-                ret = xmlRegExecPushString(exec, cur->name, NULL);
+                            if ((fullname != fn) && (fullname != cur->name))
+                                xmlFree(fullname);
+                        } else {
+                            ret = xmlRegExecPushString(exec, cur->name, NULL);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                /*
+                 * Switch to next element
+                 */
+                cur = cur->next;
+                while (cur == NULL) {
+                    cur = nodeVPop(ctxt);
+                    if (cur == NULL)
+                        break;
+                    cur = cur->next;
+                }
             }
-            break;
-            default:
-            break;
-        }
-        /*
-         * Switch to next element
-         */
-        cur = cur->next;
-        while (cur == NULL) {
-            cur = nodeVPop(ctxt);
-            if (cur == NULL)
-            break;
-            cur = cur->next;
-        }
-        }
-        ret = xmlRegExecPushString(exec, NULL, NULL);
+            ret = xmlRegExecPushString(exec, NULL, NULL);
 fail:
-        xmlRegFreeExecCtxt(exec);
-    }
+            xmlRegFreeExecCtxt(exec);
+        }
     }
 #else  /* LIBXML_REGEXP_ENABLED */
     /*
@@ -5430,10 +5431,10 @@ fail:
      */
     ctxt->vstateMax = 8;
     ctxt->vstateTab = (xmlValidState *) xmlMalloc(
-         ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
+                 ctxt->vstateMax * sizeof(ctxt->vstateTab[0]));
     if (ctxt->vstateTab == NULL) {
-    xmlVErrMemory(ctxt, "malloc failed");
-    return(-1);
+        xmlVErrMemory(ctxt, "malloc failed");
+        return(-1);
     }
     /*
      * The first entry in the stack is reserved to the current state
@@ -5450,135 +5451,135 @@ fail:
     STATE = 0;
     ret = xmlValidateElementType(ctxt);
     if ((ret == -3) && (warn)) {
-    xmlErrValidWarning(ctxt, child, XML_DTD_CONTENT_NOT_DETERMINIST,
-           "Content model for Element %s is ambiguous\n",
-                       name, NULL, NULL);
+        xmlErrValidWarning(ctxt, child, XML_DTD_CONTENT_NOT_DETERMINIST,
+               "Content model for Element %s is ambiguous\n",
+                           name, NULL, NULL);
     } else if (ret == -2) {
-    /*
-     * An entities reference appeared at this level.
-     * Build a minimal representation of this node content
-     * sufficient to run the validation process on it
-     */
-    DEBUG_VALID_MSG("Found an entity reference, linearizing");
-    cur = child;
-    while (cur != NULL) {
-        switch (cur->type) {
-        case XML_ENTITY_REF_NODE:
-            /*
-             * Push the current node to be able to roll back
-             * and process within the entity
-             */
-            if ((cur->children != NULL) &&
-            (cur->children->children != NULL)) {
-            nodeVPush(ctxt, cur);
-            cur = cur->children->children;
-            continue;
-            }
-            break;
-        case XML_TEXT_NODE:
-            if (xmlIsBlankNode(cur))
-            break;
-            /* no break on purpose */
-        case XML_CDATA_SECTION_NODE:
-            /* no break on purpose */
-        case XML_ELEMENT_NODE:
-            /*
-             * Allocate a new node and minimally fills in
-             * what's required
-             */
-            tmp = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
-            if (tmp == NULL) {
-            xmlVErrMemory(ctxt, "malloc failed");
-            xmlFreeNodeList(repl);
-            ret = -1;
-            goto done;
-            }
-            tmp->type = cur->type;
-            tmp->name = cur->name;
-            tmp->ns = cur->ns;
-            tmp->next = NULL;
-            tmp->content = NULL;
-            if (repl == NULL)
-            repl = last = tmp;
-            else {
-            last->next = tmp;
-            last = tmp;
-            }
-            if (cur->type == XML_CDATA_SECTION_NODE) {
-            /*
-             * E59 spaces in CDATA does not match the
-             * nonterminal S
-             */
-            tmp->content = xmlStrdup(BAD_CAST "CDATA");
-            }
-            break;
-        default:
-            break;
-        }
         /*
-         * Switch to next element
+         * An entities reference appeared at this level.
+         * Build a minimal representation of this node content
+         * sufficient to run the validation process on it
          */
-        cur = cur->next;
-        while (cur == NULL) {
-        cur = nodeVPop(ctxt);
-        if (cur == NULL)
-            break;
-        cur = cur->next;
+        DEBUG_VALID_MSG("Found an entity reference, linearizing");
+        cur = child;
+        while (cur != NULL) {
+            switch (cur->type) {
+                case XML_ENTITY_REF_NODE:
+                    /*
+                     * Push the current node to be able to roll back
+                     * and process within the entity
+                     */
+                    if ((cur->children != NULL) &&
+                        (cur->children->children != NULL)) {
+                        nodeVPush(ctxt, cur);
+                        cur = cur->children->children;
+                        continue;
+                    }
+                    break;
+                case XML_TEXT_NODE:
+                    if (xmlIsBlankNode(cur))
+                        break;
+                    /* no break on purpose */
+                case XML_CDATA_SECTION_NODE:
+                    /* no break on purpose */
+                case XML_ELEMENT_NODE:
+                    /*
+                     * Allocate a new node and minimally fills in
+                     * what's required
+                     */
+                    tmp = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
+                    if (tmp == NULL) {
+                        xmlVErrMemory(ctxt, "malloc failed");
+                        xmlFreeNodeList(repl);
+                        ret = -1;
+                        goto done;
+                    }
+                    tmp->type = cur->type;
+                    tmp->name = cur->name;
+                    tmp->ns = cur->ns;
+                    tmp->next = NULL;
+                    tmp->content = NULL;
+                    if (repl == NULL)
+                        repl = last = tmp;
+                    else {
+                        last->next = tmp;
+                        last = tmp;
+                    }
+                    if (cur->type == XML_CDATA_SECTION_NODE) {
+                        /*
+                         * E59 spaces in CDATA does not match the
+                         * nonterminal S
+                         */
+                        tmp->content = xmlStrdup(BAD_CAST "CDATA");
+                    }
+                    break;
+                default:
+                    break;
+            }
+            /*
+             * Switch to next element
+             */
+            cur = cur->next;
+            while (cur == NULL) {
+                cur = nodeVPop(ctxt);
+                if (cur == NULL)
+                    break;
+                cur = cur->next;
+            }
         }
-    }
 
-    /*
-     * Relaunch the validation
-     */
-    ctxt->vstate = &ctxt->vstateTab[0];
-    ctxt->vstateNr = 1;
-    CONT = cont;
-    NODE = repl;
-    DEPTH = 0;
-    OCCURS = 0;
-    STATE = 0;
-    ret = xmlValidateElementType(ctxt);
+        /*
+         * Relaunch the validation
+         */
+        ctxt->vstate = &ctxt->vstateTab[0];
+        ctxt->vstateNr = 1;
+        CONT = cont;
+        NODE = repl;
+        DEPTH = 0;
+        OCCURS = 0;
+        STATE = 0;
+        ret = xmlValidateElementType(ctxt);
     }
 #endif /* LIBXML_REGEXP_ENABLED */
     if ((warn) && ((ret != 1) && (ret != -3))) {
-    if (ctxt != NULL) {
-        char expr[5000];
-        char list[5000];
+        if (ctxt != NULL) {
+            char expr[5000];
+            char list[5000];
 
-        expr[0] = 0;
-        xmlSnprintfElementContent(&expr[0], 5000, cont, 1);
-        list[0] = 0;
+            expr[0] = 0;
+            xmlSnprintfElementContent(&expr[0], 5000, cont, 1);
+            list[0] = 0;
 #ifndef LIBXML_REGEXP_ENABLED
-        if (repl != NULL)
-        xmlSnprintfElements(&list[0], 5000, repl, 1);
-        else
+            if (repl != NULL)
+                xmlSnprintfElements(&list[0], 5000, repl, 1);
+            else
 #endif /* LIBXML_REGEXP_ENABLED */
-        xmlSnprintfElements(&list[0], 5000, child, 1);
+                xmlSnprintfElements(&list[0], 5000, child, 1);
 
-        if (name != NULL) {
-        xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
-       "Element %s content does not follow the DTD, expecting %s, got %s\n",
-               name, BAD_CAST expr, BAD_CAST list);
+            if (name != NULL) {
+                xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
+           "Element %s content does not follow the DTD, expecting %s, got %s\n",
+                       name, BAD_CAST expr, BAD_CAST list);
+            } else {
+                xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
+           "Element content does not follow the DTD, expecting %s, got %s\n",
+                       BAD_CAST expr, BAD_CAST list, NULL);
+            }
         } else {
-        xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
-       "Element content does not follow the DTD, expecting %s, got %s\n",
-               BAD_CAST expr, BAD_CAST list, NULL);
+            if (name != NULL) {
+                xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
+                       "Element %s content does not follow the DTD\n",
+                       name, NULL, NULL);
+            } else {
+                xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
+                       "Element content does not follow the DTD\n",
+                                NULL, NULL, NULL);
+            }
         }
-    } else {
-        if (name != NULL) {
-        xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
-               "Element %s content does not follow the DTD\n",
-               name, NULL, NULL);
-        } else {
-        xmlErrValidNode(ctxt, parent, XML_DTD_CONTENT_MODEL,
-               "Element content does not follow the DTD\n",
-                        NULL, NULL, NULL);
-        }
-    }
-    ret = 0;
+        ret = 0;
     }
     if (ret == -3)
-    ret = 1;
+        ret = 1;
 
 #ifndef  LIBXML_REGEXP_ENABLED
 done:
@@ -5586,21 +5587,21 @@ done:
      * Deallocate the copy if done, and free up the validation stack
      */
     while (repl != NULL) {
-    tmp = repl->next;
-    xmlFree(repl);
-    repl = tmp;
+        tmp = repl->next;
+        xmlFree(repl);
+        repl = tmp;
     }
     ctxt->vstateMax = 0;
     if (ctxt->vstateTab != NULL) {
-    xmlFree(ctxt->vstateTab);
-    ctxt->vstateTab = NULL;
+        xmlFree(ctxt->vstateTab);
+        ctxt->vstateTab = NULL;
     }
 #endif
     ctxt->nodeMax = 0;
     ctxt->nodeNr = 0;
     if (ctxt->nodeTab != NULL) {
-    xmlFree(ctxt->nodeTab);
-    ctxt->nodeTab = NULL;
+        xmlFree(ctxt->nodeTab);
+        ctxt->nodeTab = NULL;
     }
     return(ret);
 
@@ -5624,51 +5625,51 @@ xmlValidateOneCdataElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
 
     if ((ctxt == NULL) || (doc == NULL) || (elem == NULL) ||
         (elem->type != XML_ELEMENT_NODE))
-    return(0);
+        return(0);
 
     child = elem->children;
 
     cur = child;
     while (cur != NULL) {
-    switch (cur->type) {
-        case XML_ENTITY_REF_NODE:
-        /*
-         * Push the current node to be able to roll back
-         * and process within the entity
-         */
-        if ((cur->children != NULL) &&
-            (cur->children->children != NULL)) {
-            nodeVPush(ctxt, cur);
-            cur = cur->children->children;
-            continue;
+        switch (cur->type) {
+            case XML_ENTITY_REF_NODE:
+                /*
+                 * Push the current node to be able to roll back
+                 * and process within the entity
+                 */
+                if ((cur->children != NULL) &&
+                    (cur->children->children != NULL)) {
+                    nodeVPush(ctxt, cur);
+                    cur = cur->children->children;
+                    continue;
+                }
+                break;
+            case XML_COMMENT_NODE:
+            case XML_PI_NODE:
+            case XML_TEXT_NODE:
+            case XML_CDATA_SECTION_NODE:
+                break;
+            default:
+                ret = 0;
+                goto done;
         }
-        break;
-        case XML_COMMENT_NODE:
-        case XML_PI_NODE:
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        break;
-        default:
-        ret = 0;
-        goto done;
-    }
-    /*
-     * Switch to next element
-     */
-    cur = cur->next;
-    while (cur == NULL) {
-        cur = nodeVPop(ctxt);
-        if (cur == NULL)
-        break;
+        /*
+         * Switch to next element
+         */
         cur = cur->next;
-    }
+        while (cur == NULL) {
+            cur = nodeVPop(ctxt);
+            if (cur == NULL)
+                break;
+            cur = cur->next;
+        }
     }
 done:
     ctxt->nodeMax = 0;
     ctxt->nodeNr = 0;
     if (ctxt->nodeTab != NULL) {
-    xmlFree(ctxt->nodeTab);
-    ctxt->nodeTab = NULL;
+        xmlFree(ctxt->nodeTab);
+        ctxt->nodeTab = NULL;
     }
     return(ret);
 }
@@ -5685,56 +5686,56 @@ done:
  */
 static int
 xmlValidateCheckMixed(xmlValidCtxtPtr ctxt,
-                  xmlElementContentPtr cont, const xmlChar *qname) {
+                      xmlElementContentPtr cont, const xmlChar *qname) {
     const xmlChar *name;
     int plen;
     name = xmlSplitQName3(qname, &plen);
 
     if (name == NULL) {
-    while (cont != NULL) {
-        if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
-        if ((cont->prefix == NULL) && (xmlStrEqual(cont->name, qname)))
-            return(1);
-        } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
-           (cont->c1 != NULL) &&
-           (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
-        if ((cont->c1->prefix == NULL) &&
-            (xmlStrEqual(cont->c1->name, qname)))
-            return(1);
-        } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
-        (cont->c1 == NULL) ||
-        (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
-        xmlErrValid(NULL, XML_DTD_MIXED_CORRUPT,
-            "Internal: MIXED struct corrupted\n",
-            NULL);
-        break;
+        while (cont != NULL) {
+            if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                if ((cont->prefix == NULL) && (xmlStrEqual(cont->name, qname)))
+                    return(1);
+            } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
+               (cont->c1 != NULL) &&
+               (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
+                if ((cont->c1->prefix == NULL) &&
+                    (xmlStrEqual(cont->c1->name, qname)))
+                    return(1);
+            } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
+                (cont->c1 == NULL) ||
+                (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
+                xmlErrValid(NULL, XML_DTD_MIXED_CORRUPT,
+                        "Internal: MIXED struct corrupted\n",
+                        NULL);
+                break;
+            }
+            cont = cont->c2;
         }
-        cont = cont->c2;
-    }
     } else {
-    while (cont != NULL) {
-        if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
-        if ((cont->prefix != NULL) &&
-            (xmlStrncmp(cont->prefix, qname, plen) == 0) &&
-            (xmlStrEqual(cont->name, name)))
-            return(1);
-        } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
-           (cont->c1 != NULL) &&
-           (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
-        if ((cont->c1->prefix != NULL) &&
-            (xmlStrncmp(cont->c1->prefix, qname, plen) == 0) &&
-            (xmlStrEqual(cont->c1->name, name)))
-            return(1);
-        } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
-        (cont->c1 == NULL) ||
-        (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
-        xmlErrValid(ctxt, XML_DTD_MIXED_CORRUPT,
-            "Internal: MIXED struct corrupted\n",
-            NULL);
-        break;
+        while (cont != NULL) {
+            if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                if ((cont->prefix != NULL) &&
+                    (xmlStrncmp(cont->prefix, qname, plen) == 0) &&
+                    (xmlStrEqual(cont->name, name)))
+                    return(1);
+            } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
+               (cont->c1 != NULL) &&
+               (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
+                if ((cont->c1->prefix != NULL) &&
+                    (xmlStrncmp(cont->c1->prefix, qname, plen) == 0) &&
+                    (xmlStrEqual(cont->c1->name, name)))
+                    return(1);
+            } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
+                (cont->c1 == NULL) ||
+                (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
+                xmlErrValid(ctxt, XML_DTD_MIXED_CORRUPT,
+                        "Internal: MIXED struct corrupted\n",
+                        NULL);
+                break;
+            }
+            cont = cont->c2;
         }
-        cont = cont->c2;
-    }
     }
     return(0);
 }
@@ -5753,7 +5754,7 @@ xmlValidateCheckMixed(xmlValidCtxtPtr ctxt,
  */
 static xmlElementPtr
 xmlValidGetElemDecl(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
-                xmlNodePtr elem, int *extsubset) {
+                    xmlNodePtr elem, int *extsubset) {
     xmlElementPtr elemDecl = NULL;
     const xmlChar *prefix = NULL;
 
@@ -5761,23 +5762,23 @@ xmlValidGetElemDecl(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
         (elem == NULL) || (elem->name == NULL))
         return(NULL);
     if (extsubset != NULL)
-    *extsubset = 0;
+        *extsubset = 0;
 
     /*
      * Fetch the declaration for the qualified name
      */
     if ((elem->ns != NULL) && (elem->ns->prefix != NULL))
-    prefix = elem->ns->prefix;
+        prefix = elem->ns->prefix;
 
     if (prefix != NULL) {
-    elemDecl = xmlGetDtdQElementDesc(doc->intSubset,
-                                 elem->name, prefix);
-    if ((elemDecl == NULL) && (doc->extSubset != NULL)) {
-        elemDecl = xmlGetDtdQElementDesc(doc->extSubset,
-                                     elem->name, prefix);
-        if ((elemDecl != NULL) && (extsubset != NULL))
-        *extsubset = 1;
-    }
+        elemDecl = xmlGetDtdQElementDesc(doc->intSubset,
+                                         elem->name, prefix);
+        if ((elemDecl == NULL) && (doc->extSubset != NULL)) {
+            elemDecl = xmlGetDtdQElementDesc(doc->extSubset,
+                                             elem->name, prefix);
+            if ((elemDecl != NULL) && (extsubset != NULL))
+                *extsubset = 1;
+        }
     }
 
     /*
@@ -5786,18 +5787,18 @@ xmlValidGetElemDecl(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
      * full QName but in that case being flexible makes sense.
      */
     if (elemDecl == NULL) {
-    elemDecl = xmlGetDtdElementDesc(doc->intSubset, elem->name);
-    if ((elemDecl == NULL) && (doc->extSubset != NULL)) {
-        elemDecl = xmlGetDtdElementDesc(doc->extSubset, elem->name);
-        if ((elemDecl != NULL) && (extsubset != NULL))
-        *extsubset = 1;
-    }
+        elemDecl = xmlGetDtdElementDesc(doc->intSubset, elem->name);
+        if ((elemDecl == NULL) && (doc->extSubset != NULL)) {
+            elemDecl = xmlGetDtdElementDesc(doc->extSubset, elem->name);
+            if ((elemDecl != NULL) && (extsubset != NULL))
+                *extsubset = 1;
+        }
     }
     if (elemDecl == NULL) {
-    xmlErrValidNode(ctxt, elem,
-            XML_DTD_UNKNOWN_ELEM,
-           "No declaration for element %s\n",
-           elem->name, NULL, NULL);
+        xmlErrValidNode(ctxt, elem,
+                        XML_DTD_UNKNOWN_ELEM,
+               "No declaration for element %s\n",
+               elem->name, NULL, NULL);
     }
     return(elemDecl);
 }
@@ -5825,72 +5826,72 @@ xmlValidatePushElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
         return(0);
 /* printf("PushElem %s\n", qname); */
     if ((ctxt->vstateNr > 0) && (ctxt->vstate != NULL)) {
-    xmlValidStatePtr state = ctxt->vstate;
-    xmlElementPtr elemDecl;
+        xmlValidStatePtr state = ctxt->vstate;
+        xmlElementPtr elemDecl;
 
-    /*
-     * Check the new element against the content model of the new elem.
-     */
-    if (state->elemDecl != NULL) {
-        elemDecl = state->elemDecl;
+        /*
+         * Check the new element against the content model of the new elem.
+         */
+        if (state->elemDecl != NULL) {
+            elemDecl = state->elemDecl;
 
-        switch(elemDecl->etype) {
-        case XML_ELEMENT_TYPE_UNDEFINED:
-            ret = 0;
-            break;
-        case XML_ELEMENT_TYPE_EMPTY:
-            xmlErrValidNode(ctxt, state->node,
-                    XML_DTD_NOT_EMPTY,
-           "Element %s was declared EMPTY this one has content\n",
-               state->node->name, NULL, NULL);
-            ret = 0;
-            break;
-        case XML_ELEMENT_TYPE_ANY:
-            /* I don't think anything is required then */
-            break;
-        case XML_ELEMENT_TYPE_MIXED:
-            /* simple case of declared as #PCDATA */
-            if ((elemDecl->content != NULL) &&
-            (elemDecl->content->type ==
-             XML_ELEMENT_CONTENT_PCDATA)) {
-            xmlErrValidNode(ctxt, state->node,
-                    XML_DTD_NOT_PCDATA,
-           "Element %s was declared #PCDATA but contains non text nodes\n",
-                state->node->name, NULL, NULL);
-            ret = 0;
-            } else {
-            ret = xmlValidateCheckMixed(ctxt, elemDecl->content,
-                                    qname);
-            if (ret != 1) {
-                xmlErrValidNode(ctxt, state->node,
-                        XML_DTD_INVALID_CHILD,
-           "Element %s is not declared in %s list of possible children\n",
-                    qname, state->node->name, NULL);
+            switch(elemDecl->etype) {
+                case XML_ELEMENT_TYPE_UNDEFINED:
+                    ret = 0;
+                    break;
+                case XML_ELEMENT_TYPE_EMPTY:
+                    xmlErrValidNode(ctxt, state->node,
+                                    XML_DTD_NOT_EMPTY,
+               "Element %s was declared EMPTY this one has content\n",
+                           state->node->name, NULL, NULL);
+                    ret = 0;
+                    break;
+                case XML_ELEMENT_TYPE_ANY:
+                    /* I don't think anything is required then */
+                    break;
+                case XML_ELEMENT_TYPE_MIXED:
+                    /* simple case of declared as #PCDATA */
+                    if ((elemDecl->content != NULL) &&
+                        (elemDecl->content->type ==
+                         XML_ELEMENT_CONTENT_PCDATA)) {
+                        xmlErrValidNode(ctxt, state->node,
+                                        XML_DTD_NOT_PCDATA,
+               "Element %s was declared #PCDATA but contains non text nodes\n",
+                                state->node->name, NULL, NULL);
+                        ret = 0;
+                    } else {
+                        ret = xmlValidateCheckMixed(ctxt, elemDecl->content,
+                                                    qname);
+                        if (ret != 1) {
+                            xmlErrValidNode(ctxt, state->node,
+                                            XML_DTD_INVALID_CHILD,
+               "Element %s is not declared in %s list of possible children\n",
+                                    qname, state->node->name, NULL);
+                        }
+                    }
+                    break;
+                case XML_ELEMENT_TYPE_ELEMENT:
+                    /*
+                     * TODO:
+                     * VC: Standalone Document Declaration
+                     *     - element types with element content, if white space
+                     *       occurs directly within any instance of those types.
+                     */
+                    if (state->exec != NULL) {
+                        ret = xmlRegExecPushString(state->exec, qname, NULL);
+                        if (ret < 0) {
+                            xmlErrValidNode(ctxt, state->node,
+                                            XML_DTD_CONTENT_MODEL,
+               "Element %s content does not follow the DTD, Misplaced %s\n",
+                                   state->node->name, qname, NULL);
+                            ret = 0;
+                        } else {
+                            ret = 1;
+                        }
+                    }
+                    break;
             }
-            }
-            break;
-        case XML_ELEMENT_TYPE_ELEMENT:
-            /*
-             * TODO:
-             * VC: Standalone Document Declaration
-             *     - element types with element content, if white space
-             *       occurs directly within any instance of those types.
-             */
-            if (state->exec != NULL) {
-            ret = xmlRegExecPushString(state->exec, qname, NULL);
-            if (ret < 0) {
-                xmlErrValidNode(ctxt, state->node,
-                        XML_DTD_CONTENT_MODEL,
-           "Element %s content does not follow the DTD, Misplaced %s\n",
-                   state->node->name, qname, NULL);
-                ret = 0;
-            } else {
-                ret = 1;
-            }
-            }
-            break;
         }
-    }
     }
     eDecl = xmlValidGetElemDecl(ctxt, doc, elem, &extsubset);
     vstateVPush(ctxt, eDecl, elem);
@@ -5915,33 +5916,33 @@ xmlValidatePushCData(xmlValidCtxtPtr ctxt, const xmlChar *data, int len) {
     if (ctxt == NULL)
         return(0);
     if (len <= 0)
-    return(ret);
+        return(ret);
     if ((ctxt->vstateNr > 0) && (ctxt->vstate != NULL)) {
-    xmlValidStatePtr state = ctxt->vstate;
-    xmlElementPtr elemDecl;
+        xmlValidStatePtr state = ctxt->vstate;
+        xmlElementPtr elemDecl;
 
-    /*
-     * Check the new element against the content model of the new elem.
-     */
-    if (state->elemDecl != NULL) {
-        elemDecl = state->elemDecl;
+        /*
+         * Check the new element against the content model of the new elem.
+         */
+        if (state->elemDecl != NULL) {
+            elemDecl = state->elemDecl;
 
-        switch(elemDecl->etype) {
-        case XML_ELEMENT_TYPE_UNDEFINED:
-            ret = 0;
-            break;
-        case XML_ELEMENT_TYPE_EMPTY:
-            xmlErrValidNode(ctxt, state->node,
-                    XML_DTD_NOT_EMPTY,
-           "Element %s was declared EMPTY this one has content\n",
-               state->node->name, NULL, NULL);
-            ret = 0;
-            break;
-        case XML_ELEMENT_TYPE_ANY:
-            break;
-        case XML_ELEMENT_TYPE_MIXED:
-            break;
-        case XML_ELEMENT_TYPE_ELEMENT: {
+            switch(elemDecl->etype) {
+                case XML_ELEMENT_TYPE_UNDEFINED:
+                    ret = 0;
+                    break;
+                case XML_ELEMENT_TYPE_EMPTY:
+                    xmlErrValidNode(ctxt, state->node,
+                                    XML_DTD_NOT_EMPTY,
+               "Element %s was declared EMPTY this one has content\n",
+                           state->node->name, NULL, NULL);
+                    ret = 0;
+                    break;
+                case XML_ELEMENT_TYPE_ANY:
+                    break;
+                case XML_ELEMENT_TYPE_MIXED:
+                    break;
+                case XML_ELEMENT_TYPE_ELEMENT: {
                     int i;
 
                     for (i = 0;i < len;i++) {
@@ -5962,8 +5963,8 @@ xmlValidatePushCData(xmlValidCtxtPtr ctxt, const xmlChar *data, int len) {
                      */
                     break;
                 }
+            }
         }
-    }
     }
 done:
     return(ret);
@@ -5983,41 +5984,41 @@ done:
 int
 xmlValidatePopElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc ATTRIBUTE_UNUSED,
                       xmlNodePtr elem ATTRIBUTE_UNUSED,
-              const xmlChar *qname ATTRIBUTE_UNUSED) {
+                      const xmlChar *qname ATTRIBUTE_UNUSED) {
     int ret = 1;
 
     if (ctxt == NULL)
         return(0);
 /* printf("PopElem %s\n", qname); */
     if ((ctxt->vstateNr > 0) && (ctxt->vstate != NULL)) {
-    xmlValidStatePtr state = ctxt->vstate;
-    xmlElementPtr elemDecl;
+        xmlValidStatePtr state = ctxt->vstate;
+        xmlElementPtr elemDecl;
 
-    /*
-     * Check the new element against the content model of the new elem.
-     */
-    if (state->elemDecl != NULL) {
-        elemDecl = state->elemDecl;
+        /*
+         * Check the new element against the content model of the new elem.
+         */
+        if (state->elemDecl != NULL) {
+            elemDecl = state->elemDecl;
 
-        if (elemDecl->etype == XML_ELEMENT_TYPE_ELEMENT) {
-        if (state->exec != NULL) {
-            ret = xmlRegExecPushString(state->exec, NULL, NULL);
-            if (ret == 0) {
-            xmlErrValidNode(ctxt, state->node,
-                            XML_DTD_CONTENT_MODEL,
-       "Element %s content does not follow the DTD, Expecting more child\n",
-                   state->node->name, NULL,NULL);
-            } else {
-            /*
-             * previous validation errors should not generate
-             * a new one here
-             */
-            ret = 1;
+            if (elemDecl->etype == XML_ELEMENT_TYPE_ELEMENT) {
+                if (state->exec != NULL) {
+                    ret = xmlRegExecPushString(state->exec, NULL, NULL);
+                    if (ret == 0) {
+                        xmlErrValidNode(ctxt, state->node,
+                                        XML_DTD_CONTENT_MODEL,
+           "Element %s content does not follow the DTD, Expecting more child\n",
+                               state->node->name, NULL,NULL);
+                    } else {
+                        /*
+                         * previous validation errors should not generate
+                         * a new one here
+                         */
+                        ret = 1;
+                    }
+                }
             }
         }
-        }
-    }
-    vstateVPop(ctxt);
+        vstateVPop(ctxt);
     }
     return(ret);
 }
@@ -6057,29 +6058,29 @@ xmlValidateOneElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     if (elem == NULL) return(0);
     switch (elem->type) {
         case XML_ATTRIBUTE_NODE:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "Attribute element not expected\n", NULL, NULL ,NULL);
-        return(0);
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "Attribute element not expected\n", NULL, NULL ,NULL);
+            return(0);
         case XML_TEXT_NODE:
-        if (elem->children != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-                        "Text element has children !\n",
-                NULL,NULL,NULL);
-        return(0);
-        }
-        if (elem->ns != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-                        "Text element has namespace !\n",
-                NULL,NULL,NULL);
-        return(0);
-        }
-        if (elem->content == NULL) {
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-                        "Text element has no content !\n",
-                NULL,NULL,NULL);
-        return(0);
-        }
-        return(1);
+            if (elem->children != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                                "Text element has children !\n",
+                                NULL,NULL,NULL);
+                return(0);
+            }
+            if (elem->ns != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                                "Text element has namespace !\n",
+                                NULL,NULL,NULL);
+                return(0);
+            }
+            if (elem->content == NULL) {
+                xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                                "Text element has no content !\n",
+                                NULL,NULL,NULL);
+                return(0);
+            }
+            return(1);
         case XML_XINCLUDE_START:
         case XML_XINCLUDE_END:
             return(1);
@@ -6087,31 +6088,31 @@ xmlValidateOneElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
         case XML_ENTITY_REF_NODE:
         case XML_PI_NODE:
         case XML_COMMENT_NODE:
-        return(1);
+            return(1);
         case XML_ENTITY_NODE:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "Entity element not expected\n", NULL, NULL ,NULL);
-        return(0);
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "Entity element not expected\n", NULL, NULL ,NULL);
+            return(0);
         case XML_NOTATION_NODE:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "Notation element not expected\n", NULL, NULL ,NULL);
-        return(0);
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "Notation element not expected\n", NULL, NULL ,NULL);
+            return(0);
         case XML_DOCUMENT_NODE:
         case XML_DOCUMENT_TYPE_NODE:
         case XML_DOCUMENT_FRAG_NODE:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "Document element not expected\n", NULL, NULL ,NULL);
-        return(0);
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "Document element not expected\n", NULL, NULL ,NULL);
+            return(0);
         case XML_HTML_DOCUMENT_NODE:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "HTML Document not expected\n", NULL, NULL ,NULL);
-        return(0);
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "HTML Document not expected\n", NULL, NULL ,NULL);
+            return(0);
         case XML_ELEMENT_NODE:
-        break;
-    default:
-        xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
-           "unknown element type\n", NULL, NULL ,NULL);
-        return(0);
+            break;
+        default:
+            xmlErrValidNode(ctxt, elem, XML_ERR_INTERNAL_ERROR,
+                   "unknown element type\n", NULL, NULL ,NULL);
+            return(0);
     }
 
     /*
@@ -6119,7 +6120,7 @@ xmlValidateOneElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
      */
     elemDecl = xmlValidGetElemDecl(ctxt, doc, elem, &extsubset);
     if (elemDecl == NULL)
-    return(0);
+        return(0);
 
     /*
      * If vstateNr is not zero that means continuous validation is
@@ -6129,262 +6130,262 @@ xmlValidateOneElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc,
     /* Check that the element content matches the definition */
     switch (elemDecl->etype) {
         case XML_ELEMENT_TYPE_UNDEFINED:
-        xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ELEM,
-                        "No declaration for element %s\n",
-           elem->name, NULL, NULL);
-        return(0);
-        case XML_ELEMENT_TYPE_EMPTY:
-        if (elem->children != NULL) {
-        xmlErrValidNode(ctxt, elem, XML_DTD_NOT_EMPTY,
-           "Element %s was declared EMPTY this one has content\n",
+            xmlErrValidNode(ctxt, elem, XML_DTD_UNKNOWN_ELEM,
+                            "No declaration for element %s\n",
                    elem->name, NULL, NULL);
-        ret = 0;
-        }
-        break;
+            return(0);
+        case XML_ELEMENT_TYPE_EMPTY:
+            if (elem->children != NULL) {
+                xmlErrValidNode(ctxt, elem, XML_DTD_NOT_EMPTY,
+               "Element %s was declared EMPTY this one has content\n",
+                       elem->name, NULL, NULL);
+                ret = 0;
+            }
+            break;
         case XML_ELEMENT_TYPE_ANY:
-        /* I don't think anything is required then */
-        break;
+            /* I don't think anything is required then */
+            break;
         case XML_ELEMENT_TYPE_MIXED:
 
-        /* simple case of declared as #PCDATA */
-        if ((elemDecl->content != NULL) &&
-        (elemDecl->content->type == XML_ELEMENT_CONTENT_PCDATA)) {
-        ret = xmlValidateOneCdataElement(ctxt, doc, elem);
-        if (!ret) {
-            xmlErrValidNode(ctxt, elem, XML_DTD_NOT_PCDATA,
-           "Element %s was declared #PCDATA but contains non text nodes\n",
-               elem->name, NULL, NULL);
-        }
-        break;
-        }
-        child = elem->children;
-        /* Hum, this start to get messy */
-        while (child != NULL) {
-            if (child->type == XML_ELEMENT_NODE) {
-            name = child->name;
-            if ((child->ns != NULL) && (child->ns->prefix != NULL)) {
-            xmlChar fn[50];
-            xmlChar *fullname;
-
-            fullname = xmlBuildQName(child->name, child->ns->prefix,
-                                 fn, 50);
-            if (fullname == NULL)
-                return(0);
-            cont = elemDecl->content;
-            while (cont != NULL) {
-                if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
-                if (xmlStrEqual(cont->name, fullname))
-                    break;
-                } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
-                   (cont->c1 != NULL) &&
-                   (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
-                if (xmlStrEqual(cont->c1->name, fullname))
-                    break;
-                } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
-                (cont->c1 == NULL) ||
-                (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
-                xmlErrValid(NULL, XML_DTD_MIXED_CORRUPT,
-                    "Internal: MIXED struct corrupted\n",
-                    NULL);
-                break;
+            /* simple case of declared as #PCDATA */
+            if ((elemDecl->content != NULL) &&
+                (elemDecl->content->type == XML_ELEMENT_CONTENT_PCDATA)) {
+                ret = xmlValidateOneCdataElement(ctxt, doc, elem);
+                if (!ret) {
+                    xmlErrValidNode(ctxt, elem, XML_DTD_NOT_PCDATA,
+               "Element %s was declared #PCDATA but contains non text nodes\n",
+                           elem->name, NULL, NULL);
                 }
-                cont = cont->c2;
-            }
-            if ((fullname != fn) && (fullname != child->name))
-                xmlFree(fullname);
-            if (cont != NULL)
-                goto child_ok;
-            }
-            cont = elemDecl->content;
-            while (cont != NULL) {
-                if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
-                if (xmlStrEqual(cont->name, name)) break;
-            } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
-               (cont->c1 != NULL) &&
-               (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)) {
-                if (xmlStrEqual(cont->c1->name, name)) break;
-            } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
-                (cont->c1 == NULL) ||
-                (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)) {
-                xmlErrValid(ctxt, XML_DTD_MIXED_CORRUPT,
-                    "Internal: MIXED struct corrupted\n",
-                    NULL);
                 break;
             }
-            cont = cont->c2;
-            }
-            if (cont == NULL) {
-            xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_CHILD,
-           "Element %s is not declared in %s list of possible children\n",
-                   name, elem->name, NULL);
-            ret = 0;
-            }
-        }
-child_ok:
-            child = child->next;
-        }
-        break;
-        case XML_ELEMENT_TYPE_ELEMENT:
-        if ((doc->standalone == 1) && (extsubset == 1)) {
-        /*
-         * VC: Standalone Document Declaration
-         *     - element types with element content, if white space
-         *       occurs directly within any instance of those types.
-         */
-        child = elem->children;
-        while (child != NULL) {
-            if (child->type == XML_TEXT_NODE) {
-            const xmlChar *content = child->content;
+            child = elem->children;
+            /* Hum, this start to get messy */
+            while (child != NULL) {
+                if (child->type == XML_ELEMENT_NODE) {
+                    name = child->name;
+                    if ((child->ns != NULL) && (child->ns->prefix != NULL)) {
+                        xmlChar fn[50];
+                        xmlChar *fullname;
 
-            while (IS_BLANK_CH(*content))
-                content++;
-            if (*content == 0) {
-                xmlErrValidNode(ctxt, elem,
-                                XML_DTD_STANDALONE_WHITE_SPACE,
+                        fullname = xmlBuildQName(child->name, child->ns->prefix,
+                                                 fn, 50);
+                        if (fullname == NULL)
+                            return(0);
+                        cont = elemDecl->content;
+                        while (cont != NULL) {
+                            if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                                if (xmlStrEqual(cont->name, fullname))
+                                    break;
+                            } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
+                               (cont->c1 != NULL) &&
+                               (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)){
+                                if (xmlStrEqual(cont->c1->name, fullname))
+                                    break;
+                            } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
+                                (cont->c1 == NULL) ||
+                                (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)){
+                                xmlErrValid(NULL, XML_DTD_MIXED_CORRUPT,
+                                        "Internal: MIXED struct corrupted\n",
+                                        NULL);
+                                break;
+                            }
+                            cont = cont->c2;
+                        }
+                        if ((fullname != fn) && (fullname != child->name))
+                            xmlFree(fullname);
+                        if (cont != NULL)
+                            goto child_ok;
+                    }
+                    cont = elemDecl->content;
+                    while (cont != NULL) {
+                        if (cont->type == XML_ELEMENT_CONTENT_ELEMENT) {
+                            if (xmlStrEqual(cont->name, name)) break;
+                        } else if ((cont->type == XML_ELEMENT_CONTENT_OR) &&
+                           (cont->c1 != NULL) &&
+                           (cont->c1->type == XML_ELEMENT_CONTENT_ELEMENT)) {
+                            if (xmlStrEqual(cont->c1->name, name)) break;
+                        } else if ((cont->type != XML_ELEMENT_CONTENT_OR) ||
+                            (cont->c1 == NULL) ||
+                            (cont->c1->type != XML_ELEMENT_CONTENT_PCDATA)) {
+                            xmlErrValid(ctxt, XML_DTD_MIXED_CORRUPT,
+                                    "Internal: MIXED struct corrupted\n",
+                                    NULL);
+                            break;
+                        }
+                        cont = cont->c2;
+                    }
+                    if (cont == NULL) {
+                        xmlErrValidNode(ctxt, elem, XML_DTD_INVALID_CHILD,
+               "Element %s is not declared in %s list of possible children\n",
+                               name, elem->name, NULL);
+                        ret = 0;
+                    }
+                }
+child_ok:
+                child = child->next;
+            }
+            break;
+        case XML_ELEMENT_TYPE_ELEMENT:
+            if ((doc->standalone == 1) && (extsubset == 1)) {
+                /*
+                 * VC: Standalone Document Declaration
+                 *     - element types with element content, if white space
+                 *       occurs directly within any instance of those types.
+                 */
+                child = elem->children;
+                while (child != NULL) {
+                    if (child->type == XML_TEXT_NODE) {
+                        const xmlChar *content = child->content;
+
+                        while (IS_BLANK_CH(*content))
+                            content++;
+                        if (*content == 0) {
+                            xmlErrValidNode(ctxt, elem,
+                                            XML_DTD_STANDALONE_WHITE_SPACE,
 "standalone: %s declared in the external subset contains white spaces nodes\n",
-                   elem->name, NULL, NULL);
-                ret = 0;
-                break;
+                                   elem->name, NULL, NULL);
+                            ret = 0;
+                            break;
+                        }
+                    }
+                    child =child->next;
+                }
             }
-            }
-            child =child->next;
-        }
-        }
-        child = elem->children;
-        cont = elemDecl->content;
-        tmp = xmlValidateElementContent(ctxt, child, elemDecl, 1, elem);
-        if (tmp <= 0)
-        ret = tmp;
-        break;
+            child = elem->children;
+            cont = elemDecl->content;
+            tmp = xmlValidateElementContent(ctxt, child, elemDecl, 1, elem);
+            if (tmp <= 0)
+                ret = tmp;
+            break;
     }
     } /* not continuous */
 
     /* [ VC: Required Attribute ] */
     attr = elemDecl->attributes;
     while (attr != NULL) {
-    if (attr->def == XML_ATTRIBUTE_REQUIRED) {
-        int qualified = -1;
+        if (attr->def == XML_ATTRIBUTE_REQUIRED) {
+            int qualified = -1;
 
-        if ((attr->prefix == NULL) &&
-        (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) {
-        xmlNsPtr ns;
+            if ((attr->prefix == NULL) &&
+                (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) {
+                xmlNsPtr ns;
 
-        ns = elem->nsDef;
-        while (ns != NULL) {
-            if (ns->prefix == NULL)
-            goto found;
-            ns = ns->next;
-        }
-        } else if (xmlStrEqual(attr->prefix, BAD_CAST "xmlns")) {
-        xmlNsPtr ns;
+                ns = elem->nsDef;
+                while (ns != NULL) {
+                    if (ns->prefix == NULL)
+                        goto found;
+                    ns = ns->next;
+                }
+            } else if (xmlStrEqual(attr->prefix, BAD_CAST "xmlns")) {
+                xmlNsPtr ns;
 
-        ns = elem->nsDef;
-        while (ns != NULL) {
-            if (xmlStrEqual(attr->name, ns->prefix))
-            goto found;
-            ns = ns->next;
-        }
-        } else {
-        xmlAttrPtr attrib;
-
-        attrib = elem->properties;
-        while (attrib != NULL) {
-            if (xmlStrEqual(attrib->name, attr->name)) {
-            if (attr->prefix != NULL) {
-                xmlNsPtr nameSpace = attrib->ns;
-
-                if (nameSpace == NULL)
-                nameSpace = elem->ns;
-                /*
-                 * qualified names handling is problematic, having a
-                 * different prefix should be possible but DTDs don't
-                 * allow to define the URI instead of the prefix :-(
-                 */
-                if (nameSpace == NULL) {
-                if (qualified < 0)
-                    qualified = 0;
-                } else if (!xmlStrEqual(nameSpace->prefix,
-                            attr->prefix)) {
-                if (qualified < 1)
-                    qualified = 1;
-                } else
-                goto found;
+                ns = elem->nsDef;
+                while (ns != NULL) {
+                    if (xmlStrEqual(attr->name, ns->prefix))
+                        goto found;
+                    ns = ns->next;
+                }
             } else {
-                /*
-                 * We should allow applications to define namespaces
-                 * for their application even if the DTD doesn't
-                 * carry one, otherwise, basically we would always
-                 * break.
-                 */
-                goto found;
-            }
-            }
-            attrib = attrib->next;
-        }
-        }
-        if (qualified == -1) {
-        if (attr->prefix == NULL) {
-            xmlErrValidNode(ctxt, elem, XML_DTD_MISSING_ATTRIBUTE,
-               "Element %s does not carry attribute %s\n",
-               elem->name, attr->name, NULL);
-            ret = 0;
-            } else {
-            xmlErrValidNode(ctxt, elem, XML_DTD_MISSING_ATTRIBUTE,
-               "Element %s does not carry attribute %s:%s\n",
-               elem->name, attr->prefix,attr->name);
-            ret = 0;
-        }
-        } else if (qualified == 0) {
-        xmlErrValidWarning(ctxt, elem, XML_DTD_NO_PREFIX,
-           "Element %s required attribute %s:%s has no prefix\n",
-               elem->name, attr->prefix, attr->name);
-        } else if (qualified == 1) {
-        xmlErrValidWarning(ctxt, elem, XML_DTD_DIFFERENT_PREFIX,
-           "Element %s required attribute %s:%s has different prefix\n",
-               elem->name, attr->prefix, attr->name);
-        }
-    } else if (attr->def == XML_ATTRIBUTE_FIXED) {
-        /*
-         * Special tests checking #FIXED namespace declarations
-         * have the right value since this is not done as an
-         * attribute checking
-         */
-        if ((attr->prefix == NULL) &&
-        (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) {
-        xmlNsPtr ns;
+                xmlAttrPtr attrib;
 
-        ns = elem->nsDef;
-        while (ns != NULL) {
-            if (ns->prefix == NULL) {
-            if (!xmlStrEqual(attr->defaultValue, ns->href)) {
-                xmlErrValidNode(ctxt, elem,
-                       XML_DTD_ELEM_DEFAULT_NAMESPACE,
+                attrib = elem->properties;
+                while (attrib != NULL) {
+                    if (xmlStrEqual(attrib->name, attr->name)) {
+                        if (attr->prefix != NULL) {
+                            xmlNsPtr nameSpace = attrib->ns;
+
+                            if (nameSpace == NULL)
+                                nameSpace = elem->ns;
+                            /*
+                             * qualified names handling is problematic, having a
+                             * different prefix should be possible but DTDs don't
+                             * allow to define the URI instead of the prefix :-(
+                             */
+                            if (nameSpace == NULL) {
+                                if (qualified < 0)
+                                    qualified = 0;
+                            } else if (!xmlStrEqual(nameSpace->prefix,
+                                                    attr->prefix)) {
+                                if (qualified < 1)
+                                    qualified = 1;
+                            } else
+                                goto found;
+                        } else {
+                            /*
+                             * We should allow applications to define namespaces
+                             * for their application even if the DTD doesn't
+                             * carry one, otherwise, basically we would always
+                             * break.
+                             */
+                            goto found;
+                        }
+                    }
+                    attrib = attrib->next;
+                }
+            }
+            if (qualified == -1) {
+                if (attr->prefix == NULL) {
+                    xmlErrValidNode(ctxt, elem, XML_DTD_MISSING_ATTRIBUTE,
+                       "Element %s does not carry attribute %s\n",
+                           elem->name, attr->name, NULL);
+                    ret = 0;
+                } else {
+                    xmlErrValidNode(ctxt, elem, XML_DTD_MISSING_ATTRIBUTE,
+                       "Element %s does not carry attribute %s:%s\n",
+                           elem->name, attr->prefix,attr->name);
+                    ret = 0;
+                }
+            } else if (qualified == 0) {
+                xmlErrValidWarning(ctxt, elem, XML_DTD_NO_PREFIX,
+                   "Element %s required attribute %s:%s has no prefix\n",
+                       elem->name, attr->prefix, attr->name);
+            } else if (qualified == 1) {
+                xmlErrValidWarning(ctxt, elem, XML_DTD_DIFFERENT_PREFIX,
+                   "Element %s required attribute %s:%s has different prefix\n",
+                       elem->name, attr->prefix, attr->name);
+            }
+        } else if (attr->def == XML_ATTRIBUTE_FIXED) {
+            /*
+             * Special tests checking #FIXED namespace declarations
+             * have the right value since this is not done as an
+             * attribute checking
+             */
+            if ((attr->prefix == NULL) &&
+                (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) {
+                xmlNsPtr ns;
+
+                ns = elem->nsDef;
+                while (ns != NULL) {
+                    if (ns->prefix == NULL) {
+                        if (!xmlStrEqual(attr->defaultValue, ns->href)) {
+                            xmlErrValidNode(ctxt, elem,
+                                   XML_DTD_ELEM_DEFAULT_NAMESPACE,
    "Element %s namespace name for default namespace does not match the DTD\n",
-                   elem->name, NULL, NULL);
-                ret = 0;
-            }
-            goto found;
-            }
-            ns = ns->next;
-        }
-        } else if (xmlStrEqual(attr->prefix, BAD_CAST "xmlns")) {
-        xmlNsPtr ns;
+                                   elem->name, NULL, NULL);
+                            ret = 0;
+                        }
+                        goto found;
+                    }
+                    ns = ns->next;
+                }
+            } else if (xmlStrEqual(attr->prefix, BAD_CAST "xmlns")) {
+                xmlNsPtr ns;
 
-        ns = elem->nsDef;
-        while (ns != NULL) {
-            if (xmlStrEqual(attr->name, ns->prefix)) {
-            if (!xmlStrEqual(attr->defaultValue, ns->href)) {
-                xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
-           "Element %s namespace name for %s does not match the DTD\n",
-                   elem->name, ns->prefix, NULL);
-                ret = 0;
+                ns = elem->nsDef;
+                while (ns != NULL) {
+                    if (xmlStrEqual(attr->name, ns->prefix)) {
+                        if (!xmlStrEqual(attr->defaultValue, ns->href)) {
+                            xmlErrValidNode(ctxt, elem, XML_DTD_ELEM_NAMESPACE,
+                   "Element %s namespace name for %s does not match the DTD\n",
+                                   elem->name, ns->prefix, NULL);
+                            ret = 0;
+                        }
+                        goto found;
+                    }
+                    ns = ns->next;
+                }
             }
-            goto found;
-            }
-            ns = ns->next;
         }
-        }
-    }
 found:
         attr = attr->nexth;
     }
@@ -6414,8 +6415,8 @@ xmlValidateRoot(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
 
     root = xmlDocGetRootElement(doc);
     if ((root == NULL) || (root->name == NULL)) {
-    xmlErrValid(ctxt, XML_DTD_NO_ROOT,
-                "no root element\n", NULL);
+        xmlErrValid(ctxt, XML_DTD_NO_ROOT,
+                    "no root element\n", NULL);
         return(0);
     }
 
@@ -6424,34 +6425,34 @@ xmlValidateRoot(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
      * no internal subset has been generated
      */
     if ((doc->intSubset != NULL) &&
-    (doc->intSubset->name != NULL)) {
-    /*
-     * Check first the document root against the NQName
-     */
-    if (!xmlStrEqual(doc->intSubset->name, root->name)) {
-        if ((root->ns != NULL) && (root->ns->prefix != NULL)) {
-        xmlChar fn[50];
-        xmlChar *fullname;
+        (doc->intSubset->name != NULL)) {
+        /*
+         * Check first the document root against the NQName
+         */
+        if (!xmlStrEqual(doc->intSubset->name, root->name)) {
+            if ((root->ns != NULL) && (root->ns->prefix != NULL)) {
+                xmlChar fn[50];
+                xmlChar *fullname;
 
-        fullname = xmlBuildQName(root->name, root->ns->prefix, fn, 50);
-        if (fullname == NULL) {
-            xmlVErrMemory(ctxt, NULL);
+                fullname = xmlBuildQName(root->name, root->ns->prefix, fn, 50);
+                if (fullname == NULL) {
+                    xmlVErrMemory(ctxt, NULL);
+                    return(0);
+                }
+                ret = xmlStrEqual(doc->intSubset->name, fullname);
+                if ((fullname != fn) && (fullname != root->name))
+                    xmlFree(fullname);
+                if (ret == 1)
+                    goto name_ok;
+            }
+            if ((xmlStrEqual(doc->intSubset->name, BAD_CAST "HTML")) &&
+                (xmlStrEqual(root->name, BAD_CAST "html")))
+                goto name_ok;
+            xmlErrValidNode(ctxt, root, XML_DTD_ROOT_NAME,
+                   "root and DTD name do not match '%s' and '%s'\n",
+                   root->name, doc->intSubset->name, NULL);
             return(0);
         }
-        ret = xmlStrEqual(doc->intSubset->name, fullname);
-        if ((fullname != fn) && (fullname != root->name))
-            xmlFree(fullname);
-        if (ret == 1)
-            goto name_ok;
-        }
-        if ((xmlStrEqual(doc->intSubset->name, BAD_CAST "HTML")) &&
-        (xmlStrEqual(root->name, BAD_CAST "html")))
-        goto name_ok;
-        xmlErrValidNode(ctxt, root, XML_DTD_ROOT_NAME,
-           "root and DTD name do not match '%s' and '%s'\n",
-           root->name, doc->intSubset->name, NULL);
-        return(0);
-    }
     }
 name_ok:
     return(1);
@@ -6484,9 +6485,9 @@ xmlValidateElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc, xmlNodePtr elem) {
      * they don't really mean anything validation wise.
      */
     if ((elem->type == XML_XINCLUDE_START) ||
-    (elem->type == XML_XINCLUDE_END) ||
-    (elem->type == XML_NAMESPACE_DECL))
-    return(1);
+        (elem->type == XML_XINCLUDE_END) ||
+        (elem->type == XML_NAMESPACE_DECL))
+        return(1);
 
     CHECK_DTD;
 
@@ -6494,29 +6495,29 @@ xmlValidateElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc, xmlNodePtr elem) {
      * Entities references have to be handled separately
      */
     if (elem->type == XML_ENTITY_REF_NODE) {
-    return(1);
+        return(1);
     }
 
     ret &= xmlValidateOneElement(ctxt, doc, elem);
     if (elem->type == XML_ELEMENT_NODE) {
-    attr = elem->properties;
-    while (attr != NULL) {
-        value = xmlNodeListGetString(doc, attr->children, 0);
-        ret &= xmlValidateOneAttribute(ctxt, doc, elem, attr, value);
-        if (value != NULL)
-        xmlFree((char *)value);
-        attr= attr->next;
-    }
-    ns = elem->nsDef;
-    while (ns != NULL) {
-        if (elem->ns == NULL)
-        ret &= xmlValidateOneNamespace(ctxt, doc, elem, NULL,
-                           ns, ns->href);
-        else
-        ret &= xmlValidateOneNamespace(ctxt, doc, elem,
-                                       elem->ns->prefix, ns, ns->href);
-        ns = ns->next;
-    }
+        attr = elem->properties;
+        while (attr != NULL) {
+            value = xmlNodeListGetString(doc, attr->children, 0);
+            ret &= xmlValidateOneAttribute(ctxt, doc, elem, attr, value);
+            if (value != NULL)
+                xmlFree((char *)value);
+            attr= attr->next;
+        }
+        ns = elem->nsDef;
+        while (ns != NULL) {
+            if (elem->ns == NULL)
+                ret &= xmlValidateOneNamespace(ctxt, doc, elem, NULL,
+                                               ns, ns->href);
+            else
+                ret &= xmlValidateOneNamespace(ctxt, doc, elem,
+                                               elem->ns->prefix, ns, ns->href);
+            ns = ns->next;
+        }
     }
     child = elem->children;
     while (child != NULL) {
@@ -6536,78 +6537,78 @@ xmlValidateElement(xmlValidCtxtPtr ctxt, xmlDocPtr doc, xmlNodePtr elem) {
  */
 static void
 xmlValidateRef(xmlRefPtr ref, xmlValidCtxtPtr ctxt,
-                       const xmlChar *name) {
+                           const xmlChar *name) {
     xmlAttrPtr id;
     xmlAttrPtr attr;
 
     if (ref == NULL)
-    return;
+        return;
     if ((ref->attr == NULL) && (ref->name == NULL))
-    return;
+        return;
     attr = ref->attr;
     if (attr == NULL) {
-    xmlChar *dup, *str = NULL, *cur, save;
+        xmlChar *dup, *str = NULL, *cur, save;
 
-    dup = xmlStrdup(name);
-    if (dup == NULL) {
-        ctxt->valid = 0;
-        return;
-    }
-    cur = dup;
-    while (*cur != 0) {
-        str = cur;
-        while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
-        save = *cur;
-        *cur = 0;
-        id = xmlGetID(ctxt->doc, str);
-        if (id == NULL) {
-        xmlErrValidNodeNr(ctxt, NULL, XML_DTD_UNKNOWN_ID,
-       "attribute %s line %d references an unknown ID \"%s\"\n",
-               ref->name, ref->lineno, str);
-        ctxt->valid = 0;
+        dup = xmlStrdup(name);
+        if (dup == NULL) {
+            ctxt->valid = 0;
+            return;
         }
-        if (save == 0)
-        break;
-        *cur = save;
-        while (IS_BLANK_CH(*cur)) cur++;
-    }
-    xmlFree(dup);
+        cur = dup;
+        while (*cur != 0) {
+            str = cur;
+            while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
+            save = *cur;
+            *cur = 0;
+            id = xmlGetID(ctxt->doc, str);
+            if (id == NULL) {
+                xmlErrValidNodeNr(ctxt, NULL, XML_DTD_UNKNOWN_ID,
+           "attribute %s line %d references an unknown ID \"%s\"\n",
+                       ref->name, ref->lineno, str);
+                ctxt->valid = 0;
+            }
+            if (save == 0)
+                break;
+            *cur = save;
+            while (IS_BLANK_CH(*cur)) cur++;
+        }
+        xmlFree(dup);
     } else if (attr->atype == XML_ATTRIBUTE_IDREF) {
-    id = xmlGetID(ctxt->doc, name);
-    if (id == NULL) {
-        xmlErrValidNode(ctxt, attr->parent, XML_DTD_UNKNOWN_ID,
-       "IDREF attribute %s references an unknown ID \"%s\"\n",
-           attr->name, name, NULL);
-        ctxt->valid = 0;
-    }
-    } else if (attr->atype == XML_ATTRIBUTE_IDREFS) {
-    xmlChar *dup, *str = NULL, *cur, save;
-
-    dup = xmlStrdup(name);
-    if (dup == NULL) {
-        xmlVErrMemory(ctxt, "IDREFS split");
-        ctxt->valid = 0;
-        return;
-    }
-    cur = dup;
-    while (*cur != 0) {
-        str = cur;
-        while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
-        save = *cur;
-        *cur = 0;
-        id = xmlGetID(ctxt->doc, str);
+        id = xmlGetID(ctxt->doc, name);
         if (id == NULL) {
-        xmlErrValidNode(ctxt, attr->parent, XML_DTD_UNKNOWN_ID,
-       "IDREFS attribute %s references an unknown ID \"%s\"\n",
-                 attr->name, str, NULL);
-        ctxt->valid = 0;
+            xmlErrValidNode(ctxt, attr->parent, XML_DTD_UNKNOWN_ID,
+           "IDREF attribute %s references an unknown ID \"%s\"\n",
+                   attr->name, name, NULL);
+            ctxt->valid = 0;
         }
-        if (save == 0)
-        break;
-        *cur = save;
-        while (IS_BLANK_CH(*cur)) cur++;
-    }
-    xmlFree(dup);
+    } else if (attr->atype == XML_ATTRIBUTE_IDREFS) {
+        xmlChar *dup, *str = NULL, *cur, save;
+
+        dup = xmlStrdup(name);
+        if (dup == NULL) {
+            xmlVErrMemory(ctxt, "IDREFS split");
+            ctxt->valid = 0;
+            return;
+        }
+        cur = dup;
+        while (*cur != 0) {
+            str = cur;
+            while ((*cur != 0) && (!IS_BLANK_CH(*cur))) cur++;
+            save = *cur;
+            *cur = 0;
+            id = xmlGetID(ctxt->doc, str);
+            if (id == NULL) {
+                xmlErrValidNode(ctxt, attr->parent, XML_DTD_UNKNOWN_ID,
+           "IDREFS attribute %s references an unknown ID \"%s\"\n",
+                             attr->name, str, NULL);
+                ctxt->valid = 0;
+            }
+            if (save == 0)
+                break;
+            *cur = save;
+            while (IS_BLANK_CH(*cur)) cur++;
+        }
+        xmlFree(dup);
     }
 }
 
@@ -6621,9 +6622,9 @@ xmlValidateRef(xmlRefPtr ref, xmlValidCtxtPtr ctxt,
 static int
 xmlWalkValidateList(const void *data, void *user)
 {
-    xmlValidateMemoPtr memo = (xmlValidateMemoPtr)user;
-    xmlValidateRef((xmlRefPtr)data, memo->ctxt, memo->name);
-    return 1;
+        xmlValidateMemoPtr memo = (xmlValidateMemoPtr)user;
+        xmlValidateRef((xmlRefPtr)data, memo->ctxt, memo->name);
+        return 1;
 }
 
 /**
@@ -6640,7 +6641,7 @@ xmlValidateCheckRefCallback(void *payload, void *data, const xmlChar *name) {
     xmlValidateMemo memo;
 
     if (ref_list == NULL)
-    return;
+        return;
     memo.ctxt = ctxt;
     memo.name = name;
 
@@ -6672,8 +6673,8 @@ xmlValidateDocumentFinal(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
         return(0);
     if (doc == NULL) {
         xmlErrValid(ctxt, XML_DTD_NO_DOC,
-        "xmlValidateDocumentFinal: doc == NULL\n", NULL);
-    return(0);
+                "xmlValidateDocumentFinal: doc == NULL\n", NULL);
+        return(0);
     }
 
     /* trick to get correct line id report */
@@ -6728,9 +6729,9 @@ xmlValidateDtd(xmlValidCtxtPtr ctxt, xmlDocPtr doc, xmlDtdPtr dtd) {
     doc->intSubset = NULL;
     ret = xmlValidateRoot(ctxt, doc);
     if (ret == 0) {
-    doc->extSubset = oldExt;
-    doc->intSubset = oldInt;
-    return(ret);
+        doc->extSubset = oldExt;
+        doc->intSubset = oldInt;
+        return(ret);
     }
     if (doc->ids != NULL) {
           xmlFreeIDTable(doc->ids);
@@ -6750,28 +6751,28 @@ xmlValidateDtd(xmlValidCtxtPtr ctxt, xmlDocPtr doc, xmlDtdPtr dtd) {
 
 static void
 xmlValidateNotationCallback(void *payload, void *data,
-                        const xmlChar *name ATTRIBUTE_UNUSED) {
+                            const xmlChar *name ATTRIBUTE_UNUSED) {
     xmlEntityPtr cur = (xmlEntityPtr) payload;
     xmlValidCtxtPtr ctxt = (xmlValidCtxtPtr) data;
     if (cur == NULL)
-    return;
+        return;
     if (cur->etype == XML_EXTERNAL_GENERAL_UNPARSED_ENTITY) {
-    xmlChar *notation = cur->content;
+        xmlChar *notation = cur->content;
 
-    if (notation != NULL) {
-        int ret;
+        if (notation != NULL) {
+            int ret;
 
-        ret = xmlValidateNotationUse(ctxt, cur->doc, notation);
-        if (ret != 1) {
-        ctxt->valid = 0;
+            ret = xmlValidateNotationUse(ctxt, cur->doc, notation);
+            if (ret != 1) {
+                ctxt->valid = 0;
+            }
         }
-    }
     }
 }
 
 static void
 xmlValidateAttributeCallback(void *payload, void *data,
-                         const xmlChar *name ATTRIBUTE_UNUSED) {
+                             const xmlChar *name ATTRIBUTE_UNUSED) {
     xmlAttributePtr cur = (xmlAttributePtr) payload;
     xmlValidCtxtPtr ctxt = (xmlValidCtxtPtr) data;
     int ret;
@@ -6779,65 +6780,65 @@ xmlValidateAttributeCallback(void *payload, void *data,
     xmlElementPtr elem = NULL;
 
     if (cur == NULL)
-    return;
+        return;
     switch (cur->atype) {
-    case XML_ATTRIBUTE_CDATA:
-    case XML_ATTRIBUTE_ID:
-    case XML_ATTRIBUTE_IDREF    :
-    case XML_ATTRIBUTE_IDREFS:
-    case XML_ATTRIBUTE_NMTOKEN:
-    case XML_ATTRIBUTE_NMTOKENS:
-    case XML_ATTRIBUTE_ENUMERATION:
-        break;
-    case XML_ATTRIBUTE_ENTITY:
-    case XML_ATTRIBUTE_ENTITIES:
-    case XML_ATTRIBUTE_NOTATION:
-        if (cur->defaultValue != NULL) {
+        case XML_ATTRIBUTE_CDATA:
+        case XML_ATTRIBUTE_ID:
+        case XML_ATTRIBUTE_IDREF        :
+        case XML_ATTRIBUTE_IDREFS:
+        case XML_ATTRIBUTE_NMTOKEN:
+        case XML_ATTRIBUTE_NMTOKENS:
+        case XML_ATTRIBUTE_ENUMERATION:
+            break;
+        case XML_ATTRIBUTE_ENTITY:
+        case XML_ATTRIBUTE_ENTITIES:
+        case XML_ATTRIBUTE_NOTATION:
+            if (cur->defaultValue != NULL) {
 
-        ret = xmlValidateAttributeValue2(ctxt, ctxt->doc, cur->name,
-                                     cur->atype, cur->defaultValue);
-        if ((ret == 0) && (ctxt->valid == 1))
-            ctxt->valid = 0;
-        }
-        if (cur->tree != NULL) {
-        xmlEnumerationPtr tree = cur->tree;
-        while (tree != NULL) {
-            ret = xmlValidateAttributeValue2(ctxt, ctxt->doc,
-                    cur->name, cur->atype, tree->name);
-            if ((ret == 0) && (ctxt->valid == 1))
-            ctxt->valid = 0;
-            tree = tree->next;
-        }
-        }
+                ret = xmlValidateAttributeValue2(ctxt, ctxt->doc, cur->name,
+                                                 cur->atype, cur->defaultValue);
+                if ((ret == 0) && (ctxt->valid == 1))
+                    ctxt->valid = 0;
+            }
+            if (cur->tree != NULL) {
+                xmlEnumerationPtr tree = cur->tree;
+                while (tree != NULL) {
+                    ret = xmlValidateAttributeValue2(ctxt, ctxt->doc,
+                                    cur->name, cur->atype, tree->name);
+                    if ((ret == 0) && (ctxt->valid == 1))
+                        ctxt->valid = 0;
+                    tree = tree->next;
+                }
+            }
     }
     if (cur->atype == XML_ATTRIBUTE_NOTATION) {
-    doc = cur->doc;
-    if (cur->elem == NULL) {
-        xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
-           "xmlValidateAttributeCallback(%s): internal error\n",
-           (const char *) cur->name);
-        return;
-    }
+        doc = cur->doc;
+        if (cur->elem == NULL) {
+            xmlErrValid(ctxt, XML_ERR_INTERNAL_ERROR,
+                   "xmlValidateAttributeCallback(%s): internal error\n",
+                   (const char *) cur->name);
+            return;
+        }
 
-    if (doc != NULL)
-        elem = xmlGetDtdElementDesc(doc->intSubset, cur->elem);
-    if ((elem == NULL) && (doc != NULL))
-        elem = xmlGetDtdElementDesc(doc->extSubset, cur->elem);
-    if ((elem == NULL) && (cur->parent != NULL) &&
-        (cur->parent->type == XML_DTD_NODE))
-        elem = xmlGetDtdElementDesc((xmlDtdPtr) cur->parent, cur->elem);
-    if (elem == NULL) {
-        xmlErrValidNode(ctxt, NULL, XML_DTD_UNKNOWN_ELEM,
-           "attribute %s: could not find decl for element %s\n",
-           cur->name, cur->elem, NULL);
-        return;
-    }
-    if (elem->etype == XML_ELEMENT_TYPE_EMPTY) {
-        xmlErrValidNode(ctxt, NULL, XML_DTD_EMPTY_NOTATION,
-           "NOTATION attribute %s declared for EMPTY element %s\n",
-           cur->name, cur->elem, NULL);
-        ctxt->valid = 0;
-    }
+        if (doc != NULL)
+            elem = xmlGetDtdElementDesc(doc->intSubset, cur->elem);
+        if ((elem == NULL) && (doc != NULL))
+            elem = xmlGetDtdElementDesc(doc->extSubset, cur->elem);
+        if ((elem == NULL) && (cur->parent != NULL) &&
+            (cur->parent->type == XML_DTD_NODE))
+            elem = xmlGetDtdElementDesc((xmlDtdPtr) cur->parent, cur->elem);
+        if (elem == NULL) {
+            xmlErrValidNode(ctxt, NULL, XML_DTD_UNKNOWN_ELEM,
+                   "attribute %s: could not find decl for element %s\n",
+                   cur->name, cur->elem, NULL);
+            return;
+        }
+        if (elem->etype == XML_ELEMENT_TYPE_EMPTY) {
+            xmlErrValidNode(ctxt, NULL, XML_DTD_EMPTY_NOTATION,
+                   "NOTATION attribute %s declared for EMPTY element %s\n",
+                   cur->name, cur->elem, NULL);
+            ctxt->valid = 0;
+        }
     }
 }
 
@@ -6866,26 +6867,26 @@ xmlValidateDtdFinal(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
 
     if ((doc == NULL) || (ctxt == NULL)) return(0);
     if ((doc->intSubset == NULL) && (doc->extSubset == NULL))
-    return(0);
+        return(0);
     ctxt->doc = doc;
     ctxt->valid = 1;
     dtd = doc->intSubset;
     if ((dtd != NULL) && (dtd->attributes != NULL)) {
-    table = (xmlAttributeTablePtr) dtd->attributes;
-    xmlHashScan(table, xmlValidateAttributeCallback, ctxt);
+        table = (xmlAttributeTablePtr) dtd->attributes;
+        xmlHashScan(table, xmlValidateAttributeCallback, ctxt);
     }
     if ((dtd != NULL) && (dtd->entities != NULL)) {
-    entities = (xmlEntitiesTablePtr) dtd->entities;
-    xmlHashScan(entities, xmlValidateNotationCallback, ctxt);
+        entities = (xmlEntitiesTablePtr) dtd->entities;
+        xmlHashScan(entities, xmlValidateNotationCallback, ctxt);
     }
     dtd = doc->extSubset;
     if ((dtd != NULL) && (dtd->attributes != NULL)) {
-    table = (xmlAttributeTablePtr) dtd->attributes;
-    xmlHashScan(table, xmlValidateAttributeCallback, ctxt);
+        table = (xmlAttributeTablePtr) dtd->attributes;
+        xmlHashScan(table, xmlValidateAttributeCallback, ctxt);
     }
     if ((dtd != NULL) && (dtd->entities != NULL)) {
-    entities = (xmlEntitiesTablePtr) dtd->entities;
-    xmlHashScan(entities, xmlValidateNotationCallback, ctxt);
+        entities = (xmlEntitiesTablePtr) dtd->entities;
+        xmlHashScan(entities, xmlValidateNotationCallback, ctxt);
     }
     return(ctxt->valid);
 }
@@ -6913,39 +6914,39 @@ xmlValidateDocument(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
         return(0);
     if ((doc->intSubset == NULL) && (doc->extSubset == NULL)) {
         xmlErrValid(ctxt, XML_DTD_NO_DTD,
-                "no DTD found!\n", NULL);
-    return(0);
-    }
-    if ((doc->intSubset != NULL) && ((doc->intSubset->SystemID != NULL) ||
-    (doc->intSubset->ExternalID != NULL)) && (doc->extSubset == NULL)) {
-    xmlChar *sysID;
-    if (doc->intSubset->SystemID != NULL) {
-        sysID = xmlBuildURI(doc->intSubset->SystemID,
-            doc->URL);
-        if (sysID == NULL) {
-            xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
-            "Could not build URI for external subset \"%s\"\n",
-            (const char *) doc->intSubset->SystemID);
-        return 0;
-        }
-    } else
-        sysID = NULL;
-        doc->extSubset = xmlParseDTD(doc->intSubset->ExternalID,
-            (const xmlChar *)sysID);
-    if (sysID != NULL)
-        xmlFree(sysID);
-        if (doc->extSubset == NULL) {
-        if (doc->intSubset->SystemID != NULL) {
-        xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
-               "Could not load the external subset \"%s\"\n",
-               (const char *) doc->intSubset->SystemID);
-        } else {
-        xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
-               "Could not load the external subset \"%s\"\n",
-               (const char *) doc->intSubset->ExternalID);
-        }
+                    "no DTD found!\n", NULL);
         return(0);
     }
+    if ((doc->intSubset != NULL) && ((doc->intSubset->SystemID != NULL) ||
+        (doc->intSubset->ExternalID != NULL)) && (doc->extSubset == NULL)) {
+        xmlChar *sysID;
+        if (doc->intSubset->SystemID != NULL) {
+            sysID = xmlBuildURI(doc->intSubset->SystemID,
+                        doc->URL);
+            if (sysID == NULL) {
+                xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
+                        "Could not build URI for external subset \"%s\"\n",
+                        (const char *) doc->intSubset->SystemID);
+                return 0;
+            }
+        } else
+            sysID = NULL;
+        doc->extSubset = xmlParseDTD(doc->intSubset->ExternalID,
+                        (const xmlChar *)sysID);
+        if (sysID != NULL)
+            xmlFree(sysID);
+        if (doc->extSubset == NULL) {
+            if (doc->intSubset->SystemID != NULL) {
+                xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
+                       "Could not load the external subset \"%s\"\n",
+                       (const char *) doc->intSubset->SystemID);
+            } else {
+                xmlErrValid(ctxt, XML_DTD_LOAD_ERROR,
+                       "Could not load the external subset \"%s\"\n",
+                       (const char *) doc->intSubset->ExternalID);
+            }
+            return(0);
+        }
     }
 
     if (doc->ids != NULL) {
@@ -6966,9 +6967,9 @@ xmlValidateDocument(xmlValidCtxtPtr ctxt, xmlDocPtr doc) {
 }
 
 /************************************************************************
- *                                  *
- *      Routines for dynamic validation editing         *
- *                                  *
+ *                                                                      *
+ *              Routines for dynamic validation editing                 *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -6994,24 +6995,24 @@ xmlValidGetPotentialChildren(xmlElementContent *ctree,
     if (*len >= max) return(*len);
 
     switch (ctree->type) {
-    case XML_ELEMENT_CONTENT_PCDATA:
-        for (i = 0; i < *len;i++)
-        if (xmlStrEqual(BAD_CAST "#PCDATA", names[i])) return(*len);
-        names[(*len)++] = BAD_CAST "#PCDATA";
-        break;
-    case XML_ELEMENT_CONTENT_ELEMENT:
-        for (i = 0; i < *len;i++)
-        if (xmlStrEqual(ctree->name, names[i])) return(*len);
-        names[(*len)++] = ctree->name;
-        break;
-    case XML_ELEMENT_CONTENT_SEQ:
-        xmlValidGetPotentialChildren(ctree->c1, names, len, max);
-        xmlValidGetPotentialChildren(ctree->c2, names, len, max);
-        break;
-    case XML_ELEMENT_CONTENT_OR:
-        xmlValidGetPotentialChildren(ctree->c1, names, len, max);
-        xmlValidGetPotentialChildren(ctree->c2, names, len, max);
-        break;
+        case XML_ELEMENT_CONTENT_PCDATA:
+            for (i = 0; i < *len;i++)
+                if (xmlStrEqual(BAD_CAST "#PCDATA", names[i])) return(*len);
+            names[(*len)++] = BAD_CAST "#PCDATA";
+            break;
+        case XML_ELEMENT_CONTENT_ELEMENT:
+            for (i = 0; i < *len;i++)
+                if (xmlStrEqual(ctree->name, names[i])) return(*len);
+            names[(*len)++] = ctree->name;
+            break;
+        case XML_ELEMENT_CONTENT_SEQ:
+            xmlValidGetPotentialChildren(ctree->c1, names, len, max);
+            xmlValidGetPotentialChildren(ctree->c2, names, len, max);
+            break;
+        case XML_ELEMENT_CONTENT_OR:
+            xmlValidGetPotentialChildren(ctree->c1, names, len, max);
+            xmlValidGetPotentialChildren(ctree->c2, names, len, max);
+            break;
    }
 
    return(*len);
@@ -7077,7 +7078,7 @@ xmlValidGetValidElements(xmlNode *prev, xmlNode *next, const xmlChar **names,
     if (max <= 0) return(-1);
 
     memset(&vctxt, 0, sizeof (xmlValidCtxt));
-    vctxt.error = xmlNoValidityErr; /* this suppresses err/warn output */
+    vctxt.error = xmlNoValidityErr;     /* this suppresses err/warn output */
 
     nb_valid_elements = 0;
     ref_node = prev ? prev : next;
@@ -7124,18 +7125,18 @@ xmlValidGetValidElements(xmlNode *prev, xmlNode *next, const xmlChar **names,
      * still valid
      */
     nb_elements = xmlValidGetPotentialChildren(element_desc->content,
-               elements, &nb_elements, 256);
+                       elements, &nb_elements, 256);
 
     for (i = 0;i < nb_elements;i++) {
-    test_node->name = elements[i];
-    if (xmlValidateOneElement(&vctxt, parent->doc, parent)) {
-        int j;
+        test_node->name = elements[i];
+        if (xmlValidateOneElement(&vctxt, parent->doc, parent)) {
+            int j;
 
-        for (j = 0; j < nb_valid_elements;j++)
-        if (xmlStrEqual(elements[i], names[j])) break;
-        names[nb_valid_elements++] = elements[i];
-        if (nb_valid_elements >= max) break;
-    }
+            for (j = 0; j < nb_valid_elements;j++)
+                if (xmlStrEqual(elements[i], names[j])) break;
+            names[nb_valid_elements++] = elements[i];
+            if (nb_valid_elements >= max) break;
+        }
     }
 
     /*

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xpath.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xpath.c
@@ -488,9 +488,9 @@ int wrap_cmp( xmlNodePtr x, xmlNodePtr y );
  *                                                                      *
  ************************************************************************/
 
-double xmlXPathNAN;
-double xmlXPathPINF;
-double xmlXPathNINF;
+double xmlXPathNAN = 0.0;
+double xmlXPathPINF = 0.0;
+double xmlXPathNINF = 0.0;
 
 /**
  * xmlXPathInit:
@@ -9260,52 +9260,45 @@ xmlXPathSubstringAfterFunction(xmlXPathParserContextPtr ctxt, int nargs) {
  */
 void
 xmlXPathNormalizeFunction(xmlXPathParserContextPtr ctxt, int nargs) {
-  xmlXPathObjectPtr obj = NULL;
-  xmlChar *source = NULL;
-  xmlBufPtr target;
-  xmlChar blank;
+    xmlChar *source, *target;
+    int blank;
 
-  if (ctxt == NULL) return;
-  if (nargs == 0) {
-    /* Use current context node */
-      valuePush(ctxt,
-          xmlXPathCacheWrapString(ctxt->context,
-            xmlXPathCastNodeToString(ctxt->context->node)));
-    nargs = 1;
-  }
+    if (ctxt == NULL) return;
+    if (nargs == 0) {
+        /* Use current context node */
+        valuePush(ctxt,
+            xmlXPathCacheWrapString(ctxt->context,
+                xmlXPathCastNodeToString(ctxt->context->node)));
+        nargs = 1;
+    }
 
-  CHECK_ARITY(1);
-  CAST_TO_STRING;
-  CHECK_TYPE(XPATH_STRING);
-  obj = valuePop(ctxt);
-  source = obj->stringval;
-
-  target = xmlBufCreate();
-  if (target && source) {
+    CHECK_ARITY(1);
+    CAST_TO_STRING;
+    CHECK_TYPE(XPATH_STRING);
+    source = ctxt->value->stringval;
+    if (source == NULL)
+        return;
+    target = source;
 
     /* Skip leading whitespaces */
     while (IS_BLANK_CH(*source))
-      source++;
+        source++;
 
     /* Collapse intermediate whitespaces, and skip trailing whitespaces */
     blank = 0;
     while (*source) {
-      if (IS_BLANK_CH(*source)) {
-        blank = 0x20;
-      } else {
-        if (blank) {
-          xmlBufAdd(target, &blank, 1);
-          blank = 0;
+        if (IS_BLANK_CH(*source)) {
+            blank = 1;
+        } else {
+            if (blank) {
+                *target++ = 0x20;
+                blank = 0;
+            }
+            *target++ = *source;
         }
-        xmlBufAdd(target, source, 1);
-      }
-      source++;
+        source++;
     }
-    valuePush(ctxt, xmlXPathCacheNewString(ctxt->context,
-        xmlBufContent(target)));
-    xmlBufFree(target);
-  }
-  xmlXPathReleaseObject(ctxt->context, obj);
+    *target = 0;
 }
 
 /**

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/config.h
@@ -46,7 +46,7 @@
    function. */
 #ifndef isinf
 #define isinf(d) ((_fpclass(d) == _FPCLASS_PINF) ? 1 \
-    : ((_fpclass(d) == _FPCLASS_NINF) ? -1 : 0))
+                 : ((_fpclass(d) == _FPCLASS_NINF) ? -1 : 0))
 #endif
 /* _isnan(x) returns nonzero if (x == NaN) and zero otherwise. */
 #ifndef isnan

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.13"
+#define LIBXML_DOTTED_VERSION "2.9.14"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20913
+#define LIBXML_VERSION 20914
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20913"
+#define LIBXML_VERSION_STRING "20914"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20913);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20914);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/UPDATING.txt
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/UPDATING.txt
@@ -1,0 +1,39 @@
+Updating libxslt in OpenJFX:
+
+1. Download respective libxslt source tarball from here: https://gitlab.gnome.org/GNOME/libxslt/-/releases.
+Alternatively we can also clone the libxslt repo from github. (url- https://gitlab.gnome.org/GNOME/libxslt.git)
+
+2. Extract contents into 'modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src' directory.
+3. We do not have any local changes in the libxslt source but libxslt source needs to be configured before integrating into JavaFX.
+Below are platform wise steps to configure.
+
+- For windows
+4. Configure libxslt.
+        > cd modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/win32
+        > cscript configure.js compiler=msvc xslt_debug=no  iconv=no mem_debug=no modules=no  zlib=no profiler=no trio=no
+        - Above command generates a header file 'src/config.h' file (on all platforms) and libxslt\src\libxslt\xsltconfig.h.
+4.1 Copy `libxslt\src\config.h` to `libxslt\win32\config.h'. config.h file defines several macros to control libxslt features.
+We do not require all of the features to be enabled.
+4.2 Compare the generated `libxslt\src\config.h` with existing `libxslt\win32\config.h' and update the macros based on the output of ./configure.
+4.3 Update version related info in libxslt\src\libxslt\xsltconfig.h.
+
+5. Remove files & directories which are not relevant to JavaFX WebKit.
+
+- For Mac
+6. Prerequisites to compile libxslt: libtool, autoconf, automake
+7. Configure libxslt.
+        > cd modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src
+        > ./autogen.sh
+        > ./configure
+7.1 Copy `libxslt/src/config.h` to `libxslt/mac/config.h` and follow same guidelines as Windows to retain changes from our repo.
+
+- For Linux
+8. Prerequisites to compile libxslt: libtool, autoconf, automake
+9. Configure libxslt.
+        > cd modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src
+        > ./configure
+9.1 Copy `libxslt/src/config.h` to `libxslt/linux/config.h` and follow same guidelines as Windows to retain changes from our repo.
+
+10. Update version info in 'modules/javafx.web/src/main/legal/libxslt.md'. Also, update copyright if any new files are added.
+
+11. Remove tabs and trailing whitespaces from source files(.h and .c).

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/config.h
@@ -2,7 +2,7 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Define to 1 if you have the `clock_gettime' function. */
-
+#define HAVE_CLOCK_GETTIME 1
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
@@ -29,7 +29,7 @@
 #define HAVE_FTIME 1
 
 /* Define if gcrypt library is available. */
-
+/* #undef HAVE_GCRYPT */
 
 /* Define to 1 if you have the `gettimeofday' function. */
 #define HAVE_GETTIMEOFDAY 1
@@ -53,7 +53,7 @@
 #define HAVE_LOCALE_H 1
 
 /* Define to 1 if you have the `localtime' function. */
-
+#define HAVE_LOCALTIME 1
 
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
@@ -140,13 +140,12 @@
 #define HAVE_VSPRINTF 1
 
 /* Define to 1 if you have the <xlocale.h> header file. */
-
+/* #undef HAVE_XLOCALE_H */
 
 /* Define to 1 if you have the `_stat' function. */
 /* #undef HAVE__STAT */
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
 
 /* Name of package */
@@ -159,7 +158,7 @@
 #define PACKAGE_NAME "libxslt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxslt 1.1.34"
+#define PACKAGE_STRING "libxslt 1.1.35"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxslt"
@@ -168,7 +167,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.1.34"
+#define PACKAGE_VERSION "1.1.35"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
@@ -196,7 +195,7 @@
 
 
 /* Version number of package */
-#define VERSION "1.1.34"
+#define VERSION "1.1.35"
 
 /* Define if debugging support is enabled */
 /* #undef WITH_DEBUGGER */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/libexslt/exsltconfig.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/libexslt/exsltconfig.h
@@ -18,7 +18,7 @@ extern "C" {
  *
  * the version string like "1.2.3"
  */
-#define LIBEXSLT_DOTTED_VERSION "1.1.34"
+#define LIBEXSLT_DOTTED_VERSION "0.8.20"
 
 /**
  * LIBEXSLT_VERSION:
@@ -46,7 +46,7 @@ extern "C" {
  *
  * Whether crypto support is configured into exslt
  */
-#if 1
+#if 0
 #define EXSLT_CRYPTO_ENABLED
 #endif
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/libxslt/xsltwin32config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/linux/libxslt/xsltwin32config.h
@@ -23,21 +23,21 @@ extern "C" {
  *
  * the version string like "1.2.3"
  */
-#define LIBXSLT_DOTTED_VERSION "1.1.34"
+#define LIBXSLT_DOTTED_VERSION "1.1.35"
 
 /**
  * LIBXSLT_VERSION:
  *
  * the version number: 1.2.3 value is 1002003
  */
-#define LIBXSLT_VERSION 10134
+#define LIBXSLT_VERSION 10135
 
 /**
  * LIBXSLT_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "1002003"
  */
-#define LIBXSLT_VERSION_STRING "10134"
+#define LIBXSLT_VERSION_STRING "10135"
 
 /**
  * LIBXSLT_VERSION_EXTRA:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/mac/config.h
@@ -53,7 +53,7 @@
 #define HAVE_LOCALE_H 1
 
 /* Define to 1 if you have the `localtime' function. */
-
+#define HAVE_LOCALTIME 1
 
 /* Define to 1 if you have the `localtime_r' function. */
 #define HAVE_LOCALTIME_R 1
@@ -61,8 +61,8 @@
 /* Define to 1 if you have the <math.h> header file. */
 #define HAVE_MATH_H 1
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
 
 /* Define to 1 if you have the <nan.h> header file. */
 /* #undef HAVE_NAN_H */
@@ -93,6 +93,9 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -139,6 +142,9 @@
 /* Define to 1 if you have the `vsprintf' function. */
 #define HAVE_VSPRINTF 1
 
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
 /* Define to 1 if you have the <xlocale.h> header file. */
 #define HAVE_XLOCALE_H 1
 
@@ -158,7 +164,7 @@
 #define PACKAGE_NAME "libxslt"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxslt 1.1.34"
+#define PACKAGE_STRING "libxslt 1.1.35"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxslt"
@@ -167,9 +173,11 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.1.34"
+#define PACKAGE_VERSION "1.1.35"
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
 /* Enable extensions on AIX 3, Interix.  */
@@ -195,7 +203,7 @@
 
 
 /* Version number of package */
-#define VERSION "1.1.34"
+#define VERSION "1.1.35"
 
 /* Define if debugging support is enabled */
 /* #undef WITH_DEBUGGER */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/INSTALL
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/INSTALL
@@ -4,9 +4,10 @@ Requirements:
 =============
 
 this library requires a recent version of libxml2 which you can grab from
-either the GNOME FTP or the xmlsoft.org server:
+either the GNOME download server or the GitLab release page:
 
-  ftp://xmlsoft.org/
+    https://gitlab.gnome.org/GNOME/libxml2/-/releases
+    https://download.gnome.org/sources/libxml2/
 
 When installing from a distribution package like a tar.gz:
 ==========================================================

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/Makefile.am
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST = xsltConf.sh.in xslt-config.in libxslt.spec libxslt.spec.in \
              FEATURES TODO Copyright libxslt.m4 \
 	     win32/libxslt/libxslt.def win32/libxslt/libxslt.dsw \
 	     win32/libxslt/libxslt_so.dsp win32/libxslt/xsltproc.dsp \
+	     CMakeLists.txt config.h.cmake.in FindGcrypt.cmake libxslt-config.cmake.in libxslt-config.cmake.cmake.in \
 	     $(CVS_EXTRA_DIST)
 
 ## We create xsltConf.sh here and not from configure because we want
@@ -72,6 +73,9 @@ rpm: cleantar
 
 pkgconfigdir=$(libdir)/pkgconfig
 pkgconfig_DATA = libxslt.pc libexslt.pc
+
+cmakedir = $(libdir)/cmake/libxslt
+cmake_DATA = FindGcrypt.cmake libxslt-config.cmake
 
 m4datadir = $(datadir)/aclocal
 m4data_DATA = libxslt.m4

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/README
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/README
@@ -2,12 +2,12 @@
      XSLT support for libxml2 (XML toolkit from the GNOME project)
 
 Full documentation is available on-line at
-    http://xmlsoft.org/XSLT/
+    https://gitlab.gnome.org/GNOME/libxslt/-/wikis
 
 This code is released under the MIT Licence see the Copyright file.
  
 To report bugs, follow the instructions at:
-  http://xmlsoft.org/XSLT/bugs.html
+    https://gitlab.gnome.org/GNOME/libxslt/-/issues
 
 A mailing-list xslt@gnome.org is available, to subscribe:
     http://mail.gnome.org/mailman/listinfo/xslt

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/config.h.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/config.h.in
@@ -60,8 +60,8 @@
 /* Define to 1 if you have the <math.h> header file. */
 #undef HAVE_MATH_H
 
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
+/* Define to 1 if you have the <minix/config.h> header file. */
+#undef HAVE_MINIX_CONFIG_H
 
 /* Define to 1 if you have the <nan.h> header file. */
 #undef HAVE_NAN_H
@@ -92,6 +92,9 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#undef HAVE_STDIO_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
@@ -138,14 +141,16 @@
 /* Define to 1 if you have the `vsprintf' function. */
 #undef HAVE_VSPRINTF
 
+/* Define to 1 if you have the <wchar.h> header file. */
+#undef HAVE_WCHAR_H
+
 /* Define to 1 if you have the <xlocale.h> header file. */
 #undef HAVE_XLOCALE_H
 
 /* Define to 1 if you have the `_stat' function. */
 #undef HAVE__STAT
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */
@@ -169,28 +174,96 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* Enable extensions on AIX 3, Interix.  */
 #ifndef _ALL_SOURCE
 # undef _ALL_SOURCE
 #endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# undef _DARWIN_C_SOURCE
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# undef __EXTENSIONS__
+#endif
 /* Enable GNU extensions on systems that have them.  */
 #ifndef _GNU_SOURCE
 # undef _GNU_SOURCE
 #endif
-/* Enable threading extensions on Solaris.  */
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# undef _HPUX_ALT_XOPEN_SOCKET_API
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+# undef _MINIX
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# undef _NETBSD_SOURCE
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# undef _OPENBSD_SOURCE
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+# undef _POSIX_SOURCE
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+# undef _POSIX_1_SOURCE
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
 #ifndef _POSIX_PTHREAD_SEMANTICS
 # undef _POSIX_PTHREAD_SEMANTICS
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# undef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# undef __STDC_WANT_IEC_60559_BFP_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# undef __STDC_WANT_IEC_60559_DFP_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# undef __STDC_WANT_IEC_60559_FUNCS_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# undef __STDC_WANT_IEC_60559_TYPES_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# undef __STDC_WANT_LIB_EXT2__
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# undef __STDC_WANT_MATH_SPEC_FUNCS__
 #endif
 /* Enable extensions on HP NonStop.  */
 #ifndef _TANDEM_SOURCE
 # undef _TANDEM_SOURCE
 #endif
-/* Enable general extensions on Solaris.  */
-#ifndef __EXTENSIONS__
-# undef __EXTENSIONS__
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+# undef _XOPEN_SOURCE
 #endif
 
 
@@ -202,13 +275,3 @@
 
 /* Define if profiling support is enabled */
 #undef WITH_PROFILER
-
-/* Define to 1 if on MINIX. */
-#undef _MINIX
-
-/* Define to 2 if the system does not provide POSIX.1 features except with
-   this defined. */
-#undef _POSIX_1_SOURCE
-
-/* Define to 1 if you need to in order for `stat' and other things to work. */
-#undef _POSIX_SOURCE

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/configure.ac
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ(2.63)
 
 m4_define([MAJOR_VERSION], [1])
 m4_define([MINOR_VERSION], [1])
-m4_define([MICRO_VERSION], [34])
+m4_define([MICRO_VERSION], [35])
 
 AC_INIT([libxslt], [MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION])
 AC_CONFIG_SRCDIR([libxslt/xslt.c])
@@ -109,6 +109,13 @@ AC_ARG_WITH(html-subdir, AS_HELP_STRING([--with-html-subdir=path],
 
 AC_SUBST(HTML_DIR)
 
+AC_ARG_ENABLE(rebuild-docs,
+[  --enable-rebuild-docs[[=yes/no]]  rebuild some generated docs [[default=no]]])
+if test "$enable_rebuild_docs" = "yes" -a "$srcdir" != "."; then
+  AC_MSG_ERROR([cannot rebuild docs when builddir != srcdir])
+fi
+AM_CONDITIONAL([REBUILD_DOCS], [test "$enable_rebuild_docs" = "yes"])
+
 dnl
 dnl Check the environment
 dnl
@@ -146,15 +153,18 @@ dnl Look for pthread.h, needed for testThreads
 case $host in
   *-mingw*) ;;
   *)
+WITH_THREADS=0
 THREAD_LIBS=""
 AC_CHECK_HEADER(pthread.h,
     AC_CHECK_LIB(pthread, pthread_join,[
        AC_DEFINE([HAVE_LIBPTHREAD], [], [Define if pthread library is there (-lpthread)])
        AC_DEFINE([HAVE_PTHREAD_H], [], [Define if <pthread.h> is there])
+       WITH_THREADS="1"
        THREAD_LIBS="-lpthread"]))
   ;;
 esac
 
+AC_SUBST(WITH_THREADS)
 AC_SUBST(THREAD_LIBS)
 
 dnl
@@ -230,76 +240,107 @@ dnl
 PYTHON_VERSION=
 PYTHON_INCLUDES=
 PYTHON_SITE_PACKAGES=
+PYTHON_TESTS=
 pythondir=
-AC_ARG_WITH(python, [  --with-python[=DIR]    Build Python bindings if found])
+AC_ARG_WITH(python,
+[  --with-python[[=DIR]]     build Python bindings if found])
+AC_ARG_WITH(python_install_dir,
+[  --with-python-install-dir=DIR
+                          install Python bindings in DIR])
 if test "$with_python" != "no" ; then
     if test -x "$with_python/bin/python"
     then
         echo Found python in $with_python/bin/python
         PYTHON="$with_python/bin/python"
     else
-	if test -x "$with_python"
-	then
-	    echo Found python in $with_python
-	    PYTHON="$with_python"
-	else
-            if test -x "$PYTHON"
+        if test -x "$with_python/python.exe"
+        then
+            echo Found python in $with_python/python.exe
+            PYTHON="$with_python/python.exe"
+        else
+            if test -x "$with_python"
             then
-                echo Found python in environment PYTHON=$PYTHON
-                with_python=`$PYTHON -c "import sys; print sys.exec_prefix"`
-	    else
-	        AC_PATH_PROG(PYTHON, python python2.4 python2.3 python2.2 python2.1 python2.0 python1.6 python1.5)
+                echo Found python in $with_python
+                PYTHON="$with_python"
+            else
+                if test -x "$PYTHON"
+                then
+                    echo Found python in environment PYTHON=$PYTHON
+                    with_python=`$PYTHON -c "import sys; print(sys.exec_prefix)"`
+                else
+                    AC_PATH_PROG(PYTHON, python python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python2.0 python1.6 python1.5)
+		fi
 	    fi
 	fi
     fi
     if test "$PYTHON" != ""
     then
-        echo "PYTHON is pointing at $PYTHON"
-        PYTHON_VERSION=`$PYTHON -c "import sys; print sys.version[[0:3]]"`
+        PYTHON_VERSION=`$PYTHON -c "from distutils import sysconfig; print(sysconfig.get_python_version())"`
+	PYTHON_INCLUDES=`$PYTHON -c "from distutils import sysconfig; print(sysconfig.get_python_inc())"`
+# does not work as it produce a /usr/lib/python path instead of/usr/lib64/python
+#
+#	PYTHON_SITE_PACKAGES=`$PYTHON -c "from distutils import sysconfig; print(sysconfig.get_python_lib())"`
 	echo Found Python version $PYTHON_VERSION
-	LIBXML2_PYTHON=`$PYTHON -c "try : import libxml2 ; print 1
-except: print 0"`
+  LIBXML2_PYTHON=`$PYTHON -c "import sys
+try:
+    import libxml2
+    sys.stdout.write('1')
+except:
+    sys.stdout.write('0')
+"`
 	if test "$LIBXML2_PYTHON" = "1"
 	then
 	    echo Found libxml2-python module
 	else
 	    echo Warning: Missing libxml2-python
-	fi
+  fi
     fi
-    if test "$PYTHON_VERSION" != ""
+    if test "$PYTHON_VERSION" != "" -a "$PYTHON_INCLUDES" = ""
     then
-	if test -r $with_python/include/python$PYTHON_VERSION/Python.h -a \
-	   -d $with_python/lib/python$PYTHON_VERSION/site-packages
+	if test -r $with_python/include/python$PYTHON_VERSION/Python.h
 	then
 	    PYTHON_INCLUDES=$with_python/include/python$PYTHON_VERSION
-	    PYTHON_SITE_PACKAGES='$(libdir)/python$(PYTHON_VERSION)/site-packages'
 	else
 	    if test -r $prefix/include/python$PYTHON_VERSION/Python.h
 	    then
 	        PYTHON_INCLUDES=$prefix/include/python$PYTHON_VERSION
-		PYTHON_SITE_PACKAGES='$(libdir)/python$(PYTHON_VERSION)/site-packages'
 	    else
 		if test -r /usr/include/python$PYTHON_VERSION/Python.h
 		then
 		    PYTHON_INCLUDES=/usr/include/python$PYTHON_VERSION
-		    PYTHON_SITE_PACKAGES='$(libdir)/python$(PYTHON_VERSION)/site-packages'
 		else
-		    echo could not find python$PYTHON_VERSION/Python.h
+	            if test -r $with_python/include/Python.h
+	            then
+	                PYTHON_INCLUDES=$with_python/include
+	            else
+		        echo could not find python$PYTHON_VERSION/Python.h or $with_python/include/Python.h
+		    fi
 		fi
 	    fi
-	    if test ! -d "$PYTHON_SITE_PACKAGES"
+	fi
+    fi
+    if test "$with_python_install_dir" != ""
+    then
+	PYTHON_SITE_PACKAGES="$with_python_install_dir"
+    fi
+    if test "$PYTHON_VERSION" != "" -a "$PYTHON_SITE_PACKAGES" = ""
+    then
+	if test -d $libdir/python$PYTHON_VERSION/site-packages
+	then
+	    PYTHON_SITE_PACKAGES=$libdir/python$PYTHON_VERSION/site-packages
+	else
+	    if test -d $with_python/lib/site-packages
 	    then
-		    PYTHON_SITE_PACKAGES=`$PYTHON -c "from distutils import sysconfig; print sysconfig.get_python_lib()"`
+		PYTHON_SITE_PACKAGES=$with_python/lib/site-packages
+	    else
+		PYTHON_SITE_PACKAGES=$($PYTHON -c 'from distutils import sysconfig; print(sysconfig.get_python_lib(True,False,"${exec_prefix}"))')
 	    fi
 	fi
-        PYTHON_LIBS=`python$PYTHON_VERSION-config --libs`
     fi
-    if test "$with_python" != ""
-    then
-        pythondir='$(PYTHON_SITE_PACKAGES)'
-    else
-        pythondir='$(libdir)/python$(PYTHON_VERSION)/site-packages'
-    fi
+    pythondir='$(PYTHON_SITE_PACKAGES)'
+    PYTHON_LIBS=`python$PYTHON_VERSION-config --ldflags`
+else
+    PYTHON=
 fi
 AM_CONDITIONAL(WITH_PYTHON, test "$PYTHON_INCLUDES" != "")
 if test "$PYTHON_INCLUDES" != ""
@@ -474,7 +515,7 @@ if test "${GCC}" != "yes" ; then
                ;;
     esac
 else
-    CFLAGS="${CFLAGS} -Wall -Wextra -Wformat=2 -Wmissing-format-attribute"
+    CFLAGS="${CFLAGS} -Wall -Wextra -Wformat=2 -Wmissing-format-attribute -Wshadow"
     case "${host}" in
           alpha*-*-linux* )
 	       CFLAGS="${CFLAGS} -mieee"
@@ -491,6 +532,7 @@ dnl
 
 build_shared_libs="yes"
 build_static_libs="yes"
+xml_config_dynamic=
 
 if test "$enable_shared" = "no"; then
     build_shared_libs="no"
@@ -515,10 +557,11 @@ if test "x$LIBXML_SRC" != "x"; then
         XML_CONFIG="${LIBXML_SRC}/xml2-config"
         LIBXML_CFLAGS="-I${LIBXML_SRC}/include"
         if test "$build_static_libs" = "no"; then
-            LIBXML_LIBS="-L${LIBXML_SRC} `$XML_CONFIG --libs --dynamic`"
-        else
-            LIBXML_LIBS="-L${LIBXML_SRC} `$XML_CONFIG --libs`"
+            if $XML_CONFIG --help | grep -q '\--dynamic'; then
+                xml_config_dynamic=--dynamic
+            fi
         fi
+        LIBXML_LIBS="-L${LIBXML_SRC} `$XML_CONFIG --libs $xml_config_dynamic`"
         WITH_MODULES="`$XML_CONFIG --modules`"
         cd $CWD
     else
@@ -546,7 +589,7 @@ dnl make sure xml2-config is executable,
 dnl test version and init our variables
 dnl
 
-if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs print > /dev/null 2>&1
+if test "x$LIBXML_LIBS" = "x" && ${XML_CONFIG} --libs > /dev/null 2>&1
 then
     AC_MSG_CHECKING(for libxml libraries >= $LIBXML_REQUIRED_VERSION)
     XMLVERS=`$XML_CONFIG --version`
@@ -557,17 +600,18 @@ then
     fi
 
     if test "$build_static_libs" = "no"; then
-        LIBXML_LIBS="`$XML_CONFIG --libs --dynamic`"
-    else
-        LIBXML_LIBS="`$XML_CONFIG --libs`"
+        if $XML_CONFIG --help | grep -q '\--dynamic'; then
+            xml_config_dynamic=--dynamic
+        fi
     fi
-	LIBXML_CFLAGS="`$XML_CONFIG --cflags`"
-        WITH_MODULES="`$XML_CONFIG --modules`"
+    LIBXML_LIBS="`$XML_CONFIG --libs $xml_config_dynamic`"
+    LIBXML_CFLAGS="`$XML_CONFIG --cflags`"
+    WITH_MODULES="`$XML_CONFIG --modules`"
 fi
 
 if test "x$LIBXML_LIBS" = "x"
 then
-	AC_MSG_ERROR([Could not find libxml2 anywhere, check ftp://xmlsoft.org/.])
+	AC_MSG_ERROR([Could not find libxml2 anywhere.])
 fi
 
 
@@ -650,11 +694,9 @@ AC_SUBST(XSLT_PRIVATE_LIBS)
 
 EXSLT_LIBDIR='-L${libdir}'
 EXSLT_INCLUDEDIR='-I${includedir}'
-EXSLT_LIBS="-lexslt $XSLT_LIBS"
 EXSLT_PRIVATE_LIBS="$XSLT_PRIVATE_LIBS $LIBGCRYPT_LIBS"
 AC_SUBST(EXSLT_LIBDIR)
 AC_SUBST(EXSLT_INCLUDEDIR)
-AC_SUBST(EXSLT_LIBS)
 AC_SUBST(EXSLT_PRIVATE_LIBS)
 
 AC_SUBST(EXTRA_LIBS)
@@ -672,6 +714,7 @@ AC_CONFIG_FILES([
 Makefile
 libxslt.pc
 libexslt.pc
+libxslt-config.cmake
 libxslt/Makefile
 libxslt/xsltconfig.h
 libxslt/xsltwin32config.h
@@ -710,6 +753,8 @@ tests/exslt/crypto/Makefile
 tests/plugins/Makefile
 tests/fuzz/Makefile
 doc/Makefile
+doc/devhelp/Makefile
+doc/EXSLT/devhelp/Makefile
 xslt-config
 libxslt.spec
 ])

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libexslt.pc.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libexslt.pc.in
@@ -7,7 +7,7 @@ includedir=@includedir@
 Name: libexslt
 Version: @LIBEXSLT_VERSION@
 Description: EXSLT Extension library
-Requires: libxml-2.0
+Requires: libxml-2.0, libxslt
 Cflags: @EXSLT_INCLUDEDIR@
-Libs: @EXSLT_LIBDIR@ @EXSLT_LIBS@
+Libs: @EXSLT_LIBDIR@ -lexslt
 Libs.private: @EXSLT_PRIVATE_LIBS@

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.m4
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.m4
@@ -122,9 +122,8 @@ main()
       {
         printf("\n*** An old version of libxslt (%d.%d.%d) was found.\n",
                xslt_major_version, xslt_minor_version, xslt_micro_version);
-        printf("*** You need a version of libxslt newer than %d.%d.%d. The latest version of\n",
+        printf("*** You need a version of libxslt newer than %d.%d.%d.\n",
            major, minor, micro);
-        printf("*** libxslt is always available from ftp://ftp.xmlsoft.org.\n");
         printf("***\n");
         printf("*** If you have already installed a sufficiently new version, this error\n");
         printf("*** probably means that the wrong copy of the xslt-config shell script is\n");

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.pc.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.pc.in
@@ -9,5 +9,5 @@ Version: @VERSION@
 Description: XSLT library version 2.
 Requires: libxml-2.0
 Cflags: @XSLT_INCLUDEDIR@
-Libs: @XSLT_LIBDIR@ @XSLT_LIBS@ @EXTRA_LIBS@
+Libs: @XSLT_LIBDIR@ -lxslt
 Libs.private: @XSLT_PRIVATE_LIBS@

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.spec
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.spec
@@ -1,12 +1,12 @@
 Summary: Library providing the GNOME XSLT engine
 Name: libxslt
-Version: 1.1.34
+Version: 1.1.35
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
-Source: ftp://xmlsoft.org/XSLT/libxslt-%{version}.tar.gz
+Source: https://download.gnome.org/sources/libxslt/1.1/libxslt-%{version}.tar.xz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
-URL: http://xmlsoft.org/XSLT/
+URL: https://gitlab.gnome.org/GNOME/libxslt
 Requires: libxml2 >= 2.6.27
 BuildRequires: libxml2-devel >= 2.6.27
 BuildRequires: python python-devel
@@ -128,5 +128,5 @@ rm -fr %{buildroot}
 %doc python/tests/*.xsl
 
 %changelog
-* Thu Nov 14 2019 Daniel Veillard <veillard@redhat.com>
-- upstream release 1.1.34 see http://xmlsoft.org/XSLT/news.html
+* Fri May 13 2022 Daniel Veillard <veillard@redhat.com>
+- upstream release 1.1.35

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.spec.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt.spec.in
@@ -4,9 +4,9 @@ Version: @VERSION@
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
-Source: ftp://xmlsoft.org/XSLT/libxslt-%{version}.tar.gz
+Source: https://download.gnome.org/sources/libxslt/@LIBXSLT_MAJOR_VERSION@.@LIBXSLT_MINOR_VERSION@/libxslt-%{version}.tar.xz
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
-URL: http://xmlsoft.org/XSLT/
+URL: https://gitlab.gnome.org/GNOME/libxslt
 Requires: libxml2 >= @LIBXML_REQUIRED_VERSION@
 BuildRequires: libxml2-devel >= @LIBXML_REQUIRED_VERSION@
 BuildRequires: python python-devel
@@ -129,4 +129,4 @@ rm -fr %{buildroot}
 
 %changelog
 * @RELDATE@ Daniel Veillard <veillard@redhat.com>
-- upstream release @VERSION@ see http://xmlsoft.org/XSLT/news.html
+- upstream release @VERSION@

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attributes.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attributes.c
@@ -64,7 +64,7 @@
 #define IS_BLANK(c) (((c) == 0x20) || ((c) == 0x09) || ((c) == 0xA) ||  \
                      ((c) == 0x0D))
 
-#define IS_BLANK_NODE(n)                        \
+#define IS_BLANK_NODE(n)                                                \
     (((n)->type == XML_TEXT_NODE) && (xsltIsBlank((n)->content)))
 
 #define ATTRSET_UNRESOLVED 0
@@ -114,9 +114,9 @@ xsltResolveAttrSet(xsltAttrSetPtr set, xsltStylesheetPtr topStyle,
                    const xmlChar *ns, int depth);
 
 /************************************************************************
- *                                  *
- *          XSLT Attribute handling             *
- *                                  *
+ *                                                                      *
+ *                      XSLT Attribute handling                         *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -134,8 +134,8 @@ xsltNewAttrElem(xmlNodePtr attr) {
     cur = (xsltAttrElemPtr) xmlMalloc(sizeof(xsltAttrElem));
     if (cur == NULL) {
         xsltGenericError(xsltGenericErrorContext,
-        "xsltNewAttrElem : malloc failed\n");
-    return(NULL);
+                "xsltNewAttrElem : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltAttrElem));
     cur->attr = attr;
@@ -164,9 +164,9 @@ xsltFreeAttrElemList(xsltAttrElemPtr list) {
     xsltAttrElemPtr next;
 
     while (list != NULL) {
-    next = list->next;
-    xsltFreeAttrElem(list);
-    list = next;
+        next = list->next;
+        xsltFreeAttrElem(list);
+        list = next;
     }
 }
 
@@ -184,17 +184,17 @@ xsltAddAttrElemList(xsltAttrElemPtr list, xmlNodePtr attr) {
     xsltAttrElemPtr next, cur;
 
     if (attr == NULL)
-    return(list);
+        return(list);
     if (list == NULL)
-    return(xsltNewAttrElem(attr));
+        return(xsltNewAttrElem(attr));
     cur = list;
     while (cur != NULL) {
-    next = cur->next;
-    if (next == NULL) {
-        cur->next = xsltNewAttrElem(attr);
-        return(list);
-    }
-    cur = next;
+        next = cur->next;
+        if (next == NULL) {
+            cur->next = xsltNewAttrElem(attr);
+            return(list);
+        }
+        cur = next;
     }
     return(list);
 }
@@ -215,8 +215,8 @@ xsltNewUseAttrSet(const xmlChar *ncname, const xmlChar *ns) {
     cur = (xsltUseAttrSetPtr) xmlMalloc(sizeof(xsltUseAttrSet));
     if (cur == NULL) {
         xsltGenericError(xsltGenericErrorContext,
-        "xsltNewUseAttrSet : malloc failed\n");
-    return(NULL);
+                "xsltNewUseAttrSet : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltUseAttrSet));
     cur->ncname = ncname;
@@ -246,9 +246,9 @@ xsltFreeUseAttrSetList(xsltUseAttrSetPtr list) {
     xsltUseAttrSetPtr next;
 
     while (list != NULL) {
-    next = list->next;
-    xsltFreeUseAttrSet(list);
-    list = next;
+        next = list->next;
+        xsltFreeUseAttrSet(list);
+        list = next;
     }
 }
 
@@ -270,17 +270,17 @@ xsltAddUseAttrSetList(xsltUseAttrSetPtr list, const xmlChar *ncname,
     if (ncname == NULL)
         return(list);
     if (list == NULL)
-    return(xsltNewUseAttrSet(ncname, ns));
+        return(xsltNewUseAttrSet(ncname, ns));
     cur = list;
     while (cur != NULL) {
         if ((cur->ncname == ncname) && (cur->ns == ns))
             return(list);
-    next = cur->next;
-    if (next == NULL) {
-        cur->next = xsltNewUseAttrSet(ncname, ns);
-        return(list);
-    }
-    cur = next;
+        next = cur->next;
+        if (next == NULL) {
+            cur->next = xsltNewUseAttrSet(ncname, ns);
+            return(list);
+        }
+        cur = next;
     }
     return(list);
 }
@@ -299,8 +299,8 @@ xsltNewAttrSet() {
     cur = (xsltAttrSetPtr) xmlMalloc(sizeof(xsltAttrSet));
     if (cur == NULL) {
         xsltGenericError(xsltGenericErrorContext,
-        "xsltNewAttrSet : malloc failed\n");
-    return(NULL);
+                "xsltNewAttrSet : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltAttrSet));
     return(cur);
@@ -337,12 +337,12 @@ xsltMergeAttrSets(xsltAttrSetPtr set, xsltAttrSetPtr other) {
     int add;
 
     while (old != NULL) {
-    /*
-     * Check that the attribute is not yet in the list
-     */
-    cur = set->attrs;
-    add = 1;
-    while (cur != NULL) {
+        /*
+         * Check that the attribute is not yet in the list
+         */
+        cur = set->attrs;
+        add = 1;
+        while (cur != NULL) {
             xsltStylePreCompPtr curComp = cur->attr->psvi;
             xsltStylePreCompPtr oldComp = old->attr->psvi;
 
@@ -351,27 +351,27 @@ xsltMergeAttrSets(xsltAttrSetPtr set, xsltAttrSetPtr other) {
                 add = 0;
                 break;
             }
-        if (cur->next == NULL)
-        break;
+            if (cur->next == NULL)
+                break;
             cur = cur->next;
-    }
-
-    if (add == 1) {
-        if (cur == NULL) {
-        set->attrs = xsltNewAttrElem(old->attr);
-        } else if (add) {
-        cur->next = xsltNewAttrElem(old->attr);
         }
-    }
 
-    old = old->next;
+        if (add == 1) {
+            if (cur == NULL) {
+                set->attrs = xsltNewAttrElem(old->attr);
+            } else if (add) {
+                cur->next = xsltNewAttrElem(old->attr);
+            }
+        }
+
+        old = old->next;
     }
 }
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -392,15 +392,15 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
     xsltAttrSetPtr set;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     value = xmlGetNsProp(cur, (const xmlChar *)"name", NULL);
     if ((value == NULL) || (*value == 0)) {
-    xsltGenericError(xsltGenericErrorContext,
-         "xsl:attribute-set : name is missing\n");
+        xsltGenericError(xsltGenericErrorContext,
+             "xsl:attribute-set : name is missing\n");
         if (value)
-        xmlFree(value);
-    return;
+            xmlFree(value);
+        return;
     }
 
     if (xmlValidateQName(value, 0)) {
@@ -429,13 +429,13 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
 
     if (style->attributeSets == NULL) {
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
-    xsltGenericDebug(xsltGenericDebugContext,
-        "creating attribute set table\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+            "creating attribute set table\n");
 #endif
-    style->attributeSets = xmlHashCreate(10);
+        style->attributeSets = xmlHashCreate(10);
     }
     if (style->attributeSets == NULL)
-    return;
+        return;
 
     set = xmlHashLookup2(style->attributeSets, ncname, nsUri);
     if (set == NULL) {
@@ -450,28 +450,28 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
     */
     child = cur->children;
     while (child != NULL) {
-    /*
-    * Report invalid nodes.
-    */
-    if ((child->type != XML_ELEMENT_NODE) ||
-        (child->ns == NULL) ||
-        (! IS_XSLT_ELEM(child)))
-    {
-        if (child->type == XML_ELEMENT_NODE)
-        xsltTransformError(NULL, style, child,
-            "xsl:attribute-set : unexpected child %s\n",
-                         child->name);
-        else
-        xsltTransformError(NULL, style, child,
-            "xsl:attribute-set : child of unexpected type\n");
-    } else if (!IS_XSLT_NAME(child, "attribute")) {
-        xsltTransformError(NULL, style, child,
-        "xsl:attribute-set : unexpected child xsl:%s\n",
-        child->name);
-    } else {
+        /*
+        * Report invalid nodes.
+        */
+        if ((child->type != XML_ELEMENT_NODE) ||
+            (child->ns == NULL) ||
+            (! IS_XSLT_ELEM(child)))
+        {
+            if (child->type == XML_ELEMENT_NODE)
+                xsltTransformError(NULL, style, child,
+                        "xsl:attribute-set : unexpected child %s\n",
+                                 child->name);
+            else
+                xsltTransformError(NULL, style, child,
+                        "xsl:attribute-set : child of unexpected type\n");
+        } else if (!IS_XSLT_NAME(child, "attribute")) {
+            xsltTransformError(NULL, style, child,
+                "xsl:attribute-set : unexpected child xsl:%s\n",
+                child->name);
+        } else {
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
-        xsltGenericDebug(xsltGenericDebugContext,
-        "add attribute to list %s\n", ncname);
+            xsltGenericDebug(xsltGenericDebugContext,
+                "add attribute to list %s\n", ncname);
 #endif
             xsltStylePreCompute(style, child);
             if (child->children != NULL) {
@@ -488,11 +488,11 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
                     "compiled\n", child->name);
             }
             else {
-            set->attrs = xsltAddAttrElemList(set->attrs, child);
+                set->attrs = xsltAddAttrElemList(set->attrs, child);
             }
-    }
+        }
 
-    child = child->next;
+        child = child->next;
     }
 
     /*
@@ -500,23 +500,23 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
     */
     value = xmlGetNsProp(cur, BAD_CAST "use-attribute-sets", NULL);
     if (value != NULL) {
-    const xmlChar *curval, *endval;
-    curval = value;
-    while (*curval != 0) {
-        while (IS_BLANK(*curval)) curval++;
-        if (*curval == 0)
-        break;
-        endval = curval;
-        while ((*endval != 0) && (!IS_BLANK(*endval))) endval++;
-        curval = xmlDictLookup(style->dict, curval, endval - curval);
-        if (curval) {
-        const xmlChar *ncname2 = NULL;
-        const xmlChar *prefix2 = NULL;
+        const xmlChar *curval, *endval;
+        curval = value;
+        while (*curval != 0) {
+            while (IS_BLANK(*curval)) curval++;
+            if (*curval == 0)
+                break;
+            endval = curval;
+            while ((*endval != 0) && (!IS_BLANK(*endval))) endval++;
+            curval = xmlDictLookup(style->dict, curval, endval - curval);
+            if (curval) {
+                const xmlChar *ncname2 = NULL;
+                const xmlChar *prefix2 = NULL;
                 const xmlChar *nsUri2 = NULL;
 
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsl:attribute-set : %s adds use %s\n", ncname, curval);
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "xsl:attribute-set : %s adds use %s\n", ncname, curval);
 #endif
 
                 if (xmlValidateQName(curval, 0)) {
@@ -528,7 +528,7 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
                     return;
                 }
 
-        ncname2 = xsltSplitQName(style->dict, curval, &prefix2);
+                ncname2 = xsltSplitQName(style->dict, curval, &prefix2);
                 if (prefix2 != NULL) {
                     xmlNsPtr ns2 = xmlSearchNs(style->doc, cur, prefix2);
                     if (ns2 == NULL) {
@@ -544,16 +544,16 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
                 }
                 set->useAttrSets = xsltAddUseAttrSetList(set->useAttrSets,
                                                          ncname2, nsUri2);
+            }
+            curval = endval;
         }
-        curval = endval;
-    }
-    xmlFree(value);
-    value = NULL;
+        xmlFree(value);
+        value = NULL;
     }
 
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
     xsltGenericDebug(xsltGenericDebugContext,
-    "updated attribute list %s\n", ncname);
+        "updated attribute list %s\n", ncname);
 #endif
 }
 
@@ -567,7 +567,7 @@ xsltParseStylesheetAttributeSet(xsltStylesheetPtr style, xmlNodePtr cur) {
  */
 static void
 xsltResolveUseAttrSets(xsltAttrSetPtr set, xsltStylesheetPtr topStyle,
-               int depth) {
+                       int depth) {
     xsltStylesheetPtr cur;
     xsltAttrSetPtr other;
     xsltUseAttrSetPtr use = set->useAttrSets;
@@ -621,7 +621,7 @@ xsltResolveAttrSet(xsltAttrSetPtr set, xsltStylesheetPtr topStyle,
     if (set->state == ATTRSET_RESOLVED)
         return;
     if (set->state == ATTRSET_RESOLVING) {
-    xsltTransformError(NULL, topStyle, NULL,
+        xsltTransformError(NULL, topStyle, NULL,
             "xsl:attribute-set : use-attribute-sets recursion detected"
             " on %s\n", name);
         topStyle->errors++;
@@ -629,11 +629,11 @@ xsltResolveAttrSet(xsltAttrSetPtr set, xsltStylesheetPtr topStyle,
         return;
     }
     if (depth > 100) {
-    xsltTransformError(NULL, topStyle, NULL,
-        "xsl:attribute-set : use-attribute-sets maximum recursion "
-        "depth exceeded on %s\n", name);
+        xsltTransformError(NULL, topStyle, NULL,
+                "xsl:attribute-set : use-attribute-sets maximum recursion "
+                "depth exceeded on %s\n", name);
         topStyle->errors++;
-    return;
+        return;
     }
 
     set->state = ATTRSET_RESOLVING;
@@ -675,8 +675,8 @@ xsltResolveAttrSet(xsltAttrSetPtr set, xsltStylesheetPtr topStyle,
  */
 static void
 xsltResolveSASCallback(void *payload, void *data,
-                   const xmlChar *name, const xmlChar *ns,
-               ATTRIBUTE_UNUSED const xmlChar *ignored) {
+                       const xmlChar *name, const xmlChar *ns,
+                       ATTRIBUTE_UNUSED const xmlChar *ignored) {
     xsltAttrSetPtr set = (xsltAttrSetPtr) payload;
     xsltAttrSetContextPtr asctx = (xsltAttrSetContextPtr) data;
     xsltStylesheetPtr topStyle = asctx->topStyle;
@@ -691,7 +691,7 @@ xsltResolveSASCallback(void *payload, void *data,
          * removing the hash entry.
          */
         if (xmlHashAddEntry2(topStyle->attributeSets, name, ns, set) < 0) {
-        xsltGenericError(xsltGenericErrorContext,
+            xsltGenericError(xsltGenericErrorContext,
                 "xsl:attribute-set : internal error, can't move imported "
                 " attribute set %s\n", name);
         }
@@ -711,21 +711,21 @@ xsltResolveStylesheetAttributeSet(xsltStylesheetPtr style) {
 
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
     xsltGenericDebug(xsltGenericDebugContext,
-        "Resolving attribute sets references\n");
+            "Resolving attribute sets references\n");
 #endif
     asctx.topStyle = style;
     cur = style;
     while (cur != NULL) {
-    if (cur->attributeSets != NULL) {
-        if (style->attributeSets == NULL) {
+        if (cur->attributeSets != NULL) {
+            if (style->attributeSets == NULL) {
 #ifdef WITH_XSLT_DEBUG_ATTRIBUTES
-        xsltGenericDebug(xsltGenericDebugContext,
-            "creating attribute set table\n");
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "creating attribute set table\n");
 #endif
-        style->attributeSets = xmlHashCreate(10);
-        }
+                style->attributeSets = xmlHashCreate(10);
+            }
             asctx.style = cur;
-        xmlHashScanFull(cur->attributeSets, xsltResolveSASCallback,
+            xmlHashScanFull(cur->attributeSets, xsltResolveSASCallback,
                             &asctx);
 
             if (cur != style) {
@@ -736,8 +736,8 @@ xsltResolveStylesheetAttributeSet(xsltStylesheetPtr style) {
                 xmlHashFree(cur->attributeSets, NULL);
                 cur->attributeSets = NULL;
             }
-    }
-    cur = xsltNextImport(cur);
+        }
+        cur = xsltNextImport(cur);
     }
 }
 
@@ -752,13 +752,13 @@ xsltResolveStylesheetAttributeSet(xsltStylesheetPtr style) {
  */
 void
 xsltAttribute(xsltTransformContextPtr ctxt,
-          xmlNodePtr contextNode,
+              xmlNodePtr contextNode,
               xmlNodePtr inst,
-          xsltElemPreCompPtr castedComp)
+              xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemAttributePtr comp =
-    (xsltStyleItemAttributePtr) castedComp;
+        (xsltStyleItemAttributePtr) castedComp;
 #else
     xsltStylePreCompPtr comp = (xsltStylePreCompPtr) castedComp;
 #endif
@@ -794,8 +794,8 @@ xsltAttribute(xsltTransformContextPtr ctxt,
 
     if (comp == NULL) {
         xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltAttribute(): "
-        "The XSLT 'attribute' instruction was not compiled.\n");
+            "Internal error in xsltAttribute(): "
+            "The XSLT 'attribute' instruction was not compiled.\n");
         return;
     }
     /*
@@ -814,7 +814,7 @@ xsltAttribute(xsltTransformContextPtr ctxt,
     */
     targetElem = ctxt->insert;
     if (targetElem->type != XML_ELEMENT_NODE)
-    return;
+        return;
 
     /*
     * SPEC XSLT 1.0:
@@ -827,14 +827,14 @@ xsltAttribute(xsltTransformContextPtr ctxt,
     *  element, but here we report an error.
     */
     if (targetElem->children != NULL) {
-    /*
-    * NOTE: Ah! This seems to be intended to support streamed
-    *  result generation!.
-    */
+        /*
+        * NOTE: Ah! This seems to be intended to support streamed
+        *  result generation!.
+        */
         xsltTransformError(ctxt, NULL, inst,
-        "xsl:attribute: Cannot add attributes to an "
-        "element if children have been already added "
-        "to the element.\n");
+            "xsl:attribute: Cannot add attributes to an "
+            "element if children have been already added "
+            "to the element.\n");
         return;
     }
 
@@ -849,42 +849,42 @@ xsltAttribute(xsltTransformContextPtr ctxt,
 #endif
 
     if (comp->name == NULL) {
-    /* TODO: fix attr acquisition wrt to the XSLT namespace */
+        /* TODO: fix attr acquisition wrt to the XSLT namespace */
         prop = xsltEvalAttrValueTemplate(ctxt, inst,
-        (const xmlChar *) "name", XSLT_NAMESPACE);
+            (const xmlChar *) "name", XSLT_NAMESPACE);
         if (prop == NULL) {
             xsltTransformError(ctxt, NULL, inst,
-        "xsl:attribute: The attribute 'name' is missing.\n");
+                "xsl:attribute: The attribute 'name' is missing.\n");
             goto error;
         }
-    if (xmlValidateQName(prop, 0)) {
-        xsltTransformError(ctxt, NULL, inst,
-        "xsl:attribute: The effective name '%s' is not a "
-        "valid QName.\n", prop);
-        /* we fall through to catch any further errors, if possible */
-    }
+        if (xmlValidateQName(prop, 0)) {
+            xsltTransformError(ctxt, NULL, inst,
+                "xsl:attribute: The effective name '%s' is not a "
+                "valid QName.\n", prop);
+            /* we fall through to catch any further errors, if possible */
+        }
 
-    /*
-    * Reject a name of "xmlns".
-    */
-    if (xmlStrEqual(prop, BAD_CAST "xmlns")) {
+        /*
+        * Reject a name of "xmlns".
+        */
+        if (xmlStrEqual(prop, BAD_CAST "xmlns")) {
             xsltTransformError(ctxt, NULL, inst,
                 "xsl:attribute: The effective name 'xmlns' is not allowed.\n");
-        xmlFree(prop);
-        goto error;
-    }
+            xmlFree(prop);
+            goto error;
+        }
 
-    name = xsltSplitQName(ctxt->dict, prop, &prefix);
-    xmlFree(prop);
+        name = xsltSplitQName(ctxt->dict, prop, &prefix);
+        xmlFree(prop);
     } else {
-    /*
-    * The "name" value was static.
-    */
+        /*
+        * The "name" value was static.
+        */
 #ifdef XSLT_REFACTORED
-    prefix = comp->nsPrefix;
-    name = comp->name;
+        prefix = comp->nsPrefix;
+        name = comp->name;
 #else
-    name = xsltSplitQName(ctxt->dict, comp->name, &prefix);
+        name = xsltSplitQName(ctxt->dict, comp->name, &prefix);
 #endif
     }
 
@@ -895,35 +895,35 @@ xsltAttribute(xsltTransformContextPtr ctxt,
     * Evaluate the namespace name.
     */
     if (comp->has_ns) {
-    /*
-    * The "namespace" attribute was existent.
-    */
-    if (comp->ns != NULL) {
         /*
-        * No AVT; just plain text for the namespace name.
+        * The "namespace" attribute was existent.
         */
-        if (comp->ns[0] != 0)
-        nsName = comp->ns;
-    } else {
-        xmlChar *tmpNsName;
-        /*
-        * Eval the AVT.
-        */
-        /* TODO: check attr acquisition wrt to the XSLT namespace */
-        tmpNsName = xsltEvalAttrValueTemplate(ctxt, inst,
-        (const xmlChar *) "namespace", XSLT_NAMESPACE);
-        /*
-        * This fixes bug #302020: The AVT might also evaluate to the
-        * empty string; this means that the empty string also indicates
-        * "no namespace".
-        * SPEC XSLT 1.0:
-        *  "If the string is empty, then the expanded-name of the
-        *  attribute has a null namespace URI."
-        */
-        if ((tmpNsName != NULL) && (tmpNsName[0] != 0))
-        nsName = xmlDictLookup(ctxt->dict, BAD_CAST tmpNsName, -1);
-        xmlFree(tmpNsName);
-    }
+        if (comp->ns != NULL) {
+            /*
+            * No AVT; just plain text for the namespace name.
+            */
+            if (comp->ns[0] != 0)
+                nsName = comp->ns;
+        } else {
+            xmlChar *tmpNsName;
+            /*
+            * Eval the AVT.
+            */
+            /* TODO: check attr acquisition wrt to the XSLT namespace */
+            tmpNsName = xsltEvalAttrValueTemplate(ctxt, inst,
+                (const xmlChar *) "namespace", XSLT_NAMESPACE);
+            /*
+            * This fixes bug #302020: The AVT might also evaluate to the
+            * empty string; this means that the empty string also indicates
+            * "no namespace".
+            * SPEC XSLT 1.0:
+            *  "If the string is empty, then the expanded-name of the
+            *  attribute has a null namespace URI."
+            */
+            if ((tmpNsName != NULL) && (tmpNsName[0] != 0))
+                nsName = xmlDictLookup(ctxt->dict, BAD_CAST tmpNsName, -1);
+            xmlFree(tmpNsName);
+        }
 
         if (xmlStrEqual(nsName, BAD_CAST "http://www.w3.org/2000/xmlns/")) {
             xsltTransformError(ctxt, NULL, inst,
@@ -937,26 +937,26 @@ xsltAttribute(xsltTransformContextPtr ctxt,
             prefix = NULL;
         }
     } else if (prefix != NULL) {
-    /*
-    * SPEC XSLT 1.0:
-    *  "If the namespace attribute is not present, then the QName is
-    *  expanded into an expanded-name using the namespace declarations
-    *  in effect for the xsl:attribute element, *not* including any
-    *  default namespace declaration."
-    */
-    ns = xmlSearchNs(inst->doc, inst, prefix);
-    if (ns == NULL) {
         /*
-        * Note that this is treated as an error now (checked with
-        *  Saxon, Xalan-J and MSXML).
+        * SPEC XSLT 1.0:
+        *  "If the namespace attribute is not present, then the QName is
+        *  expanded into an expanded-name using the namespace declarations
+        *  in effect for the xsl:attribute element, *not* including any
+        *  default namespace declaration."
         */
-        xsltTransformError(ctxt, NULL, inst,
-        "xsl:attribute: The QName '%s:%s' has no "
-        "namespace binding in scope in the stylesheet; "
-        "this is an error, since the namespace was not "
-        "specified by the instruction itself.\n", prefix, name);
-    } else
-        nsName = ns->href;
+        ns = xmlSearchNs(inst->doc, inst, prefix);
+        if (ns == NULL) {
+            /*
+            * Note that this is treated as an error now (checked with
+            *  Saxon, Xalan-J and MSXML).
+            */
+            xsltTransformError(ctxt, NULL, inst,
+                "xsl:attribute: The QName '%s:%s' has no "
+                "namespace binding in scope in the stylesheet; "
+                "this is an error, since the namespace was not "
+                "specified by the instruction itself.\n", prefix, name);
+        } else
+            nsName = ns->href;
     }
 
     /*
@@ -966,117 +966,117 @@ xsltAttribute(xsltTransformContextPtr ctxt,
 
 #if 0
     if (0) {
-    /*
-    * OPTIMIZE TODO: How do we know if we are adding to a
-    *  fragment or to the result tree?
-    *
-    * If we are adding to a result tree fragment (i.e., not to the
-    * actual result tree), we'll don't bother searching for the
-    * ns-decl, but just store it in the dummy-doc of the result
-    * tree fragment.
-    */
-    if (nsName != NULL) {
         /*
-        * TODO: Get the doc of @targetElem.
+        * OPTIMIZE TODO: How do we know if we are adding to a
+        *  fragment or to the result tree?
+        *
+        * If we are adding to a result tree fragment (i.e., not to the
+        * actual result tree), we'll don't bother searching for the
+        * ns-decl, but just store it in the dummy-doc of the result
+        * tree fragment.
         */
-        ns = xsltTreeAcquireStoredNs(some doc, nsName, prefix);
-    }
+        if (nsName != NULL) {
+            /*
+            * TODO: Get the doc of @targetElem.
+            */
+            ns = xsltTreeAcquireStoredNs(some doc, nsName, prefix);
+        }
     }
 #endif
 
     if (nsName != NULL) {
-    /*
-    * Something about ns-prefixes:
-    * SPEC XSLT 1.0:
-    *  "XSLT processors may make use of the prefix of the QName specified
-    *  in the name attribute when selecting the prefix used for outputting
-    *  the created attribute as XML; however, they are not required to do
-    *  so and, if the prefix is xmlns, they must not do so"
-    */
-    /*
-    * xsl:attribute can produce a scenario where the prefix is NULL,
-    * so generate a prefix.
-    */
-    if ((prefix == NULL) || xmlStrEqual(prefix, BAD_CAST "xmlns")) {
-        xmlChar *pref = xmlStrdup(BAD_CAST "ns_1");
+        /*
+        * Something about ns-prefixes:
+        * SPEC XSLT 1.0:
+        *  "XSLT processors may make use of the prefix of the QName specified
+        *  in the name attribute when selecting the prefix used for outputting
+        *  the created attribute as XML; however, they are not required to do
+        *  so and, if the prefix is xmlns, they must not do so"
+        */
+        /*
+        * xsl:attribute can produce a scenario where the prefix is NULL,
+        * so generate a prefix.
+        */
+        if ((prefix == NULL) || xmlStrEqual(prefix, BAD_CAST "xmlns")) {
+            xmlChar *pref = xmlStrdup(BAD_CAST "ns_1");
 
-        ns = xsltGetSpecialNamespace(ctxt, inst, nsName, pref, targetElem);
+            ns = xsltGetSpecialNamespace(ctxt, inst, nsName, pref, targetElem);
 
-        xmlFree(pref);
-    } else {
-        ns = xsltGetSpecialNamespace(ctxt, inst, nsName, prefix,
-        targetElem);
-    }
-    if (ns == NULL) {
-        xsltTransformError(ctxt, NULL, inst,
-        "Namespace fixup error: Failed to acquire an in-scope "
-        "namespace binding for the generated attribute '{%s}%s'.\n",
-        nsName, name);
-        goto error;
-    }
+            xmlFree(pref);
+        } else {
+            ns = xsltGetSpecialNamespace(ctxt, inst, nsName, prefix,
+                targetElem);
+        }
+        if (ns == NULL) {
+            xsltTransformError(ctxt, NULL, inst,
+                "Namespace fixup error: Failed to acquire an in-scope "
+                "namespace binding for the generated attribute '{%s}%s'.\n",
+                nsName, name);
+            goto error;
+        }
     }
     /*
     * Construction of the value
     * -------------------------
     */
     if (inst->children == NULL) {
-    /*
-    * No content.
-    * TODO: Do we need to put the empty string in ?
-    */
-    attr = xmlSetNsProp(ctxt->insert, ns, name, (const xmlChar *) "");
-    } else if ((inst->children->next == NULL) &&
-        ((inst->children->type == XML_TEXT_NODE) ||
-         (inst->children->type == XML_CDATA_SECTION_NODE)))
-    {
-    xmlNodePtr copyTxt;
-
-    /*
-    * xmlSetNsProp() will take care of duplicates.
-    */
-    attr = xmlSetNsProp(ctxt->insert, ns, name, NULL);
-    if (attr == NULL) /* TODO: report error ? */
-        goto error;
-    /*
-    * This was taken over from xsltCopyText() (transform.c).
-    */
-    if (ctxt->internalized &&
-        (ctxt->insert->doc != NULL) &&
-        (ctxt->insert->doc->dict == ctxt->dict))
-    {
-        copyTxt = xmlNewText(NULL);
-        if (copyTxt == NULL) /* TODO: report error */
-        goto error;
         /*
-        * This is a safe scenario where we don't need to lookup
-        * the dict.
+        * No content.
+        * TODO: Do we need to put the empty string in ?
         */
-        copyTxt->content = inst->children->content;
+        attr = xmlSetNsProp(ctxt->insert, ns, name, (const xmlChar *) "");
+    } else if ((inst->children->next == NULL) &&
+            ((inst->children->type == XML_TEXT_NODE) ||
+             (inst->children->type == XML_CDATA_SECTION_NODE)))
+    {
+        xmlNodePtr copyTxt;
+
+        /*
+        * xmlSetNsProp() will take care of duplicates.
+        */
+        attr = xmlSetNsProp(ctxt->insert, ns, name, NULL);
+        if (attr == NULL) /* TODO: report error ? */
+            goto error;
+        /*
+        * This was taken over from xsltCopyText() (transform.c).
+        */
+        if (ctxt->internalized &&
+            (ctxt->insert->doc != NULL) &&
+            (ctxt->insert->doc->dict == ctxt->dict))
+        {
+            copyTxt = xmlNewText(NULL);
+            if (copyTxt == NULL) /* TODO: report error */
+                goto error;
+            /*
+            * This is a safe scenario where we don't need to lookup
+            * the dict.
+            */
+            copyTxt->content = inst->children->content;
+            /*
+            * Copy "disable-output-escaping" information.
+            * TODO: Does this have any effect for attribute values
+            *  anyway?
+            */
+            if (inst->children->name == xmlStringTextNoenc)
+                copyTxt->name = xmlStringTextNoenc;
+        } else {
+            /*
+            * Copy the value.
+            */
+            copyTxt = xmlNewText(inst->children->content);
+            if (copyTxt == NULL) /* TODO: report error */
+                goto error;
+        }
+        attr->children = attr->last = copyTxt;
+        copyTxt->parent = (xmlNodePtr) attr;
+        copyTxt->doc = attr->doc;
         /*
         * Copy "disable-output-escaping" information.
         * TODO: Does this have any effect for attribute values
         *  anyway?
         */
         if (inst->children->name == xmlStringTextNoenc)
-        copyTxt->name = xmlStringTextNoenc;
-    } else {
-        /*
-        * Copy the value.
-        */
-        copyTxt = xmlNewText(inst->children->content);
-        if (copyTxt == NULL) /* TODO: report error */
-        goto error;
-    }
-    attr->children = attr->last = copyTxt;
-    copyTxt->parent = (xmlNodePtr) attr;
-    copyTxt->doc = attr->doc;
-    /*
-    * Copy "disable-output-escaping" information.
-    * TODO: Does this have any effect for attribute values
-    *  anyway?
-    */
-    if (inst->children->name == xmlStringTextNoenc)
-        copyTxt->name = xmlStringTextNoenc;
+            copyTxt->name = xmlStringTextNoenc;
 
         /*
          * since we create the attribute without content IDness must be
@@ -1086,22 +1086,22 @@ xsltAttribute(xsltTransformContextPtr ctxt,
             (xmlIsID(attr->doc, attr->parent, attr)))
             xmlAddID(NULL, attr->doc, copyTxt->content, attr);
     } else {
-    /*
-    * The sequence constructor might be complex, so instantiate it.
-    */
-    value = xsltEvalTemplateString(ctxt, contextNode, inst);
-    if (value != NULL) {
-        attr = xmlSetNsProp(ctxt->insert, ns, name, value);
-        xmlFree(value);
-    } else {
         /*
-        * TODO: Do we have to add the empty string to the attr?
-        * TODO: Does a  value of NULL indicate an
-        *  error in xsltEvalTemplateString() ?
+        * The sequence constructor might be complex, so instantiate it.
         */
-        attr = xmlSetNsProp(ctxt->insert, ns, name,
-        (const xmlChar *) "");
-    }
+        value = xsltEvalTemplateString(ctxt, contextNode, inst);
+        if (value != NULL) {
+            attr = xmlSetNsProp(ctxt->insert, ns, name, value);
+            xmlFree(value);
+        } else {
+            /*
+            * TODO: Do we have to add the empty string to the attr?
+            * TODO: Does a  value of NULL indicate an
+            *  error in xsltEvalTemplateString() ?
+            */
+            attr = xmlSetNsProp(ctxt->insert, ns, name,
+                (const xmlChar *) "");
+        }
     }
 
 error:
@@ -1132,24 +1132,24 @@ xsltApplyAttributeSet(xsltTransformContextPtr ctxt, xmlNodePtr node,
     xsltStylesheetPtr style;
 
     if (attrSets == NULL) {
-    if (inst == NULL)
-        return;
-    else {
-        /*
-        * Extract the value from @inst.
-        */
-        if (inst->type == XML_ATTRIBUTE_NODE) {
-        if ( ((xmlAttrPtr) inst)->children != NULL)
-            attrSets = ((xmlAttrPtr) inst)->children->content;
+        if (inst == NULL)
+            return;
+        else {
+            /*
+            * Extract the value from @inst.
+            */
+            if (inst->type == XML_ATTRIBUTE_NODE) {
+                if ( ((xmlAttrPtr) inst)->children != NULL)
+                    attrSets = ((xmlAttrPtr) inst)->children->content;
 
+            }
+            if (attrSets == NULL) {
+                /*
+                * TODO: Return an error?
+                */
+                return;
+            }
         }
-        if (attrSets == NULL) {
-        /*
-        * TODO: Return an error?
-        */
-        return;
-        }
-    }
     }
     /*
     * Parse/apply the list of QNames.
@@ -1182,7 +1182,7 @@ xsltApplyAttributeSet(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
             ncname = xsltSplitQName(ctxt->dict, curstr, &prefix);
             if (prefix != NULL) {
-            ns = xmlSearchNs(inst->doc, inst, prefix);
+                ns = xmlSearchNs(inst->doc, inst, prefix);
                 if (ns == NULL) {
                     xsltTransformError(ctxt, NULL, inst,
                         "use-attribute-set : No namespace found for QName "
@@ -1196,21 +1196,21 @@ xsltApplyAttributeSet(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
 #ifdef WITH_DEBUGGER
             if ((style != NULL) &&
-        (style->attributeSets != NULL) &&
-        (ctxt->debugStatus != XSLT_DEBUG_NONE))
-        {
+                (style->attributeSets != NULL) &&
+                (ctxt->debugStatus != XSLT_DEBUG_NONE))
+            {
                 set = xmlHashLookup2(style->attributeSets, ncname, nsUri);
                 if ((set != NULL) && (set->attrs != NULL) &&
                     (set->attrs->attr != NULL))
                     xslHandleDebugger(set->attrs->attr->parent, node, NULL,
-            ctxt);
+                        ctxt);
             }
 #endif
-        /*
-        * Lookup the referenced attribute-set. All attribute sets were
+            /*
+            * Lookup the referenced attribute-set. All attribute sets were
             * moved to the top stylesheet so there's no need to iterate
             * imported stylesheets
-        */
+            */
             set = xmlHashLookup2(style->attributeSets, ncname, nsUri);
             if (set != NULL) {
                 xsltAttrElemPtr cur = set->attrs;
@@ -1242,7 +1242,7 @@ xsltFreeAttributeSetsEntry(void *payload,
 void
 xsltFreeAttributeSetsHashes(xsltStylesheetPtr style) {
     if (style->attributeSets != NULL)
-    xmlHashFree((xmlHashTablePtr) style->attributeSets,
-            xsltFreeAttributeSetsEntry);
+        xmlHashFree((xmlHashTablePtr) style->attributeSets,
+                    xsltFreeAttributeSetsEntry);
     style->attributeSets = NULL;
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attributes.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attributes.h
@@ -19,17 +19,17 @@ extern "C" {
 #endif
 
 XSLTPUBFUN void XSLTCALL
-    xsltParseStylesheetAttributeSet (xsltStylesheetPtr style,
-                     xmlNodePtr cur);
+        xsltParseStylesheetAttributeSet (xsltStylesheetPtr style,
+                                         xmlNodePtr cur);
 XSLTPUBFUN void XSLTCALL
-    xsltFreeAttributeSetsHashes (xsltStylesheetPtr style);
+        xsltFreeAttributeSetsHashes     (xsltStylesheetPtr style);
 XSLTPUBFUN void XSLTCALL
-    xsltApplyAttributeSet       (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     const xmlChar *attributes);
+        xsltApplyAttributeSet           (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         const xmlChar *attributes);
 XSLTPUBFUN void XSLTCALL
-    xsltResolveStylesheetAttributeSet(xsltStylesheetPtr style);
+        xsltResolveStylesheetAttributeSet(xsltStylesheetPtr style);
 #ifdef __cplusplus
 }
 #endif

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attrvt.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/attrvt.c
@@ -37,9 +37,9 @@ typedef struct _xsltAttrVT xsltAttrVT;
 typedef xsltAttrVT *xsltAttrVTPtr;
 struct _xsltAttrVT {
     struct _xsltAttrVT *next; /* next xsltAttrVT */
-    int nb_seg;     /* Number of segments */
-    int max_seg;    /* max capacity before re-alloc needed */
-    int strstart;   /* is the start a string */
+    int nb_seg;         /* Number of segments */
+    int max_seg;        /* max capacity before re-alloc needed */
+    int strstart;       /* is the start a string */
     /*
      * the namespaces in scope
      */
@@ -71,10 +71,10 @@ xsltNewAttrVT(xsltStylesheetPtr style) {
 
     cur = (xsltAttrVTPtr) xmlMalloc(size);
     if (cur == NULL) {
-    xsltTransformError(NULL, style, NULL,
-        "xsltNewAttrVTPtr : malloc failed\n");
-    if (style != NULL) style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, style, NULL,
+                "xsltNewAttrVTPtr : malloc failed\n");
+        if (style != NULL) style->errors++;
+        return(NULL);
     }
     memset(cur, 0, size);
 
@@ -104,17 +104,17 @@ xsltFreeAttrVT(xsltAttrVTPtr avt) {
     if (avt == NULL) return;
 
     if (avt->strstart == 1) {
-    for (i = 0;i < avt->nb_seg; i += 2)
-        if (avt->segments[i] != NULL)
-        xmlFree((xmlChar *) avt->segments[i]);
-    for (i = 1;i < avt->nb_seg; i += 2)
-        xmlXPathFreeCompExpr((xmlXPathCompExprPtr) avt->segments[i]);
+        for (i = 0;i < avt->nb_seg; i += 2)
+            if (avt->segments[i] != NULL)
+                xmlFree((xmlChar *) avt->segments[i]);
+        for (i = 1;i < avt->nb_seg; i += 2)
+            xmlXPathFreeCompExpr((xmlXPathCompExprPtr) avt->segments[i]);
     } else {
-    for (i = 0;i < avt->nb_seg; i += 2)
-        xmlXPathFreeCompExpr((xmlXPathCompExprPtr) avt->segments[i]);
-    for (i = 1;i < avt->nb_seg; i += 2)
-        if (avt->segments[i] != NULL)
-        xmlFree((xmlChar *) avt->segments[i]);
+        for (i = 0;i < avt->nb_seg; i += 2)
+            xmlXPathFreeCompExpr((xmlXPathCompExprPtr) avt->segments[i]);
+        for (i = 1;i < avt->nb_seg; i += 2)
+            if (avt->segments[i] != NULL)
+                xmlFree((xmlChar *) avt->segments[i]);
     }
     if (avt->nsList != NULL)
         xmlFree(avt->nsList);
@@ -133,8 +133,8 @@ xsltFreeAVTList(void *avt) {
 
     while (cur != NULL) {
         next = cur->next;
-    xsltFreeAttrVT(cur);
-    cur = next;
+        xsltFreeAttrVT(cur);
+        cur = next;
     }
 }
 /**
@@ -154,14 +154,14 @@ xsltSetAttrVTsegment(xsltAttrVTPtr avt, void *val) {
     if (avt->nb_seg >= avt->max_seg) {
         size_t size = sizeof(xsltAttrVT) +
                       (avt->max_seg + MAX_AVT_SEG) * sizeof(void *);
-    xsltAttrVTPtr tmp = (xsltAttrVTPtr) xmlRealloc(avt, size);
-    if (tmp == NULL) {
+        xsltAttrVTPtr tmp = (xsltAttrVTPtr) xmlRealloc(avt, size);
+        if (tmp == NULL) {
             xsltFreeAttrVT(avt);
-        return NULL;
-    }
+            return NULL;
+        }
         avt = tmp;
-    memset(&avt->segments[avt->nb_seg], 0, MAX_AVT_SEG*sizeof(void *));
-    avt->max_seg += MAX_AVT_SEG;
+        memset(&avt->segments[avt->nb_seg], 0, MAX_AVT_SEG*sizeof(void *));
+        avt->max_seg += MAX_AVT_SEG;
     }
     avt->segments[avt->nb_seg++] = val;
     return avt;
@@ -190,10 +190,10 @@ xsltCompileAttr(xsltStylesheetPtr style, xmlAttrPtr attr) {
     if ((attr->children->type != XML_TEXT_NODE) ||
         (attr->children->next != NULL)) {
         xsltTransformError(NULL, style, attr->parent,
-        "Attribute '%s': The content is expected to be a single text "
-        "node when compiling an AVT.\n", attr->name);
-    style->errors++;
-    return;
+            "Attribute '%s': The content is expected to be a single text "
+            "node when compiling an AVT.\n", attr->name);
+        style->errors++;
+        return;
     }
     str = attr->children->content;
     if ((xmlStrchr(str, '{') == NULL) &&
@@ -201,12 +201,12 @@ xsltCompileAttr(xsltStylesheetPtr style, xmlAttrPtr attr) {
 
 #ifdef WITH_XSLT_DEBUG_AVT
     xsltGenericDebug(xsltGenericDebugContext,
-            "Found AVT %s: %s\n", attr->name, str);
+                    "Found AVT %s: %s\n", attr->name, str);
 #endif
     if (attr->psvi != NULL) {
 #ifdef WITH_XSLT_DEBUG_AVT
-    xsltGenericDebug(xsltGenericDebugContext,
-            "AVT %s: already compiled\n", attr->name);
+        xsltGenericDebug(xsltGenericDebugContext,
+                        "AVT %s: already compiled\n", attr->name);
 #endif
         return;
     }
@@ -215,33 +215,112 @@ xsltCompileAttr(xsltStylesheetPtr style, xmlAttrPtr attr) {
     */
     avt = xsltNewAttrVT(style);
     if (avt == NULL)
-    return;
+        return;
     attr->psvi = avt;
 
     avt->nsList = xmlGetNsList(attr->doc, attr->parent);
     if (avt->nsList != NULL) {
-    while (avt->nsList[i] != NULL)
-        i++;
+        while (avt->nsList[i] != NULL)
+            i++;
     }
     avt->nsNr = i;
 
     cur = str;
     while (*cur != 0) {
-    if (*cur == '{') {
-        if (*(cur+1) == '{') {  /* escaped '{' */
+        if (*cur == '{') {
+            if (*(cur+1) == '{') {      /* escaped '{' */
+                cur++;
+                ret = xmlStrncat(ret, str, cur - str);
+                cur++;
+                str = cur;
+                continue;
+            }
+            if (*(cur+1) == '}') {      /* skip empty AVT */
+                ret = xmlStrncat(ret, str, cur - str);
+                cur += 2;
+                str = cur;
+                continue;
+            }
+            if ((ret != NULL) || (cur - str > 0)) {
+                ret = xmlStrncat(ret, str, cur - str);
+                str = cur;
+                if (avt->nb_seg == 0)
+                    avt->strstart = 1;
+                if ((avt = xsltSetAttrVTsegment(avt, (void *) ret)) == NULL)
+                    goto error;
+                ret = NULL;
+                lastavt = 0;
+            }
+
             cur++;
-        ret = xmlStrncat(ret, str, cur - str);
-        cur++;
-        str = cur;
-        continue;
-        }
-        if (*(cur+1) == '}') {  /* skip empty AVT */
-        ret = xmlStrncat(ret, str, cur - str);
-            cur += 2;
-        str = cur;
-        continue;
-        }
-        if ((ret != NULL) || (cur - str > 0)) {
+            while ((*cur != 0) && (*cur != '}')) {
+                /* Need to check for literal (bug539741) */
+                if ((*cur == '\'') || (*cur == '"')) {
+                    char delim = *(cur++);
+                    while ((*cur != 0) && (*cur != delim))
+                        cur++;
+                    if (*cur != 0)
+                        cur++;  /* skip the ending delimiter */
+                } else
+                    cur++;
+            }
+            if (*cur == 0) {
+                xsltTransformError(NULL, style, attr->parent,
+                     "Attribute '%s': The AVT has an unmatched '{'.\n",
+                     attr->name);
+                style->errors++;
+                goto error;
+            }
+            str++;
+            expr = xmlStrndup(str, cur - str);
+            if (expr == NULL) {
+                /*
+                * TODO: What needs to be done here?
+                */
+                XSLT_TODO
+                goto error;
+            } else {
+                xmlXPathCompExprPtr comp;
+
+                comp = xsltXPathCompile(style, expr);
+                if (comp == NULL) {
+                    xsltTransformError(NULL, style, attr->parent,
+                         "Attribute '%s': Failed to compile the expression "
+                         "'%s' in the AVT.\n", attr->name, expr);
+                    style->errors++;
+                    goto error;
+                }
+                if (avt->nb_seg == 0)
+                    avt->strstart = 0;
+                if (lastavt == 1) {
+                    if ((avt = xsltSetAttrVTsegment(avt, NULL)) == NULL)
+                        goto error;
+                }
+                if ((avt = xsltSetAttrVTsegment(avt, (void *) comp)) == NULL)
+                    goto error;
+                lastavt = 1;
+                xmlFree(expr);
+                expr = NULL;
+            }
+            cur++;
+            str = cur;
+        } else if (*cur == '}') {
+            cur++;
+            if (*cur == '}') {  /* escaped '}' */
+                ret = xmlStrncat(ret, str, cur - str);
+                cur++;
+                str = cur;
+                continue;
+            } else {
+                xsltTransformError(NULL, style, attr->parent,
+                     "Attribute '%s': The AVT has an unmatched '}'.\n",
+                     attr->name);
+                goto error;
+            }
+        } else
+            cur++;
+    }
+    if ((ret != NULL) || (cur - str > 0)) {
         ret = xmlStrncat(ret, str, cur - str);
         str = cur;
         if (avt->nb_seg == 0)
@@ -249,107 +328,28 @@ xsltCompileAttr(xsltStylesheetPtr style, xmlAttrPtr attr) {
         if ((avt = xsltSetAttrVTsegment(avt, (void *) ret)) == NULL)
             goto error;
         ret = NULL;
-        lastavt = 0;
-        }
-
-        cur++;
-        while ((*cur != 0) && (*cur != '}')) {
-        /* Need to check for literal (bug539741) */
-        if ((*cur == '\'') || (*cur == '"')) {
-            char delim = *(cur++);
-            while ((*cur != 0) && (*cur != delim))
-            cur++;
-            if (*cur != 0)
-            cur++;  /* skip the ending delimiter */
-        } else
-            cur++;
-        }
-        if (*cur == 0) {
-            xsltTransformError(NULL, style, attr->parent,
-             "Attribute '%s': The AVT has an unmatched '{'.\n",
-             attr->name);
-        style->errors++;
-        goto error;
-        }
-        str++;
-        expr = xmlStrndup(str, cur - str);
-        if (expr == NULL) {
-        /*
-        * TODO: What needs to be done here?
-        */
-            XSLT_TODO
-        goto error;
-        } else {
-        xmlXPathCompExprPtr comp;
-
-        comp = xsltXPathCompile(style, expr);
-        if (comp == NULL) {
-            xsltTransformError(NULL, style, attr->parent,
-             "Attribute '%s': Failed to compile the expression "
-             "'%s' in the AVT.\n", attr->name, expr);
-            style->errors++;
-            goto error;
-        }
-        if (avt->nb_seg == 0)
-            avt->strstart = 0;
-        if (lastavt == 1) {
-            if ((avt = xsltSetAttrVTsegment(avt, NULL)) == NULL)
-                goto error;
-        }
-        if ((avt = xsltSetAttrVTsegment(avt, (void *) comp)) == NULL)
-            goto error;
-        lastavt = 1;
-        xmlFree(expr);
-        expr = NULL;
-        }
-        cur++;
-        str = cur;
-    } else if (*cur == '}') {
-        cur++;
-        if (*cur == '}') {  /* escaped '}' */
-        ret = xmlStrncat(ret, str, cur - str);
-        cur++;
-        str = cur;
-        continue;
-        } else {
-            xsltTransformError(NULL, style, attr->parent,
-             "Attribute '%s': The AVT has an unmatched '}'.\n",
-             attr->name);
-        goto error;
-        }
-    } else
-        cur++;
-    }
-    if ((ret != NULL) || (cur - str > 0)) {
-    ret = xmlStrncat(ret, str, cur - str);
-    str = cur;
-    if (avt->nb_seg == 0)
-        avt->strstart = 1;
-    if ((avt = xsltSetAttrVTsegment(avt, (void *) ret)) == NULL)
-        goto error;
-    ret = NULL;
     }
 
 error:
     if (avt == NULL) {
         xsltTransformError(NULL, style, attr->parent,
-        "xsltCompileAttr: malloc problem\n");
+                "xsltCompileAttr: malloc problem\n");
     } else {
         if (attr->psvi != avt) {  /* may have changed from realloc */
             attr->psvi = avt;
-        /*
-         * This is a "hack", but I can't see any clean method of
-         * doing it.  If a re-alloc has taken place, then the pointer
-         * for this AVT may have changed.  style->attVTs was set by
-         * xsltNewAttrVT, so it needs to be re-set to the new value!
-         */
-        style->attVTs = avt;
-    }
+            /*
+             * This is a "hack", but I can't see any clean method of
+             * doing it.  If a re-alloc has taken place, then the pointer
+             * for this AVT may have changed.  style->attVTs was set by
+             * xsltNewAttrVT, so it needs to be re-set to the new value!
+             */
+            style->attVTs = avt;
+        }
     }
     if (ret != NULL)
-    xmlFree(ret);
+        xmlFree(ret);
     if (expr != NULL)
-    xmlFree(expr);
+        xmlFree(expr);
 }
 
 
@@ -377,20 +377,20 @@ xsltEvalAVT(xsltTransformContextPtr ctxt, void *avt, xmlNodePtr node) {
     str = cur->strstart;
     for (i = 0;i < cur->nb_seg;i++) {
         if (str) {
-        ret = xmlStrcat(ret, (const xmlChar *) cur->segments[i]);
-    } else {
-        comp = (xmlXPathCompExprPtr) cur->segments[i];
-        tmp = xsltEvalXPathStringNs(ctxt, comp, cur->nsNr, cur->nsList);
-        if (tmp != NULL) {
-            if (ret != NULL) {
-            ret = xmlStrcat(ret, tmp);
-            xmlFree(tmp);
+            ret = xmlStrcat(ret, (const xmlChar *) cur->segments[i]);
         } else {
-            ret = tmp;
+            comp = (xmlXPathCompExprPtr) cur->segments[i];
+            tmp = xsltEvalXPathStringNs(ctxt, comp, cur->nsNr, cur->nsList);
+            if (tmp != NULL) {
+                if (ret != NULL) {
+                    ret = xmlStrcat(ret, tmp);
+                    xmlFree(tmp);
+                } else {
+                    ret = tmp;
+                }
+            }
         }
-        }
-    }
-    str = !str;
+        str = !str;
     }
     return(ret);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/documents.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/documents.c
@@ -36,9 +36,9 @@
 #endif
 
 /************************************************************************
- *                                  *
- *      Hooks for the document loader               *
- *                                  *
+ *                                                                      *
+ *              Hooks for the document loader                           *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -60,7 +60,7 @@
 static xmlDocPtr
 xsltDocDefaultLoaderFunc(const xmlChar * URI, xmlDictPtr dict, int options,
                          void *ctxt ATTRIBUTE_UNUSED,
-             xsltLoadType type ATTRIBUTE_UNUSED)
+                         xsltLoadType type ATTRIBUTE_UNUSED)
 {
     xmlParserCtxtPtr pctxt;
     xmlParserInputPtr inputStream;
@@ -71,13 +71,13 @@ xsltDocDefaultLoaderFunc(const xmlChar * URI, xmlDictPtr dict, int options,
         return(NULL);
     if ((dict != NULL) && (pctxt->dict != NULL)) {
         xmlDictFree(pctxt->dict);
-    pctxt->dict = NULL;
+        pctxt->dict = NULL;
     }
     if (dict != NULL) {
-    pctxt->dict = dict;
-    xmlDictReference(pctxt->dict);
+        pctxt->dict = dict;
+        xmlDictReference(pctxt->dict);
 #ifdef WITH_XSLT_DEBUG
-    xsltGenericDebug(xsltGenericDebugContext,
+        xsltGenericDebug(xsltGenericDebugContext,
                      "Reusing dictionary for document\n");
 #endif
     }
@@ -85,7 +85,7 @@ xsltDocDefaultLoaderFunc(const xmlChar * URI, xmlDictPtr dict, int options,
     inputStream = xmlLoadExternalEntity((const char *) URI, NULL, pctxt);
     if (inputStream == NULL) {
         xmlFreeParserCtxt(pctxt);
-    return(NULL);
+        return(NULL);
     }
     inputPush(pctxt, inputStream);
     if (pctxt->directory == NULL)
@@ -126,9 +126,9 @@ xsltSetLoaderFunc(xsltDocLoaderFunc f) {
 }
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -146,26 +146,26 @@ xsltNewDocument(xsltTransformContextPtr ctxt, xmlDocPtr doc) {
 
     cur = (xsltDocumentPtr) xmlMalloc(sizeof(xsltDocument));
     if (cur == NULL) {
-    xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
-        "xsltNewDocument : malloc failed\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
+                "xsltNewDocument : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltDocument));
     cur->doc = doc;
     if (ctxt != NULL) {
         if (! XSLT_IS_RES_TREE_FRAG(doc)) {
-        cur->next = ctxt->docList;
-        ctxt->docList = cur;
-    }
-    /*
-    * A key with a specific name for a specific document
-    * will only be computed if there's a call to the key()
-    * function using that specific name for that specific
-    * document. I.e. computation of keys will be done in
-    * xsltGetKey() (keys.c) on an on-demand basis.
-    *
-    * xsltInitCtxtKeys(ctxt, cur); not called here anymore
-    */
+            cur->next = ctxt->docList;
+            ctxt->docList = cur;
+        }
+        /*
+        * A key with a specific name for a specific document
+        * will only be computed if there's a call to the key()
+        * function using that specific name for that specific
+        * document. I.e. computation of keys will be done in
+        * xsltGetKey() (keys.c) on an on-demand basis.
+        *
+        * xsltInitCtxtKeys(ctxt, cur); not called here anymore
+        */
     }
     return(cur);
 }
@@ -185,15 +185,15 @@ xsltNewStyleDocument(xsltStylesheetPtr style, xmlDocPtr doc) {
 
     cur = (xsltDocumentPtr) xmlMalloc(sizeof(xsltDocument));
     if (cur == NULL) {
-    xsltTransformError(NULL, style, (xmlNodePtr) doc,
-        "xsltNewStyleDocument : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, style, (xmlNodePtr) doc,
+                "xsltNewStyleDocument : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltDocument));
     cur->doc = doc;
     if (style != NULL) {
-    cur->next = style->docList;
-    style->docList = cur;
+        cur->next = style->docList;
+        style->docList = cur;
     }
     return(cur);
 }
@@ -214,29 +214,29 @@ xsltFreeStyleDocuments(xsltStylesheetPtr style) {
 #endif
 
     if (style == NULL)
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
     if (XSLT_HAS_INTERNAL_NSMAP(style))
-    nsMap = XSLT_GET_INTERNAL_NSMAP(style);
+        nsMap = XSLT_GET_INTERNAL_NSMAP(style);
     else
-    nsMap = NULL;
+        nsMap = NULL;
 #endif
 
     cur = style->docList;
     while (cur != NULL) {
-    doc = cur;
-    cur = cur->next;
+        doc = cur;
+        cur = cur->next;
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
-    /*
-    * Restore all changed namespace URIs of ns-decls.
-    */
-    if (nsMap)
-        xsltRestoreDocumentNamespaces(nsMap, doc->doc);
+        /*
+        * Restore all changed namespace URIs of ns-decls.
+        */
+        if (nsMap)
+            xsltRestoreDocumentNamespaces(nsMap, doc->doc);
 #endif
-    xsltFreeDocumentKeys(doc);
-    if (!doc->main)
-        xmlFreeDoc(doc->doc);
+        xsltFreeDocumentKeys(doc);
+        if (!doc->main)
+            xmlFreeDoc(doc->doc);
         xmlFree(doc);
     }
 }
@@ -253,20 +253,20 @@ xsltFreeDocuments(xsltTransformContextPtr ctxt) {
 
     cur = ctxt->docList;
     while (cur != NULL) {
-    doc = cur;
-    cur = cur->next;
-    xsltFreeDocumentKeys(doc);
-    if (!doc->main)
-        xmlFreeDoc(doc->doc);
+        doc = cur;
+        cur = cur->next;
+        xsltFreeDocumentKeys(doc);
+        if (!doc->main)
+            xmlFreeDoc(doc->doc);
         xmlFree(doc);
     }
     cur = ctxt->styleList;
     while (cur != NULL) {
-    doc = cur;
-    cur = cur->next;
-    xsltFreeDocumentKeys(doc);
-    if (!doc->main)
-        xmlFreeDoc(doc->doc);
+        doc = cur;
+        cur = cur->next;
+        xsltFreeDocumentKeys(doc);
+        if (!doc->main)
+            xmlFreeDoc(doc->doc);
         xmlFree(doc);
     }
 }
@@ -287,22 +287,22 @@ xsltLoadDocument(xsltTransformContextPtr ctxt, const xmlChar *URI) {
     xmlDocPtr doc;
 
     if ((ctxt == NULL) || (URI == NULL))
-    return(NULL);
+        return(NULL);
 
     /*
      * Security framework check
      */
     if (ctxt->sec != NULL) {
-    int res;
+        int res;
 
-    res = xsltCheckRead(ctxt->sec, ctxt, URI);
-    if (res <= 0) {
+        res = xsltCheckRead(ctxt->sec, ctxt, URI);
+        if (res <= 0) {
             if (res == 0)
                 xsltTransformError(ctxt, NULL, NULL,
                      "xsltLoadDocument: read rights for %s denied\n",
                                  URI);
-        return(NULL);
-    }
+            return(NULL);
+        }
     }
 
     /*
@@ -310,38 +310,38 @@ xsltLoadDocument(xsltTransformContextPtr ctxt, const xmlChar *URI) {
      */
     ret = ctxt->docList;
     while (ret != NULL) {
-    if ((ret->doc != NULL) && (ret->doc->URL != NULL) &&
-        (xmlStrEqual(ret->doc->URL, URI)))
-        return(ret);
-    ret = ret->next;
+        if ((ret->doc != NULL) && (ret->doc->URL != NULL) &&
+            (xmlStrEqual(ret->doc->URL, URI)))
+            return(ret);
+        ret = ret->next;
     }
 
     doc = xsltDocDefaultLoader(URI, ctxt->dict, ctxt->parserOptions,
                                (void *) ctxt, XSLT_LOAD_DOCUMENT);
 
     if (doc == NULL)
-    return(NULL);
+        return(NULL);
 
     if (ctxt->xinclude != 0) {
 #ifdef LIBXML_XINCLUDE_ENABLED
 #if LIBXML_VERSION >= 20603
-    xmlXIncludeProcessFlags(doc, ctxt->parserOptions);
+        xmlXIncludeProcessFlags(doc, ctxt->parserOptions);
 #else
-    xmlXIncludeProcess(doc);
+        xmlXIncludeProcess(doc);
 #endif
 #else
-    xsltTransformError(ctxt, NULL, NULL,
-        "xsltLoadDocument(%s) : XInclude processing not compiled in\n",
-                     URI);
+        xsltTransformError(ctxt, NULL, NULL,
+            "xsltLoadDocument(%s) : XInclude processing not compiled in\n",
+                         URI);
 #endif
     }
     /*
      * Apply white-space stripping if asked for
      */
     if (xsltNeedElemSpaceHandling(ctxt))
-    xsltApplyStripSpaces(ctxt, xmlDocGetRootElement(doc));
+        xsltApplyStripSpaces(ctxt, xmlDocGetRootElement(doc));
     if (ctxt->debugStatus == XSLT_DEBUG_NONE)
-    xmlXPathOrderDocElems(doc);
+        xmlXPathOrderDocElems(doc);
 
     ret = xsltNewDocument(ctxt, doc);
     return(ret);
@@ -363,23 +363,23 @@ xsltLoadStyleDocument(xsltStylesheetPtr style, const xmlChar *URI) {
     xsltSecurityPrefsPtr sec;
 
     if ((style == NULL) || (URI == NULL))
-    return(NULL);
+        return(NULL);
 
     /*
      * Security framework check
      */
     sec = xsltGetDefaultSecurityPrefs();
     if (sec != NULL) {
-    int res;
+        int res;
 
-    res = xsltCheckRead(sec, NULL, URI);
-    if (res <= 0) {
+        res = xsltCheckRead(sec, NULL, URI);
+        if (res <= 0) {
             if (res == 0)
                 xsltTransformError(NULL, NULL, NULL,
                      "xsltLoadStyleDocument: read rights for %s denied\n",
                                  URI);
-        return(NULL);
-    }
+            return(NULL);
+        }
     }
 
     /*
@@ -387,16 +387,16 @@ xsltLoadStyleDocument(xsltStylesheetPtr style, const xmlChar *URI) {
      */
     ret = style->docList;
     while (ret != NULL) {
-    if ((ret->doc != NULL) && (ret->doc->URL != NULL) &&
-        (xmlStrEqual(ret->doc->URL, URI)))
-        return(ret);
-    ret = ret->next;
+        if ((ret->doc != NULL) && (ret->doc->URL != NULL) &&
+            (xmlStrEqual(ret->doc->URL, URI)))
+            return(ret);
+        ret = ret->next;
     }
 
     doc = xsltDocDefaultLoader(URI, style->dict, XSLT_PARSE_OPTIONS,
                                (void *) style, XSLT_LOAD_STYLESHEET);
     if (doc == NULL)
-    return(NULL);
+        return(NULL);
 
     ret = xsltNewStyleDocument(style, doc);
     return(ret);
@@ -418,19 +418,19 @@ xsltFindDocument (xsltTransformContextPtr ctxt, xmlDocPtr doc) {
     xsltDocumentPtr ret;
 
     if ((ctxt == NULL) || (doc == NULL))
-    return(NULL);
+        return(NULL);
 
     /*
      * Walk the context list to find the document
      */
     ret = ctxt->docList;
     while (ret != NULL) {
-    if (ret->doc == doc)
-        return(ret);
-    ret = ret->next;
+        if (ret->doc == doc)
+            return(ret);
+        ret = ret->next;
     }
     if (doc == ctxt->style->doc)
-    return(ctxt->document);
+        return(ctxt->document);
     return(NULL);
 }
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/documents.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/documents.h
@@ -21,25 +21,25 @@ extern "C" {
 #endif
 
 XSLTPUBFUN xsltDocumentPtr XSLTCALL
-        xsltNewDocument     (xsltTransformContextPtr ctxt,
-                     xmlDocPtr doc);
+                xsltNewDocument         (xsltTransformContextPtr ctxt,
+                                         xmlDocPtr doc);
 XSLTPUBFUN xsltDocumentPtr XSLTCALL
-        xsltLoadDocument    (xsltTransformContextPtr ctxt,
-                     const xmlChar *URI);
+                xsltLoadDocument        (xsltTransformContextPtr ctxt,
+                                         const xmlChar *URI);
 XSLTPUBFUN xsltDocumentPtr XSLTCALL
-        xsltFindDocument    (xsltTransformContextPtr ctxt,
-                     xmlDocPtr doc);
+                xsltFindDocument        (xsltTransformContextPtr ctxt,
+                                         xmlDocPtr doc);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeDocuments   (xsltTransformContextPtr ctxt);
+                xsltFreeDocuments       (xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN xsltDocumentPtr XSLTCALL
-        xsltLoadStyleDocument   (xsltStylesheetPtr style,
-                     const xmlChar *URI);
+                xsltLoadStyleDocument   (xsltStylesheetPtr style,
+                                         const xmlChar *URI);
 XSLTPUBFUN xsltDocumentPtr XSLTCALL
-        xsltNewStyleDocument    (xsltStylesheetPtr style,
-                     xmlDocPtr doc);
+                xsltNewStyleDocument    (xsltStylesheetPtr style,
+                                         xmlDocPtr doc);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeStyleDocuments  (xsltStylesheetPtr style);
+                xsltFreeStyleDocuments  (xsltStylesheetPtr style);
 
 /*
  * Hooks for document loading
@@ -51,9 +51,9 @@ XSLTPUBFUN void XSLTCALL
  * Enum defining the kind of loader requirement.
  */
 typedef enum {
-    XSLT_LOAD_START = 0,    /* loading for a top stylesheet */
+    XSLT_LOAD_START = 0,        /* loading for a top stylesheet */
     XSLT_LOAD_STYLESHEET = 1,   /* loading for a stylesheet include/import */
-    XSLT_LOAD_DOCUMENT = 2  /* loading document at transformation time */
+    XSLT_LOAD_DOCUMENT = 2      /* loading document at transformation time */
 } xsltLoadType;
 
 /**
@@ -73,14 +73,14 @@ typedef enum {
  * Returns the pointer to the document (which will be modified and
  * freed by the engine later), or NULL in case of error.
  */
-typedef xmlDocPtr (*xsltDocLoaderFunc)      (const xmlChar *URI,
-                         xmlDictPtr dict,
-                         int options,
-                         void *ctxt,
-                         xsltLoadType type);
+typedef xmlDocPtr (*xsltDocLoaderFunc)          (const xmlChar *URI,
+                                                 xmlDictPtr dict,
+                                                 int options,
+                                                 void *ctxt,
+                                                 xsltLoadType type);
 
 XSLTPUBFUN void XSLTCALL
-        xsltSetLoaderFunc       (xsltDocLoaderFunc f);
+                xsltSetLoaderFunc               (xsltDocLoaderFunc f);
 
 /* the loader may be needed by extension libraries so it is exported */
 XSLTPUBVAR xsltDocLoaderFunc xsltDocDefaultLoader;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extensions.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extensions.c
@@ -44,9 +44,9 @@
 #endif
 
 /************************************************************************
- *                                  *
- *          Private Types and Globals           *
- *                                  *
+ *                                                                      *
+ *                      Private Types and Globals                       *
+ *                                                                      *
  ************************************************************************/
 
 typedef struct _xsltExtDef xsltExtDef;
@@ -89,9 +89,9 @@ static xmlHashTablePtr xsltModuleHash = NULL;
 static xmlMutexPtr xsltExtMutex = NULL;
 
 /************************************************************************
- *                                  *
- *          Type functions                  *
- *                                  *
+ *                                                                      *
+ *                      Type functions                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -393,13 +393,13 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI)
 
     if (NULL == ext_directory) {
         ext_directory = BAD_CAST LIBXSLT_DEFAULT_PLUGINS_PATH();
-    if (NULL == ext_directory)
-      return (-1);
+        if (NULL == ext_directory)
+          return (-1);
     }
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
     else
       xsltGenericDebug(xsltGenericDebugContext,
-               "LIBXSLT_PLUGINS_PATH is %s\n", ext_directory);
+                       "LIBXSLT_PLUGINS_PATH is %s\n", ext_directory);
 #endif
 
     /* build the module filename, and confirm the module exists */
@@ -415,7 +415,7 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI)
     if (1 != xmlCheckFilename(module_filename)) {
 
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
+        xsltGenericDebug(xsltGenericDebugContext,
                      "xmlCheckFilename failed for plugin: %s\n", module_filename);
 #endif
 
@@ -428,7 +428,7 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI)
     if (NULL == m) {
 
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
+        xsltGenericDebug(xsltGenericDebugContext,
                      "xmlModuleOpen failed for plugin: %s\n", module_filename);
 #endif
 
@@ -445,10 +445,10 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI)
     regfunc = vregfunc;
     if (0 == rc) {
         /*
-     * Call the module's init function.  Note that this function
-     * calls xsltRegisterExtModuleFull which will add the module
-     * to xsltExtensionsHash (together with it's entry points).
-     */
+         * Call the module's init function.  Note that this function
+         * calls xsltRegisterExtModuleFull which will add the module
+         * to xsltExtensionsHash (together with it's entry points).
+         */
         (*regfunc) ();
 
         /* register this module in our hash */
@@ -458,7 +458,7 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI)
     } else {
 
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
+        xsltGenericDebug(xsltGenericDebugContext,
                      "xmlModuleSymbol failed for plugin: %s, regfunc: %s\n",
                      module_filename, regfunc_name);
 #endif
@@ -480,9 +480,9 @@ xsltExtModuleRegisterDynamic(const xmlChar * URI ATTRIBUTE_UNUSED)
 #endif
 
 /************************************************************************
- *                                  *
- *      The stylesheet extension prefixes handling      *
- *                                  *
+ *                                                                      *
+ *              The stylesheet extension prefixes handling              *
+ *                                                                      *
  ************************************************************************/
 
 
@@ -527,7 +527,7 @@ xsltRegisterExtPrefix(xsltStylesheetPtr style,
 
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
     xsltGenericDebug(xsltGenericDebugContext,
-    "Registering extension namespace '%s'.\n", URI);
+        "Registering extension namespace '%s'.\n", URI);
 #endif
     def = (xsltExtDefPtr) style->nsDefs;
 #ifdef XSLT_REFACTORED
@@ -584,9 +584,9 @@ xsltRegisterExtPrefix(xsltStylesheetPtr style,
 }
 
 /************************************************************************
- *                                  *
- *      The extensions modules interfaces           *
- *                                  *
+ *                                                                      *
+ *              The extensions modules interfaces                       *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -678,21 +678,21 @@ xsltFreeCtxtExts(xsltTransformContextPtr ctxt)
  */
 static xsltExtDataPtr
 xsltStyleInitializeStylesheetModule(xsltStylesheetPtr style,
-                     const xmlChar * URI)
+                                     const xmlChar * URI)
 {
     xsltExtDataPtr dataContainer;
     void *userData = NULL;
     xsltExtModulePtr module;
 
     if ((style == NULL) || (URI == NULL))
-    return(NULL);
+        return(NULL);
 
     if (xsltExtensionsHash == NULL) {
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Not registered extension module: %s\n", URI);
+        xsltGenericDebug(xsltGenericDebugContext,
+            "Not registered extension module: %s\n", URI);
 #endif
-    return(NULL);
+        return(NULL);
     }
 
     xmlMutexLock(xsltExtMutex);
@@ -703,54 +703,54 @@ xsltStyleInitializeStylesheetModule(xsltStylesheetPtr style,
 
     if (module == NULL) {
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Not registered extension module: %s\n", URI);
+        xsltGenericDebug(xsltGenericDebugContext,
+            "Not registered extension module: %s\n", URI);
 #endif
-    return (NULL);
+        return (NULL);
     }
     /*
     * The specified module was registered so initialize it.
     */
     if (style->extInfos == NULL) {
-    style->extInfos = xmlHashCreate(10);
-    if (style->extInfos == NULL)
-        return (NULL);
+        style->extInfos = xmlHashCreate(10);
+        if (style->extInfos == NULL)
+            return (NULL);
     }
     /*
     * Fire the initialization callback if available.
     */
     if (module->styleInitFunc == NULL) {
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Initializing module with *no* callback: %s\n", URI);
+        xsltGenericDebug(xsltGenericDebugContext,
+            "Initializing module with *no* callback: %s\n", URI);
 #endif
     } else {
 #ifdef WITH_XSLT_DEBUG_EXTENSIONS
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Initializing module with callback: %s\n", URI);
+        xsltGenericDebug(xsltGenericDebugContext,
+            "Initializing module with callback: %s\n", URI);
 #endif
-    /*
-    * Fire the initialization callback.
-    */
-    userData = module->styleInitFunc(style, URI);
+        /*
+        * Fire the initialization callback.
+        */
+        userData = module->styleInitFunc(style, URI);
     }
     /*
     * Store the user-data in the context of the given stylesheet.
     */
     dataContainer = xsltNewExtData(module, userData);
     if (dataContainer == NULL)
-    return (NULL);
+        return (NULL);
 
     if (xmlHashAddEntry(style->extInfos, URI,
-    (void *) dataContainer) < 0)
+        (void *) dataContainer) < 0)
     {
-    xsltTransformError(NULL, style, NULL,
-        "Failed to register module '%s'.\n", URI);
-    style->errors++;
-    if (module->styleShutdownFunc)
-        module->styleShutdownFunc(style, URI, userData);
-    xsltFreeExtData(dataContainer);
-    return (NULL);
+        xsltTransformError(NULL, style, NULL,
+            "Failed to register module '%s'.\n", URI);
+        style->errors++;
+        if (module->styleShutdownFunc)
+            module->styleShutdownFunc(style, URI, userData);
+        xsltFreeExtData(dataContainer);
+        return (NULL);
     }
 
     return(dataContainer);
@@ -776,8 +776,8 @@ xsltStyleGetExtData(xsltStylesheetPtr style, const xmlChar * URI)
     xsltStylesheetPtr tmpStyle;
 
     if ((style == NULL) || (URI == NULL) ||
-    (xsltExtensionsHash == NULL))
-    return (NULL);
+        (xsltExtensionsHash == NULL))
+        return (NULL);
 
 
 #ifdef XSLT_REFACTORED
@@ -787,18 +787,18 @@ xsltStyleGetExtData(xsltStylesheetPtr style, const xmlChar * URI)
     */
     tmpStyle = style;
     while (tmpStyle->parent != NULL)
-    tmpStyle = tmpStyle->parent;
+        tmpStyle = tmpStyle->parent;
     if (tmpStyle->extInfos != NULL) {
-    dataContainer =
-        (xsltExtDataPtr) xmlHashLookup(tmpStyle->extInfos, URI);
-    if (dataContainer != NULL) {
-        /*
-        * The module was already initialized in the context
-        * of this stylesheet; just return the user-data that
-        * comes with it.
-        */
-        return(dataContainer->extData);
-    }
+        dataContainer =
+            (xsltExtDataPtr) xmlHashLookup(tmpStyle->extInfos, URI);
+        if (dataContainer != NULL) {
+            /*
+            * The module was already initialized in the context
+            * of this stylesheet; just return the user-data that
+            * comes with it.
+            */
+            return(dataContainer->extData);
+        }
     }
 #else
     /*
@@ -806,14 +806,14 @@ xsltStyleGetExtData(xsltStylesheetPtr style, const xmlChar * URI)
     */
     tmpStyle = style;
     while (tmpStyle != NULL) {
-    if (tmpStyle->extInfos != NULL) {
-        dataContainer =
-        (xsltExtDataPtr) xmlHashLookup(tmpStyle->extInfos, URI);
-        if (dataContainer != NULL) {
-        return(dataContainer->extData);
+        if (tmpStyle->extInfos != NULL) {
+            dataContainer =
+                (xsltExtDataPtr) xmlHashLookup(tmpStyle->extInfos, URI);
+            if (dataContainer != NULL) {
+                return(dataContainer->extData);
+            }
         }
-    }
-    tmpStyle = xsltNextImport(tmpStyle);
+        tmpStyle = xsltNextImport(tmpStyle);
     }
     tmpStyle = style;
 #endif
@@ -821,7 +821,7 @@ xsltStyleGetExtData(xsltStylesheetPtr style, const xmlChar * URI)
     dataContainer =
         xsltStyleInitializeStylesheetModule(tmpStyle, URI);
     if (dataContainer != NULL)
-    return (dataContainer->extData);
+        return (dataContainer->extData);
     return(NULL);
 }
 
@@ -838,29 +838,29 @@ xsltStyleGetExtData(xsltStylesheetPtr style, const xmlChar * URI)
  */
 void *
 xsltStyleStylesheetLevelGetExtData(xsltStylesheetPtr style,
-                   const xmlChar * URI)
+                                   const xmlChar * URI)
 {
     xsltExtDataPtr dataContainer = NULL;
 
     if ((style == NULL) || (URI == NULL) ||
-    (xsltExtensionsHash == NULL))
-    return (NULL);
+        (xsltExtensionsHash == NULL))
+        return (NULL);
 
     if (style->extInfos != NULL) {
-    dataContainer = (xsltExtDataPtr) xmlHashLookup(style->extInfos, URI);
-    /*
-    * The module was already initialized in the context
-    * of this stylesheet; just return the user-data that
-    * comes with it.
-    */
-    if (dataContainer)
-        return(dataContainer->extData);
+        dataContainer = (xsltExtDataPtr) xmlHashLookup(style->extInfos, URI);
+        /*
+        * The module was already initialized in the context
+        * of this stylesheet; just return the user-data that
+        * comes with it.
+        */
+        if (dataContainer)
+            return(dataContainer->extData);
     }
 
     dataContainer =
         xsltStyleInitializeStylesheetModule(style, URI);
     if (dataContainer != NULL)
-    return (dataContainer->extData);
+        return (dataContainer->extData);
     return(NULL);
 }
 #endif
@@ -1176,24 +1176,24 @@ xsltCheckExtPrefix(xsltStylesheetPtr style, const xmlChar * URI)
 {
 #ifdef XSLT_REFACTORED
     if ((style == NULL) || (style->compCtxt == NULL) ||
-    (XSLT_CCTXT(style)->inode == NULL) ||
-    (XSLT_CCTXT(style)->inode->extElemNs == NULL))
+        (XSLT_CCTXT(style)->inode == NULL) ||
+        (XSLT_CCTXT(style)->inode->extElemNs == NULL))
         return (0);
     /*
     * Lookup the extension namespaces registered
     * at the current node in the stylesheet's tree.
     */
     if (XSLT_CCTXT(style)->inode->extElemNs != NULL) {
-    int i;
-    xsltPointerListPtr list = XSLT_CCTXT(style)->inode->extElemNs;
+        int i;
+        xsltPointerListPtr list = XSLT_CCTXT(style)->inode->extElemNs;
 
-    for (i = 0; i < list->number; i++) {
-        if (xmlStrEqual((const xmlChar *) list->items[i],
-        URI))
-        {
-        return(1);
+        for (i = 0; i < list->number; i++) {
+            if (xmlStrEqual((const xmlChar *) list->items[i],
+                URI))
+            {
+                return(1);
+            }
         }
-    }
     }
 #else
     xsltExtDefPtr cur;
@@ -1204,12 +1204,12 @@ xsltCheckExtPrefix(xsltStylesheetPtr style, const xmlChar * URI)
         URI = BAD_CAST "#default";
     cur = (xsltExtDefPtr) style->nsDefs;
     while (cur != NULL) {
-    /*
-    * NOTE: This was change to work on namespace names rather
-    * than namespace prefixes. This fixes bug #339583.
-    * TODO: Consider renaming the field "prefix" of xsltExtDef
-    *  to "href".
-    */
+        /*
+        * NOTE: This was change to work on namespace names rather
+        * than namespace prefixes. This fixes bug #339583.
+        * TODO: Consider renaming the field "prefix" of xsltExtDef
+        *  to "href".
+        */
         if (xmlStrEqual(URI, cur->prefix))
             return (1);
         cur = cur->next;
@@ -1595,30 +1595,30 @@ xsltPreComputeExtModuleElement(xsltStylesheetPtr style, xmlNodePtr inst)
         return (NULL);
 
     if (ext->precomp != NULL) {
-    /*
-    * REVISIT TODO: Check if the text below is correct.
-    * This will return a xsltElemPreComp structure or NULL.
-    * 1) If the the author of the extension needs a
-    *  custom structure to hold the specific values of
-    *  this extension, he will derive a structure based on
-    *  xsltElemPreComp; thus we obviously *cannot* refactor
-    *  the xsltElemPreComp structure, since all already derived
-    *  user-defined strucures will break.
-    *  Example: For the extension xsl:document,
-    *   in xsltDocumentComp() (preproc.c), the structure
-    *   xsltStyleItemDocument is allocated, filled with
-    *   specific values and returned.
-    * 2) If the author needs no values to be stored in
-    *  this structure, then he'll return NULL;
-    */
+        /*
+        * REVISIT TODO: Check if the text below is correct.
+        * This will return a xsltElemPreComp structure or NULL.
+        * 1) If the the author of the extension needs a
+        *  custom structure to hold the specific values of
+        *  this extension, he will derive a structure based on
+        *  xsltElemPreComp; thus we obviously *cannot* refactor
+        *  the xsltElemPreComp structure, since all already derived
+        *  user-defined strucures will break.
+        *  Example: For the extension xsl:document,
+        *   in xsltDocumentComp() (preproc.c), the structure
+        *   xsltStyleItemDocument is allocated, filled with
+        *   specific values and returned.
+        * 2) If the author needs no values to be stored in
+        *  this structure, then he'll return NULL;
+        */
         comp = ext->precomp(style, inst, ext->transform);
     }
     if (comp == NULL) {
-    /*
-    * Default creation of a xsltElemPreComp structure, if
-    * the author of this extension did not create a custom
-    * structure.
-    */
+        /*
+        * Default creation of a xsltElemPreComp structure, if
+        * the author of this extension did not create a custom
+        * structure.
+        */
         comp = xsltNewElemPreComp(style, inst, ext->transform);
     }
 
@@ -1734,7 +1734,7 @@ xsltExtModuleElementLookup(const xmlChar * name, const xmlChar * URI)
             xmlMutexLock(xsltExtMutex);
 
             ext = (xsltExtElementPtr)
-              xmlHashLookup2(xsltElementsHash, name, URI);
+                  xmlHashLookup2(xsltElementsHash, name, URI);
 
             xmlMutexUnlock(xsltExtMutex);
         }
@@ -1774,7 +1774,7 @@ xsltExtModuleElementPreComputeLookup(const xmlChar * name,
             xmlMutexLock(xsltExtMutex);
 
             ext = (xsltExtElementPtr)
-              xmlHashLookup2(xsltElementsHash, name, URI);
+                  xmlHashLookup2(xsltElementsHash, name, URI);
 
             xmlMutexUnlock(xsltExtMutex);
         }
@@ -1969,15 +1969,9 @@ xsltGetExtInfo(xsltStylesheetPtr style, const xmlChar * URI)
 }
 
 /************************************************************************
- *                                  *
- *      Test module http://xmlsoft.org/XSLT/            *
- *                                  *
- ************************************************************************/
-
-/************************************************************************
- *                                  *
- *      Test of the extension module API            *
- *                                  *
+ *                                                                      *
+ *              Test of the extension module API                        *
+ *                                                                      *
  ************************************************************************/
 
 static xmlChar *testData = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extensions.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extensions.h
@@ -31,7 +31,7 @@ extern "C" {
  */
 
 XSLTPUBFUN void XSLTCALL
-        xsltInitGlobals                 (void);
+                xsltInitGlobals                 (void);
 
 /**
  * xsltStyleExtInitFunction:
@@ -42,8 +42,8 @@ XSLTPUBFUN void XSLTCALL
  *
  * Returns a pointer to the module specific data for this transformation.
  */
-typedef void * (*xsltStyleExtInitFunction)  (xsltStylesheetPtr style,
-                         const xmlChar *URI);
+typedef void * (*xsltStyleExtInitFunction)      (xsltStylesheetPtr style,
+                                                 const xmlChar *URI);
 
 /**
  * xsltStyleExtShutdownFunction:
@@ -54,8 +54,8 @@ typedef void * (*xsltStyleExtInitFunction)  (xsltStylesheetPtr style,
  * A function called at shutdown time of an XSLT extension module.
  */
 typedef void (*xsltStyleExtShutdownFunction)    (xsltStylesheetPtr style,
-                         const xmlChar *URI,
-                         void *data);
+                                                 const xmlChar *URI,
+                                                 void *data);
 
 /**
  * xsltExtInitFunction:
@@ -67,7 +67,7 @@ typedef void (*xsltStyleExtShutdownFunction)    (xsltStylesheetPtr style,
  * Returns a pointer to the module specific data for this transformation.
  */
 typedef void * (*xsltExtInitFunction)   (xsltTransformContextPtr ctxt,
-                     const xmlChar *URI);
+                                         const xmlChar *URI);
 
 /**
  * xsltExtShutdownFunction:
@@ -78,137 +78,137 @@ typedef void * (*xsltExtInitFunction)   (xsltTransformContextPtr ctxt,
  * A function called at shutdown time of an XSLT extension module.
  */
 typedef void (*xsltExtShutdownFunction) (xsltTransformContextPtr ctxt,
-                     const xmlChar *URI,
-                     void *data);
+                                         const xmlChar *URI,
+                                         void *data);
 
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtModule   (const xmlChar *URI,
-                     xsltExtInitFunction initFunc,
-                     xsltExtShutdownFunction shutdownFunc);
+                xsltRegisterExtModule   (const xmlChar *URI,
+                                         xsltExtInitFunction initFunc,
+                                         xsltExtShutdownFunction shutdownFunc);
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtModuleFull
-                    (const xmlChar * URI,
-                     xsltExtInitFunction initFunc,
-                     xsltExtShutdownFunction shutdownFunc,
-                     xsltStyleExtInitFunction styleInitFunc,
-                     xsltStyleExtShutdownFunction styleShutdownFunc);
+                xsltRegisterExtModuleFull
+                                        (const xmlChar * URI,
+                                         xsltExtInitFunction initFunc,
+                                         xsltExtShutdownFunction shutdownFunc,
+                                         xsltStyleExtInitFunction styleInitFunc,
+                                         xsltStyleExtShutdownFunction styleShutdownFunc);
 
 XSLTPUBFUN int XSLTCALL
-        xsltUnregisterExtModule (const xmlChar * URI);
+                xsltUnregisterExtModule (const xmlChar * URI);
 
 XSLTPUBFUN void * XSLTCALL
-        xsltGetExtData      (xsltTransformContextPtr ctxt,
-                     const xmlChar *URI);
+                xsltGetExtData          (xsltTransformContextPtr ctxt,
+                                         const xmlChar *URI);
 
 XSLTPUBFUN void * XSLTCALL
-        xsltStyleGetExtData (xsltStylesheetPtr style,
-                     const xmlChar *URI);
+                xsltStyleGetExtData     (xsltStylesheetPtr style,
+                                         const xmlChar *URI);
 #ifdef XSLT_REFACTORED
 XSLTPUBFUN void * XSLTCALL
-        xsltStyleStylesheetLevelGetExtData(
-                     xsltStylesheetPtr style,
-                     const xmlChar * URI);
+                xsltStyleStylesheetLevelGetExtData(
+                                         xsltStylesheetPtr style,
+                                         const xmlChar * URI);
 #endif
 XSLTPUBFUN void XSLTCALL
-        xsltShutdownCtxtExts    (xsltTransformContextPtr ctxt);
+                xsltShutdownCtxtExts    (xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN void XSLTCALL
-        xsltShutdownExts    (xsltStylesheetPtr style);
+                xsltShutdownExts        (xsltStylesheetPtr style);
 
 XSLTPUBFUN xsltTransformContextPtr XSLTCALL
-        xsltXPathGetTransformContext
-                    (xmlXPathParserContextPtr ctxt);
+                xsltXPathGetTransformContext
+                                        (xmlXPathParserContextPtr ctxt);
 
 /*
  * extension functions
 */
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtModuleFunction
-                    (const xmlChar *name,
-                     const xmlChar *URI,
-                     xmlXPathFunction function);
+                xsltRegisterExtModuleFunction
+                                        (const xmlChar *name,
+                                         const xmlChar *URI,
+                                         xmlXPathFunction function);
 XSLTPUBFUN xmlXPathFunction XSLTCALL
-    xsltExtModuleFunctionLookup (const xmlChar *name,
-                     const xmlChar *URI);
+        xsltExtModuleFunctionLookup     (const xmlChar *name,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltUnregisterExtModuleFunction
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltUnregisterExtModuleFunction
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 
 /*
  * extension elements
  */
 typedef xsltElemPreCompPtr (*xsltPreComputeFunction)
-                    (xsltStylesheetPtr style,
-                     xmlNodePtr inst,
-                     xsltTransformFunction function);
+                                        (xsltStylesheetPtr style,
+                                         xmlNodePtr inst,
+                                         xsltTransformFunction function);
 
 XSLTPUBFUN xsltElemPreCompPtr XSLTCALL
-        xsltNewElemPreComp  (xsltStylesheetPtr style,
-                     xmlNodePtr inst,
-                     xsltTransformFunction function);
+                xsltNewElemPreComp      (xsltStylesheetPtr style,
+                                         xmlNodePtr inst,
+                                         xsltTransformFunction function);
 XSLTPUBFUN void XSLTCALL
-        xsltInitElemPreComp (xsltElemPreCompPtr comp,
-                     xsltStylesheetPtr style,
-                     xmlNodePtr inst,
-                     xsltTransformFunction function,
-                     xsltElemPreCompDeallocator freeFunc);
+                xsltInitElemPreComp     (xsltElemPreCompPtr comp,
+                                         xsltStylesheetPtr style,
+                                         xmlNodePtr inst,
+                                         xsltTransformFunction function,
+                                         xsltElemPreCompDeallocator freeFunc);
 
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtModuleElement
-                    (const xmlChar *name,
-                     const xmlChar *URI,
-                     xsltPreComputeFunction precomp,
-                     xsltTransformFunction transform);
+                xsltRegisterExtModuleElement
+                                        (const xmlChar *name,
+                                         const xmlChar *URI,
+                                         xsltPreComputeFunction precomp,
+                                         xsltTransformFunction transform);
 XSLTPUBFUN xsltTransformFunction XSLTCALL
-        xsltExtElementLookup    (xsltTransformContextPtr ctxt,
-                     const xmlChar *name,
-                     const xmlChar *URI);
+                xsltExtElementLookup    (xsltTransformContextPtr ctxt,
+                                         const xmlChar *name,
+                                         const xmlChar *URI);
 XSLTPUBFUN xsltTransformFunction XSLTCALL
-        xsltExtModuleElementLookup
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltExtModuleElementLookup
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 XSLTPUBFUN xsltPreComputeFunction XSLTCALL
-        xsltExtModuleElementPreComputeLookup
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltExtModuleElementPreComputeLookup
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltUnregisterExtModuleElement
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltUnregisterExtModuleElement
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 
 /*
  * top-level elements
  */
 typedef void (*xsltTopLevelFunction)    (xsltStylesheetPtr style,
-                     xmlNodePtr inst);
+                                         xmlNodePtr inst);
 
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtModuleTopLevel
-                    (const xmlChar *name,
-                     const xmlChar *URI,
-                     xsltTopLevelFunction function);
+                xsltRegisterExtModuleTopLevel
+                                        (const xmlChar *name,
+                                         const xmlChar *URI,
+                                         xsltTopLevelFunction function);
 XSLTPUBFUN xsltTopLevelFunction XSLTCALL
-        xsltExtModuleTopLevelLookup
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltExtModuleTopLevelLookup
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltUnregisterExtModuleTopLevel
-                    (const xmlChar *name,
-                     const xmlChar *URI);
+                xsltUnregisterExtModuleTopLevel
+                                        (const xmlChar *name,
+                                         const xmlChar *URI);
 
 
 /* These 2 functions are deprecated for use within modules. */
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtFunction (xsltTransformContextPtr ctxt,
-                     const xmlChar *name,
-                     const xmlChar *URI,
-                     xmlXPathFunction function);
+                xsltRegisterExtFunction (xsltTransformContextPtr ctxt,
+                                         const xmlChar *name,
+                                         const xmlChar *URI,
+                                         xmlXPathFunction function);
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtElement  (xsltTransformContextPtr ctxt,
-                     const xmlChar *name,
-                     const xmlChar *URI,
-                     xsltTransformFunction function);
+                xsltRegisterExtElement  (xsltTransformContextPtr ctxt,
+                                         const xmlChar *name,
+                                         const xmlChar *URI,
+                                         xsltTransformFunction function);
 
 /*
  * Extension Prefix handling API.
@@ -216,42 +216,42 @@ XSLTPUBFUN int XSLTCALL
  */
 
 XSLTPUBFUN int XSLTCALL
-        xsltRegisterExtPrefix   (xsltStylesheetPtr style,
-                     const xmlChar *prefix,
-                     const xmlChar *URI);
+                xsltRegisterExtPrefix   (xsltStylesheetPtr style,
+                                         const xmlChar *prefix,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltCheckExtPrefix  (xsltStylesheetPtr style,
-                     const xmlChar *URI);
+                xsltCheckExtPrefix      (xsltStylesheetPtr style,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltCheckExtURI     (xsltStylesheetPtr style,
-                     const xmlChar *URI);
+                xsltCheckExtURI         (xsltStylesheetPtr style,
+                                         const xmlChar *URI);
 XSLTPUBFUN int XSLTCALL
-        xsltInitCtxtExts    (xsltTransformContextPtr ctxt);
+                xsltInitCtxtExts        (xsltTransformContextPtr ctxt);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeCtxtExts    (xsltTransformContextPtr ctxt);
+                xsltFreeCtxtExts        (xsltTransformContextPtr ctxt);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeExts        (xsltStylesheetPtr style);
+                xsltFreeExts            (xsltStylesheetPtr style);
 
 XSLTPUBFUN xsltElemPreCompPtr XSLTCALL
-        xsltPreComputeExtModuleElement
-                    (xsltStylesheetPtr style,
-                     xmlNodePtr inst);
+                xsltPreComputeExtModuleElement
+                                        (xsltStylesheetPtr style,
+                                         xmlNodePtr inst);
 /*
  * Extension Infos access.
  * Used by exslt initialisation
  */
 
 XSLTPUBFUN xmlHashTablePtr XSLTCALL
-        xsltGetExtInfo      (xsltStylesheetPtr style,
-                     const xmlChar *URI);
+                xsltGetExtInfo          (xsltStylesheetPtr style,
+                                         const xmlChar *URI);
 
 /**
- * Test module http://xmlsoft.org/XSLT/
+ * Test of the extension module API
  */
 XSLTPUBFUN void XSLTCALL
-        xsltRegisterTestModule  (void);
+                xsltRegisterTestModule  (void);
 XSLTPUBFUN void XSLTCALL
-        xsltDebugDumpExtensions (FILE * output);
+                xsltDebugDumpExtensions (FILE * output);
 
 
 #ifdef __cplusplus

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extra.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extra.c
@@ -37,9 +37,9 @@
 #endif
 
 /************************************************************************
- *                                  *
- *      Handling of XSLT debugging              *
- *                                  *
+ *                                                                      *
+ *              Handling of XSLT debugging                              *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -112,9 +112,9 @@ xsltDebug(xsltTransformContextPtr ctxt, xmlNodePtr node ATTRIBUTE_UNUSED,
 }
 
 /************************************************************************
- *                                  *
- *      Classic extensions as described by M. Kay       *
- *                                  *
+ *                                                                      *
+ *              Classic extensions as described by M. Kay               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -130,21 +130,21 @@ xsltDebug(xsltTransformContextPtr ctxt, xmlNodePtr node ATTRIBUTE_UNUSED,
 void
 xsltFunctionNodeSet(xmlXPathParserContextPtr ctxt, int nargs){
     if (nargs != 1) {
-    xsltTransformError(xsltXPathGetTransformContext(ctxt), NULL, NULL,
-        "node-set() : expects one result-tree arg\n");
-    ctxt->error = XPATH_INVALID_ARITY;
-    return;
+        xsltTransformError(xsltXPathGetTransformContext(ctxt), NULL, NULL,
+                "node-set() : expects one result-tree arg\n");
+        ctxt->error = XPATH_INVALID_ARITY;
+        return;
     }
     if ((ctxt->value == NULL) ||
-    ((ctxt->value->type != XPATH_XSLT_TREE) &&
-     (ctxt->value->type != XPATH_NODESET))) {
-    xsltTransformError(xsltXPathGetTransformContext(ctxt), NULL, NULL,
-        "node-set() invalid arg expecting a result tree\n");
-    ctxt->error = XPATH_INVALID_TYPE;
-    return;
+        ((ctxt->value->type != XPATH_XSLT_TREE) &&
+         (ctxt->value->type != XPATH_NODESET))) {
+        xsltTransformError(xsltXPathGetTransformContext(ctxt), NULL, NULL,
+            "node-set() invalid arg expecting a result tree\n");
+        ctxt->error = XPATH_INVALID_TYPE;
+        return;
     }
     if (ctxt->value->type == XPATH_XSLT_TREE) {
-    ctxt->value->type = XPATH_NODESET;
+        ctxt->value->type = XPATH_NODESET;
     }
 }
 
@@ -168,32 +168,32 @@ xsltRegisterExtras(xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED) {
 void
 xsltRegisterAllExtras (void) {
     xsltRegisterExtModuleFunction((const xmlChar *) "node-set",
-                  XSLT_LIBXSLT_NAMESPACE,
-                  xsltFunctionNodeSet);
+                                  XSLT_LIBXSLT_NAMESPACE,
+                                  xsltFunctionNodeSet);
     xsltRegisterExtModuleFunction((const xmlChar *) "node-set",
-                  XSLT_SAXON_NAMESPACE,
-                  xsltFunctionNodeSet);
+                                  XSLT_SAXON_NAMESPACE,
+                                  xsltFunctionNodeSet);
     xsltRegisterExtModuleFunction((const xmlChar *) "node-set",
-                  XSLT_XT_NAMESPACE,
-                  xsltFunctionNodeSet);
+                                  XSLT_XT_NAMESPACE,
+                                  xsltFunctionNodeSet);
     xsltRegisterExtModuleElement((const xmlChar *) "debug",
-                 XSLT_LIBXSLT_NAMESPACE,
-                 NULL,
-                 xsltDebug);
+                                 XSLT_LIBXSLT_NAMESPACE,
+                                 NULL,
+                                 xsltDebug);
     xsltRegisterExtModuleElement((const xmlChar *) "output",
-                 XSLT_SAXON_NAMESPACE,
-                 xsltDocumentComp,
-                 xsltDocumentElem);
+                                 XSLT_SAXON_NAMESPACE,
+                                 xsltDocumentComp,
+                                 xsltDocumentElem);
     xsltRegisterExtModuleElement((const xmlChar *) "write",
-                 XSLT_XALAN_NAMESPACE,
-                 xsltDocumentComp,
-                 xsltDocumentElem);
+                                 XSLT_XALAN_NAMESPACE,
+                                 xsltDocumentComp,
+                                 xsltDocumentElem);
     xsltRegisterExtModuleElement((const xmlChar *) "document",
-                 XSLT_XT_NAMESPACE,
-                 xsltDocumentComp,
-                 xsltDocumentElem);
+                                 XSLT_XT_NAMESPACE,
+                                 xsltDocumentComp,
+                                 xsltDocumentElem);
     xsltRegisterExtModuleElement((const xmlChar *) "document",
-                 XSLT_NAMESPACE,
-                 xsltDocumentComp,
-                 xsltDocumentElem);
+                                 XSLT_NAMESPACE,
+                                 xsltDocumentComp,
+                                 xsltDocumentElem);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extra.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/extra.h
@@ -45,24 +45,24 @@ extern "C" {
  *
  * This is the Apache project XALAN processor namespace for extensions.
  */
-#define XSLT_XALAN_NAMESPACE ((xmlChar *)   \
-                            "org.apache.xalan.xslt.extensions.Redirect")
+#define XSLT_XALAN_NAMESPACE ((xmlChar *)       \
+                                "org.apache.xalan.xslt.extensions.Redirect")
 
 
 XSLTPUBFUN void XSLTCALL
-        xsltFunctionNodeSet (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+                xsltFunctionNodeSet     (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-        xsltDebug       (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltDebug               (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 
 
 XSLTPUBFUN void XSLTCALL
-        xsltRegisterExtras  (xsltTransformContextPtr ctxt);
+                xsltRegisterExtras      (xsltTransformContextPtr ctxt);
 XSLTPUBFUN void XSLTCALL
-        xsltRegisterAllExtras   (void);
+                xsltRegisterAllExtras   (void);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/functions.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/functions.h
@@ -24,51 +24,51 @@ extern "C" {
  *
  * Registering macro, not general purpose at all but used in different modules.
  */
-#define XSLT_REGISTER_FUNCTION_LOOKUP(ctxt)         \
-    xmlXPathRegisterFuncLookup((ctxt)->xpathCtxt,       \
-    xsltXPathFunctionLookup,                \
-    (void *)(ctxt->xpathCtxt));
+#define XSLT_REGISTER_FUNCTION_LOOKUP(ctxt)                     \
+    xmlXPathRegisterFuncLookup((ctxt)->xpathCtxt,               \
+        xsltXPathFunctionLookup,                                \
+        (void *)(ctxt->xpathCtxt));
 
 XSLTPUBFUN xmlXPathFunction XSLTCALL
-    xsltXPathFunctionLookup     (void *vctxt,
-                     const xmlChar *name,
-                     const xmlChar *ns_uri);
+        xsltXPathFunctionLookup         (void *vctxt,
+                                         const xmlChar *name,
+                                         const xmlChar *ns_uri);
 
 /*
  * Interfaces for the functions implementations.
  */
 
 XSLTPUBFUN void XSLTCALL
-    xsltDocumentFunction        (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltDocumentFunction            (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltKeyFunction         (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltKeyFunction                 (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltUnparsedEntityURIFunction   (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltUnparsedEntityURIFunction   (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltFormatNumberFunction    (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltFormatNumberFunction        (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltGenerateIdFunction      (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltGenerateIdFunction          (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltSystemPropertyFunction  (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltSystemPropertyFunction      (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltElementAvailableFunction    (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltElementAvailableFunction    (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 XSLTPUBFUN void XSLTCALL
-    xsltFunctionAvailableFunction   (xmlXPathParserContextPtr ctxt,
-                     int nargs);
+        xsltFunctionAvailableFunction   (xmlXPathParserContextPtr ctxt,
+                                         int nargs);
 
 /*
  * And the registration
  */
 
 XSLTPUBFUN void XSLTCALL
-    xsltRegisterAllFunctions    (xmlXPathContextPtr ctxt);
+        xsltRegisterAllFunctions        (xmlXPathContextPtr ctxt);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/imports.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/imports.c
@@ -49,9 +49,9 @@
 
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 /**
  * xsltFixImportedCompSteps:
@@ -63,7 +63,7 @@
  *
  */
 static void xsltFixImportedCompSteps(xsltStylesheetPtr master,
-            xsltStylesheetPtr style) {
+                        xsltStylesheetPtr style) {
     xsltStylesheetPtr res;
     xmlHashScan(style->templatesHash, xsltNormalizeCompSteps, master);
     master->extrasNr += style->extrasNr;
@@ -93,33 +93,33 @@ xsltParseStylesheetImport(xsltStylesheetPtr style, xmlNodePtr cur) {
     xsltSecurityPrefsPtr sec;
 
     if ((cur == NULL) || (style == NULL))
-    return (ret);
+        return (ret);
 
     uriRef = xmlGetNsProp(cur, (const xmlChar *)"href", NULL);
     if (uriRef == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:import : missing href attribute\n");
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:import : missing href attribute\n");
+        goto error;
     }
 
     base = xmlNodeGetBase(style->doc, cur);
     URI = xmlBuildURI(uriRef, base);
     if (URI == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:import : invalid URI reference %s\n", uriRef);
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:import : invalid URI reference %s\n", uriRef);
+        goto error;
     }
 
     res = style;
     while (res != NULL) {
         if (res->doc == NULL)
-        break;
-    if (xmlStrEqual(res->doc->URL, URI)) {
-        xsltTransformError(NULL, style, cur,
-           "xsl:import : recursion detected on imported URL %s\n", URI);
-        goto error;
-    }
-    res = res->parent;
+            break;
+        if (xmlStrEqual(res->doc->URL, URI)) {
+            xsltTransformError(NULL, style, cur,
+               "xsl:import : recursion detected on imported URL %s\n", URI);
+            goto error;
+        }
+        res = res->parent;
     }
 
     /*
@@ -127,45 +127,45 @@ xsltParseStylesheetImport(xsltStylesheetPtr style, xmlNodePtr cur) {
      */
     sec = xsltGetDefaultSecurityPrefs();
     if (sec != NULL) {
-    int secres;
+        int secres;
 
-    secres = xsltCheckRead(sec, NULL, URI);
-    if (secres <= 0) {
+        secres = xsltCheckRead(sec, NULL, URI);
+        if (secres <= 0) {
             if (secres == 0)
                 xsltTransformError(NULL, NULL, NULL,
                      "xsl:import: read rights for %s denied\n",
                                  URI);
-        goto error;
-    }
+            goto error;
+        }
     }
 
     import = xsltDocDefaultLoader(URI, style->dict, XSLT_PARSE_OPTIONS,
                                   (void *) style, XSLT_LOAD_STYLESHEET);
     if (import == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:import : unable to load %s\n", URI);
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:import : unable to load %s\n", URI);
+        goto error;
     }
 
     res = xsltParseStylesheetImportedDoc(import, style);
     if (res != NULL) {
-    res->next = style->imports;
-    style->imports = res;
-    if (style->parent == NULL) {
-        xsltFixImportedCompSteps(style, res);
-    }
-    ret = 0;
+        res->next = style->imports;
+        style->imports = res;
+        if (style->parent == NULL) {
+            xsltFixImportedCompSteps(style, res);
+        }
+        ret = 0;
     } else {
-    xmlFreeDoc(import);
-    }
+        xmlFreeDoc(import);
+        }
 
 error:
     if (uriRef != NULL)
-    xmlFree(uriRef);
+        xmlFree(uriRef);
     if (base != NULL)
-    xmlFree(base);
+        xmlFree(base);
     if (URI != NULL)
-    xmlFree(URI);
+        xmlFree(URI);
 
     return (ret);
 }
@@ -193,21 +193,21 @@ xsltParseStylesheetInclude(xsltStylesheetPtr style, xmlNodePtr cur) {
     int oldNopreproc;
 
     if ((cur == NULL) || (style == NULL))
-    return (ret);
+        return (ret);
 
     uriRef = xmlGetNsProp(cur, (const xmlChar *)"href", NULL);
     if (uriRef == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:include : missing href attribute\n");
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:include : missing href attribute\n");
+        goto error;
     }
 
     base = xmlNodeGetBase(style->doc, cur);
     URI = xmlBuildURI(uriRef, base);
     if (URI == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:include : invalid URI reference %s\n", uriRef);
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:include : invalid URI reference %s\n", uriRef);
+        goto error;
     }
 
     /*
@@ -217,27 +217,27 @@ xsltParseStylesheetInclude(xsltStylesheetPtr style, xmlNodePtr cur) {
     docptr = style->includes;
     while (docptr != NULL) {
         if (xmlStrEqual(docptr->doc->URL, URI)) {
-        xsltTransformError(NULL, style, cur,
-            "xsl:include : recursion detected on included URL %s\n", URI);
-        goto error;
-    }
-    docptr = docptr->includes;
+            xsltTransformError(NULL, style, cur,
+                "xsl:include : recursion detected on included URL %s\n", URI);
+            goto error;
+        }
+        docptr = docptr->includes;
     }
 
     include = xsltLoadStyleDocument(style, URI);
     if (include == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:include : unable to load %s\n", URI);
-    goto error;
+        xsltTransformError(NULL, style, cur,
+            "xsl:include : unable to load %s\n", URI);
+        goto error;
     }
 #ifdef XSLT_REFACTORED
     if (IS_XSLT_ELEM_FAST(cur) && (cur->psvi != NULL)) {
-    ((xsltStyleItemIncludePtr) cur->psvi)->include = include;
+        ((xsltStyleItemIncludePtr) cur->psvi)->include = include;
     } else {
-    xsltTransformError(NULL, style, cur,
-        "Internal error: (xsltParseStylesheetInclude) "
-        "The xsl:include element was not compiled.\n", URI);
-    style->errors++;
+        xsltTransformError(NULL, style, cur,
+            "Internal error: (xsltParseStylesheetInclude) "
+            "The xsl:include element was not compiled.\n", URI);
+        style->errors++;
     }
 #endif
     oldDoc = style->doc;
@@ -259,18 +259,18 @@ xsltParseStylesheetInclude(xsltStylesheetPtr style, xmlNodePtr cur) {
     style->includes = include->includes;
     style->doc = oldDoc;
     if (result == NULL) {
-    ret = -1;
-    goto error;
+        ret = -1;
+        goto error;
     }
     ret = 0;
 
 error:
     if (uriRef != NULL)
-    xmlFree(uriRef);
+        xmlFree(uriRef);
     if (base != NULL)
-    xmlFree(base);
+        xmlFree(base);
     if (URI != NULL)
-    xmlFree(URI);
+        xmlFree(URI);
 
     return (ret);
 }
@@ -287,15 +287,15 @@ error:
 xsltStylesheetPtr
 xsltNextImport(xsltStylesheetPtr cur) {
     if (cur == NULL)
-    return(NULL);
+        return(NULL);
     if (cur->imports != NULL)
-    return(cur->imports);
+        return(cur->imports);
     if (cur->next != NULL)
-    return(cur->next) ;
+        return(cur->next) ;
     do {
-    cur = cur->parent;
-    if (cur == NULL) break;
-    if (cur->next != NULL) return(cur->next);
+        cur = cur->parent;
+        if (cur == NULL) break;
+        if (cur->next != NULL) return(cur->next);
     } while (cur != NULL);
     return(cur);
 }
@@ -314,12 +314,12 @@ xsltNeedElemSpaceHandling(xsltTransformContextPtr ctxt) {
     xsltStylesheetPtr style;
 
     if (ctxt == NULL)
-    return(0);
+        return(0);
     style = ctxt->style;
     while (style != NULL) {
-    if (style->stripSpaces != NULL)
-        return(1);
-    style = xsltNextImport(style);
+        if (style->stripSpaces != NULL)
+            return(1);
+        style = xsltNextImport(style);
     }
     return(0);
 }
@@ -342,33 +342,33 @@ xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt, xmlNodePtr node) {
     const xmlChar *val;
 
     if ((ctxt == NULL) || (node == NULL))
-    return(0);
+        return(0);
     style = ctxt->style;
     while (style != NULL) {
-    if (node->ns != NULL) {
-        val = (const xmlChar *)
-          xmlHashLookup2(style->stripSpaces, node->name, node->ns->href);
+        if (node->ns != NULL) {
+            val = (const xmlChar *)
+              xmlHashLookup2(style->stripSpaces, node->name, node->ns->href);
             if (val == NULL) {
                 val = (const xmlChar *)
                     xmlHashLookup2(style->stripSpaces, BAD_CAST "*",
                                    node->ns->href);
             }
-    } else {
-        val = (const xmlChar *)
-          xmlHashLookup2(style->stripSpaces, node->name, NULL);
-    }
-    if (val != NULL) {
-        if (xmlStrEqual(val, (xmlChar *) "strip"))
-        return(1);
-        if (xmlStrEqual(val, (xmlChar *) "preserve"))
-        return(0);
-    }
-    if (style->stripAll == 1)
-        return(1);
-    if (style->stripAll == -1)
-        return(0);
+        } else {
+            val = (const xmlChar *)
+                  xmlHashLookup2(style->stripSpaces, node->name, NULL);
+        }
+        if (val != NULL) {
+            if (xmlStrEqual(val, (xmlChar *) "strip"))
+                return(1);
+            if (xmlStrEqual(val, (xmlChar *) "preserve"))
+                return(0);
+        }
+        if (style->stripAll == 1)
+            return(1);
+        if (style->stripAll == -1)
+            return(0);
 
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
     return(0);
 }
@@ -392,12 +392,12 @@ xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt, xmlNodePtr node) {
  */
 xsltTemplatePtr
 xsltFindTemplate(xsltTransformContextPtr ctxt, const xmlChar *name,
-             const xmlChar *nameURI) {
+                 const xmlChar *nameURI) {
     xsltTemplatePtr cur;
     xsltStylesheetPtr style;
 
     if ((ctxt == NULL) || (name == NULL))
-    return(NULL);
+        return(NULL);
     style = ctxt->style;
     while (style != NULL) {
         if (style->namedTemplates != NULL) {
@@ -407,7 +407,7 @@ xsltFindTemplate(xsltTransformContextPtr ctxt, const xmlChar *name,
                 return(cur);
         }
 
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
     return(NULL);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/imports.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/imports.h
@@ -24,12 +24,12 @@ extern "C" {
  *
  * A macro to import pointers from the stylesheet cascading order.
  */
-#define XSLT_GET_IMPORT_PTR(res, style, name) {         \
-    xsltStylesheetPtr st = style;               \
-    res = NULL;                         \
-    while (st != NULL) {                    \
-    if (st->name != NULL) { res = st->name; break; }    \
-    st = xsltNextImport(st);                \
+#define XSLT_GET_IMPORT_PTR(res, style, name) {                 \
+    xsltStylesheetPtr st = style;                               \
+    res = NULL;                                                 \
+    while (st != NULL) {                                        \
+        if (st->name != NULL) { res = st->name; break; }        \
+        st = xsltNextImport(st);                                \
     }}
 
 /**
@@ -37,35 +37,35 @@ extern "C" {
  *
  * A macro to import intergers from the stylesheet cascading order.
  */
-#define XSLT_GET_IMPORT_INT(res, style, name) {         \
-    xsltStylesheetPtr st = style;               \
-    res = -1;                           \
-    while (st != NULL) {                    \
-    if (st->name != -1) { res = st->name; break; }  \
-    st = xsltNextImport(st);                \
+#define XSLT_GET_IMPORT_INT(res, style, name) {                 \
+    xsltStylesheetPtr st = style;                               \
+    res = -1;                                                   \
+    while (st != NULL) {                                        \
+        if (st->name != -1) { res = st->name; break; }  \
+        st = xsltNextImport(st);                                \
     }}
 
 /*
  * Module interfaces
  */
 XSLTPUBFUN int XSLTCALL
-            xsltParseStylesheetImport(xsltStylesheetPtr style,
-                          xmlNodePtr cur);
+                        xsltParseStylesheetImport(xsltStylesheetPtr style,
+                                                  xmlNodePtr cur);
 XSLTPUBFUN int XSLTCALL
-            xsltParseStylesheetInclude
-                         (xsltStylesheetPtr style,
-                          xmlNodePtr cur);
+                        xsltParseStylesheetInclude
+                                                 (xsltStylesheetPtr style,
+                                                  xmlNodePtr cur);
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltNextImport       (xsltStylesheetPtr style);
+                        xsltNextImport           (xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-            xsltNeedElemSpaceHandling(xsltTransformContextPtr ctxt);
+                        xsltNeedElemSpaceHandling(xsltTransformContextPtr ctxt);
 XSLTPUBFUN int XSLTCALL
-            xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt,
-                          xmlNodePtr node);
+                        xsltFindElemSpaceHandling(xsltTransformContextPtr ctxt,
+                                                  xmlNodePtr node);
 XSLTPUBFUN xsltTemplatePtr XSLTCALL
-            xsltFindTemplate     (xsltTransformContextPtr ctxt,
-                          const xmlChar *name,
-                          const xmlChar *nameURI);
+                        xsltFindTemplate         (xsltTransformContextPtr ctxt,
+                                                  const xmlChar *name,
+                                                  const xmlChar *nameURI);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/keys.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/keys.c
@@ -38,9 +38,9 @@ xsltInitDocKeyTable(xsltTransformContextPtr ctxt, const xmlChar *name,
                     const xmlChar *nameURI);
 
 /************************************************************************
- *                                  *
- *          Type functions                  *
- *                                  *
+ *                                                                      *
+ *                      Type functions                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -58,15 +58,15 @@ xsltNewKeyDef(const xmlChar *name, const xmlChar *nameURI) {
 
     cur = (xsltKeyDefPtr) xmlMalloc(sizeof(xsltKeyDef));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewKeyDef : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewKeyDef : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltKeyDef));
     if (name != NULL)
-    cur->name = xmlStrdup(name);
+        cur->name = xmlStrdup(name);
     if (nameURI != NULL)
-    cur->nameURI = xmlStrdup(nameURI);
+        cur->nameURI = xmlStrdup(nameURI);
     cur->nsList = NULL;
     return(cur);
 }
@@ -80,19 +80,19 @@ xsltNewKeyDef(const xmlChar *name, const xmlChar *nameURI) {
 static void
 xsltFreeKeyDef(xsltKeyDefPtr keyd) {
     if (keyd == NULL)
-    return;
+        return;
     if (keyd->comp != NULL)
-    xmlXPathFreeCompExpr(keyd->comp);
+        xmlXPathFreeCompExpr(keyd->comp);
     if (keyd->usecomp != NULL)
-    xmlXPathFreeCompExpr(keyd->usecomp);
+        xmlXPathFreeCompExpr(keyd->usecomp);
     if (keyd->name != NULL)
-    xmlFree(keyd->name);
+        xmlFree(keyd->name);
     if (keyd->nameURI != NULL)
-    xmlFree(keyd->nameURI);
+        xmlFree(keyd->nameURI);
     if (keyd->match != NULL)
-    xmlFree(keyd->match);
+        xmlFree(keyd->match);
     if (keyd->use != NULL)
-    xmlFree(keyd->use);
+        xmlFree(keyd->use);
     if (keyd->nsList != NULL)
         xmlFree(keyd->nsList);
     memset(keyd, -1, sizeof(xsltKeyDef));
@@ -110,9 +110,9 @@ xsltFreeKeyDefList(xsltKeyDefPtr keyd) {
     xsltKeyDefPtr cur;
 
     while (keyd != NULL) {
-    cur = keyd;
-    keyd = keyd->next;
-    xsltFreeKeyDef(cur);
+        cur = keyd;
+        keyd = keyd->next;
+        xsltFreeKeyDef(cur);
     }
 }
 
@@ -131,15 +131,15 @@ xsltNewKeyTable(const xmlChar *name, const xmlChar *nameURI) {
 
     cur = (xsltKeyTablePtr) xmlMalloc(sizeof(xsltKeyTable));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewKeyTable : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewKeyTable : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltKeyTable));
     if (name != NULL)
-    cur->name = xmlStrdup(name);
+        cur->name = xmlStrdup(name);
     if (nameURI != NULL)
-    cur->nameURI = xmlStrdup(nameURI);
+        cur->nameURI = xmlStrdup(nameURI);
     cur->keys = xmlHashCreate(0);
     return(cur);
 }
@@ -158,13 +158,13 @@ xsltFreeNodeSetEntry(void *payload, const xmlChar *name ATTRIBUTE_UNUSED) {
 static void
 xsltFreeKeyTable(xsltKeyTablePtr keyt) {
     if (keyt == NULL)
-    return;
+        return;
     if (keyt->name != NULL)
-    xmlFree(keyt->name);
+        xmlFree(keyt->name);
     if (keyt->nameURI != NULL)
-    xmlFree(keyt->nameURI);
+        xmlFree(keyt->nameURI);
     if (keyt->keys != NULL)
-    xmlHashFree(keyt->keys, xsltFreeNodeSetEntry);
+        xmlHashFree(keyt->keys, xsltFreeNodeSetEntry);
     memset(keyt, -1, sizeof(xsltKeyTable));
     xmlFree(keyt);
 }
@@ -180,16 +180,16 @@ xsltFreeKeyTableList(xsltKeyTablePtr keyt) {
     xsltKeyTablePtr cur;
 
     while (keyt != NULL) {
-    cur = keyt;
-    keyt = keyt->next;
-    xsltFreeKeyTable(cur);
+        cur = keyt;
+        keyt = keyt->next;
+        xsltFreeKeyTable(cur);
     }
 }
 
 /************************************************************************
- *                                  *
- *      The interpreter for the precompiled patterns        *
- *                                  *
+ *                                                                      *
+ *              The interpreter for the precompiled patterns            *
+ *                                                                      *
  ************************************************************************/
 
 
@@ -202,7 +202,7 @@ xsltFreeKeyTableList(xsltKeyTablePtr keyt) {
 void
 xsltFreeKeys(xsltStylesheetPtr style) {
     if (style->keys)
-    xsltFreeKeyDefList((xsltKeyDefPtr) style->keys);
+        xsltFreeKeyDefList((xsltKeyDefPtr) style->keys);
 }
 
 /**
@@ -224,8 +224,8 @@ skipString(const xmlChar *cur, int end) {
     end++;
     while (cur[end] != 0) {
         if (cur[end] == limit)
-        return(end + 1);
-    end++;
+            return(end + 1);
+        end++;
     }
     return(-1);
 }
@@ -248,18 +248,18 @@ skipPredicate(const xmlChar *cur, int end) {
     end++;
     while (cur[end] != 0) {
         if ((cur[end] == '\'') || (cur[end] == '"')) {
-        end = skipString(cur, end);
-        if (end <= 0)
-            return(-1);
-        continue;
-    } else if (cur[end] == '[') {
+            end = skipString(cur, end);
+            if (end <= 0)
+                return(-1);
+            continue;
+        } else if (cur[end] == '[') {
             level += 1;
-    } else if (cur[end] == ']') {
+        } else if (cur[end] == ']') {
             if (level == 0)
-            return(end + 1);
+                return(end + 1);
             level -= 1;
         }
-    end++;
+        end++;
     }
     return(-1);
 }
@@ -279,18 +279,18 @@ skipPredicate(const xmlChar *cur, int end) {
  */
 int
 xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
-       const xmlChar *nameURI, const xmlChar *match,
-       const xmlChar *use, xmlNodePtr inst) {
+           const xmlChar *nameURI, const xmlChar *match,
+           const xmlChar *use, xmlNodePtr inst) {
     xsltKeyDefPtr key;
     xmlChar *pattern = NULL;
     int current, end, start, i = 0;
 
     if ((style == NULL) || (name == NULL) || (match == NULL) || (use == NULL))
-    return(-1);
+        return(-1);
 
 #ifdef WITH_XSLT_DEBUG_KEYS
     xsltGenericDebug(xsltGenericDebugContext,
-    "Add key %s, match %s, use %s\n", name, match, use);
+        "Add key %s, match %s, use %s\n", name, match, use);
 #endif
 
     key = xsltNewKeyDef(name, nameURI);
@@ -300,7 +300,7 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
     key->nsList = xmlGetNsList(inst->doc, inst);
     if (key->nsList != NULL) {
         while (key->nsList[i] != NULL)
-        i++;
+            i++;
     }
     key->nsNr = i;
 
@@ -309,47 +309,47 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
      */
     current = end = 0;
     while (match[current] != 0) {
-    start = current;
-    while (IS_BLANK_CH(match[current]))
-        current++;
-    end = current;
-    while ((match[end] != 0) && (match[end] != '|')) {
-        if (match[end] == '[') {
-            end = skipPredicate(match, end);
-        if (end <= 0) {
+        start = current;
+        while (IS_BLANK_CH(match[current]))
+            current++;
+        end = current;
+        while ((match[end] != 0) && (match[end] != '|')) {
+            if (match[end] == '[') {
+                end = skipPredicate(match, end);
+                if (end <= 0) {
+                    xsltTransformError(NULL, style, inst,
+                        "xsl:key : 'match' pattern is malformed: %s",
+                        key->match);
+                    if (style != NULL) style->errors++;
+                    goto error;
+                }
+            } else
+                end++;
+        }
+        if (current == end) {
             xsltTransformError(NULL, style, inst,
-                "xsl:key : 'match' pattern is malformed: %s",
-                key->match);
+                               "xsl:key : 'match' pattern is empty\n");
             if (style != NULL) style->errors++;
             goto error;
         }
-        } else
-        end++;
-    }
-    if (current == end) {
-        xsltTransformError(NULL, style, inst,
-                   "xsl:key : 'match' pattern is empty\n");
-        if (style != NULL) style->errors++;
-        goto error;
-    }
-    if (match[start] != '/') {
-        pattern = xmlStrcat(pattern, (xmlChar *)"//");
-        if (pattern == NULL) {
-        if (style != NULL) style->errors++;
-        goto error;
+        if (match[start] != '/') {
+            pattern = xmlStrcat(pattern, (xmlChar *)"//");
+            if (pattern == NULL) {
+                if (style != NULL) style->errors++;
+                goto error;
+            }
         }
-    }
-    pattern = xmlStrncat(pattern, &match[start], end - start);
-    if (pattern == NULL) {
-        if (style != NULL) style->errors++;
-        goto error;
-    }
+        pattern = xmlStrncat(pattern, &match[start], end - start);
+        if (pattern == NULL) {
+            if (style != NULL) style->errors++;
+            goto error;
+        }
 
-    if (match[end] == '|') {
-        pattern = xmlStrcat(pattern, (xmlChar *)"|");
-        end++;
-    }
-    current = end;
+        if (match[end] == '|') {
+            pattern = xmlStrcat(pattern, (xmlChar *)"|");
+            end++;
+        }
+        current = end;
     }
     if (pattern == NULL) {
         xsltTransformError(NULL, style, inst,
@@ -359,7 +359,7 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
     }
 #ifdef WITH_XSLT_DEBUG_KEYS
     xsltGenericDebug(xsltGenericDebugContext,
-    "   resulting pattern %s\n", pattern);
+        "   resulting pattern %s\n", pattern);
 #endif
     /*
     * XSLT-1: "It is an error for the value of either the use
@@ -375,10 +375,10 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
     key->comp = xsltXPathCompile(style, pattern);
 #endif
     if (key->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-        "xsl:key : 'match' pattern compilation failed '%s'\n",
-                 pattern);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+                "xsl:key : 'match' pattern compilation failed '%s'\n",
+                         pattern);
+        if (style != NULL) style->errors++;
     }
 #ifdef XML_XPATH_NOVAR
     key->usecomp = xsltXPathCompileFlags(style, use, XML_XPATH_NOVAR);
@@ -386,10 +386,10 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
     key->usecomp = xsltXPathCompile(style, use);
 #endif
     if (key->usecomp == NULL) {
-    xsltTransformError(NULL, style, inst,
-        "xsl:key : 'use' expression compilation failed '%s'\n",
-                 use);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+                "xsl:key : 'use' expression compilation failed '%s'\n",
+                         use);
+        if (style != NULL) style->errors++;
     }
 
     /*
@@ -398,21 +398,21 @@ xsltAddKey(xsltStylesheetPtr style, const xmlChar *name,
      * order so add the new one at the end.
      */
     if (style->keys == NULL) {
-    style->keys = key;
+        style->keys = key;
     } else {
         xsltKeyDefPtr prev = style->keys;
 
-    while (prev->next != NULL)
-        prev = prev->next;
+        while (prev->next != NULL)
+            prev = prev->next;
 
-    prev->next = key;
+        prev->next = key;
     }
     key->next = NULL;
     key = NULL;
 
 error:
     if (pattern != NULL)
-    xmlFree(pattern);
+        xmlFree(pattern);
     if (key != NULL)
         xsltFreeKeyDef(key);
     return(0);
@@ -433,18 +433,18 @@ error:
  */
 xmlNodeSetPtr
 xsltGetKey(xsltTransformContextPtr ctxt, const xmlChar *name,
-       const xmlChar *nameURI, const xmlChar *value) {
+           const xmlChar *nameURI, const xmlChar *value) {
     xmlNodeSetPtr ret;
     xsltKeyTablePtr table;
     int init_table = 0;
 
     if ((ctxt == NULL) || (name == NULL) || (value == NULL) ||
-    (ctxt->document == NULL))
-    return(NULL);
+        (ctxt->document == NULL))
+        return(NULL);
 
 #ifdef WITH_XSLT_DEBUG_KEYS
     xsltGenericDebug(xsltGenericDebugContext,
-    "Get key %s, value %s\n", name, value);
+        "Get key %s, value %s\n", name, value);
 #endif
 
     /*
@@ -453,33 +453,33 @@ xsltGetKey(xsltTransformContextPtr ctxt, const xmlChar *name,
     if ((ctxt->document->nbKeysComputed < ctxt->nbKeys) &&
         (ctxt->keyInitLevel == 0)) {
         /*
-     * If non-recursive behaviour, just try to initialize all keys
-     */
-    if (xsltInitAllDocKeys(ctxt))
-        return(NULL);
+         * If non-recursive behaviour, just try to initialize all keys
+         */
+        if (xsltInitAllDocKeys(ctxt))
+            return(NULL);
     }
 
 retry:
     table = (xsltKeyTablePtr) ctxt->document->keys;
     while (table != NULL) {
-    if (((nameURI != NULL) == (table->nameURI != NULL)) &&
-        xmlStrEqual(table->name, name) &&
-        xmlStrEqual(table->nameURI, nameURI))
-    {
-        ret = (xmlNodeSetPtr)xmlHashLookup(table->keys, value);
-        return(ret);
-    }
-    table = table->next;
+        if (((nameURI != NULL) == (table->nameURI != NULL)) &&
+            xmlStrEqual(table->name, name) &&
+            xmlStrEqual(table->nameURI, nameURI))
+        {
+            ret = (xmlNodeSetPtr)xmlHashLookup(table->keys, value);
+            return(ret);
+        }
+        table = table->next;
     }
 
     if ((ctxt->keyInitLevel != 0) && (init_table == 0)) {
         /*
-     * Apparently one key is recursive and this one is needed,
-     * initialize just it, that time and retry
-     */
+         * Apparently one key is recursive and this one is needed,
+         * initialize just it, that time and retry
+         */
         xsltInitDocKeyTable(ctxt, name, nameURI);
-    init_table = 1;
-    goto retry;
+        init_table = 1;
+        goto retry;
     }
 
     return(NULL);
@@ -507,30 +507,30 @@ fprintf(stderr, "xsltInitDocKeyTable %s\n", name);
 
     style = ctxt->style;
     while (style != NULL) {
-    keyd = (xsltKeyDefPtr) style->keys;
-    while (keyd != NULL) {
-        if (((keyd->nameURI != NULL) ==
-         (nameURI != NULL)) &&
-        xmlStrEqual(keyd->name, name) &&
-        xmlStrEqual(keyd->nameURI, nameURI))
-        {
-        xsltInitCtxtKey(ctxt, ctxt->document, keyd);
-        if (ctxt->document->nbKeysComputed == ctxt->nbKeys)
-            return(0);
-        found = 1;
+        keyd = (xsltKeyDefPtr) style->keys;
+        while (keyd != NULL) {
+            if (((keyd->nameURI != NULL) ==
+                 (nameURI != NULL)) &&
+                xmlStrEqual(keyd->name, name) &&
+                xmlStrEqual(keyd->nameURI, nameURI))
+            {
+                xsltInitCtxtKey(ctxt, ctxt->document, keyd);
+                if (ctxt->document->nbKeysComputed == ctxt->nbKeys)
+                    return(0);
+                found = 1;
+            }
+            keyd = keyd->next;
         }
-        keyd = keyd->next;
-    }
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
     if (found == 0) {
 #ifdef WITH_XSLT_DEBUG_KEYS
-    XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltInitDocKeyTable: did not found %s\n", name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltInitDocKeyTable: did not found %s\n", name));
 #endif
-    xsltTransformError(ctxt, NULL, keyd? keyd->inst : NULL,
-        "Failed to find key definition for %s\n", name);
-    ctxt->state = XSLT_STATE_STOPPED;
+        xsltTransformError(ctxt, NULL, keyd? keyd->inst : NULL,
+            "Failed to find key definition for %s\n", name);
+        ctxt->state = XSLT_STATE_STOPPED;
         return(-1);
     }
 #ifdef KEY_INIT_DEBUG
@@ -557,7 +557,7 @@ xsltInitAllDocKeys(xsltTransformContextPtr ctxt)
     xsltKeyTablePtr table;
 
     if (ctxt == NULL)
-    return(-1);
+        return(-1);
 
 #ifdef KEY_INIT_DEBUG
 fprintf(stderr, "xsltInitAllDocKeys %d %d\n",
@@ -565,7 +565,7 @@ fprintf(stderr, "xsltInitAllDocKeys %d %d\n",
 #endif
 
     if (ctxt->document->nbKeysComputed == ctxt->nbKeys)
-    return(0);
+        return(0);
 
 
     /*
@@ -573,34 +573,34 @@ fprintf(stderr, "xsltInitAllDocKeys %d %d\n",
     */
     style = ctxt->style;
     while (style) {
-    keyd = (xsltKeyDefPtr) style->keys;
-    while (keyd != NULL) {
+        keyd = (xsltKeyDefPtr) style->keys;
+        while (keyd != NULL) {
 #ifdef KEY_INIT_DEBUG
 fprintf(stderr, "Init key %s\n", keyd->name);
 #endif
-        /*
-        * Check if keys with this QName have been already
-        * computed.
-        */
-        table = (xsltKeyTablePtr) ctxt->document->keys;
-        while (table) {
-        if (((keyd->nameURI != NULL) == (table->nameURI != NULL)) &&
-            xmlStrEqual(keyd->name, table->name) &&
-            xmlStrEqual(keyd->nameURI, table->nameURI))
-        {
-            break;
+            /*
+            * Check if keys with this QName have been already
+            * computed.
+            */
+            table = (xsltKeyTablePtr) ctxt->document->keys;
+            while (table) {
+                if (((keyd->nameURI != NULL) == (table->nameURI != NULL)) &&
+                    xmlStrEqual(keyd->name, table->name) &&
+                    xmlStrEqual(keyd->nameURI, table->nameURI))
+                {
+                    break;
+                }
+                table = table->next;
+            }
+            if (table == NULL) {
+                /*
+                * Keys with this QName have not been yet computed.
+                */
+                xsltInitDocKeyTable(ctxt, keyd->name, keyd->nameURI);
+            }
+            keyd = keyd->next;
         }
-        table = table->next;
-        }
-        if (table == NULL) {
-        /*
-        * Keys with this QName have not been yet computed.
-        */
-        xsltInitDocKeyTable(ctxt, keyd->name, keyd->nameURI);
-        }
-        keyd = keyd->next;
-    }
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
 #ifdef KEY_INIT_DEBUG
 fprintf(stderr, "xsltInitAllDocKeys: done\n");
@@ -620,7 +620,7 @@ fprintf(stderr, "xsltInitAllDocKeys: done\n");
  */
 int
 xsltInitCtxtKey(xsltTransformContextPtr ctxt, xsltDocumentPtr idoc,
-            xsltKeyDefPtr keyDef)
+                xsltKeyDefPtr keyDef)
 {
     int i, len, k;
     xmlNodeSetPtr matchList = NULL, keylist;
@@ -642,21 +642,21 @@ fprintf(stderr, "xsltInitCtxtKey %s : %d\n", keyDef->name, ctxt->keyInitLevel);
 #endif
 
     if ((keyDef->comp == NULL) || (keyDef->usecomp == NULL))
-    return(-1);
+        return(-1);
 
     /*
      * Detect recursive keys
      */
     if (ctxt->keyInitLevel > ctxt->nbKeys) {
 #ifdef WITH_XSLT_DEBUG_KEYS
-    XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,
-               xsltGenericDebug(xsltGenericDebugContext,
-               "xsltInitCtxtKey: key definition of %s is recursive\n",
-               keyDef->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,
+                   xsltGenericDebug(xsltGenericDebugContext,
+                       "xsltInitCtxtKey: key definition of %s is recursive\n",
+                       keyDef->name));
 #endif
-    xsltTransformError(ctxt, NULL, keyDef->inst,
-        "Key definition for %s is recursive\n", keyDef->name);
-    ctxt->state = XSLT_STATE_STOPPED;
+        xsltTransformError(ctxt, NULL, keyDef->inst,
+            "Key definition for %s is recursive\n", keyDef->name);
+        ctxt->state = XSLT_STATE_STOPPED;
         return(-1);
     }
     ctxt->keyInitLevel++;
@@ -698,39 +698,39 @@ fprintf(stderr, "xsltInitCtxtKey %s : %d\n", keyDef->name, ctxt->keyInitLevel);
     if (matchRes == NULL) {
 
 #ifdef WITH_XSLT_DEBUG_KEYS
-    XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltInitCtxtKey: %s evaluation failed\n", keyDef->match));
-#endif
-    xsltTransformError(ctxt, NULL, keyDef->inst,
-        "Failed to evaluate the 'match' expression.\n");
-    ctxt->state = XSLT_STATE_STOPPED;
-    goto error;
-    } else {
-    if (matchRes->type == XPATH_NODESET) {
-        matchList = matchRes->nodesetval;
-
-#ifdef WITH_XSLT_DEBUG_KEYS
-        if (matchList != NULL)
         XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltInitCtxtKey: %s evaluates to %d nodes\n",
-                 keyDef->match, matchList->nodeNr));
-#endif
-    } else {
-        /*
-        * Is not a node set, but must be.
-        */
-#ifdef WITH_XSLT_DEBUG_KEYS
-        XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltInitCtxtKey: %s is not a node set\n", keyDef->match));
+             "xsltInitCtxtKey: %s evaluation failed\n", keyDef->match));
 #endif
         xsltTransformError(ctxt, NULL, keyDef->inst,
-        "The 'match' expression did not evaluate to a node set.\n");
+            "Failed to evaluate the 'match' expression.\n");
         ctxt->state = XSLT_STATE_STOPPED;
         goto error;
-    }
+    } else {
+        if (matchRes->type == XPATH_NODESET) {
+            matchList = matchRes->nodesetval;
+
+#ifdef WITH_XSLT_DEBUG_KEYS
+            if (matchList != NULL)
+                XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltInitCtxtKey: %s evaluates to %d nodes\n",
+                                 keyDef->match, matchList->nodeNr));
+#endif
+        } else {
+            /*
+            * Is not a node set, but must be.
+            */
+#ifdef WITH_XSLT_DEBUG_KEYS
+            XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltInitCtxtKey: %s is not a node set\n", keyDef->match));
+#endif
+            xsltTransformError(ctxt, NULL, keyDef->inst,
+                "The 'match' expression did not evaluate to a node set.\n");
+            ctxt->state = XSLT_STATE_STOPPED;
+            goto error;
+        }
     }
     if ((matchList == NULL) || (matchList->nodeNr <= 0))
-    goto exit;
+        goto exit;
 
     /**
      * Multiple key definitions for the same name are allowed, so
@@ -739,11 +739,11 @@ fprintf(stderr, "xsltInitCtxtKey %s : %d\n", keyDef->name, ctxt->keyInitLevel);
     table = (xsltKeyTablePtr) idoc->keys;
     while (table != NULL) {
         if (xmlStrEqual(table->name, keyDef->name) &&
-        (((keyDef->nameURI == NULL) && (table->nameURI == NULL)) ||
-         ((keyDef->nameURI != NULL) && (table->nameURI != NULL) &&
-          (xmlStrEqual(table->nameURI, keyDef->nameURI)))))
-        break;
-    table = table->next;
+            (((keyDef->nameURI == NULL) && (table->nameURI == NULL)) ||
+             ((keyDef->nameURI != NULL) && (table->nameURI != NULL) &&
+              (xmlStrEqual(table->nameURI, keyDef->nameURI)))))
+            break;
+        table = table->next;
     }
     /**
      * If the key was not previously defined, create it now and
@@ -752,7 +752,7 @@ fprintf(stderr, "xsltInitCtxtKey %s : %d\n", keyDef->name, ctxt->keyInitLevel);
     if (table == NULL) {
         table = xsltNewKeyTable(keyDef->name, keyDef->nameURI);
         if (table == NULL)
-        goto error;
+            goto error;
         table->next = idoc->keys;
         idoc->keys = table;
     }
@@ -767,100 +767,100 @@ fprintf(stderr, "xsltInitCtxtKey %s : %d\n", keyDef->name, ctxt->keyInitLevel);
     xpctxt->proximityPosition = 1;
 
     for (i = 0; i < matchList->nodeNr; i++) {
-    cur = matchList->nodeTab[i];
-    if (! IS_XSLT_REAL_NODE(cur))
-        continue;
+        cur = matchList->nodeTab[i];
+        if (! IS_XSLT_REAL_NODE(cur))
+            continue;
         ctxt->node = cur;
-    xpctxt->node = cur;
-    /*
-    * Process the 'use' of the xsl:key.
-    * SPEC XSLT 1.0:
-    * "The use attribute is an expression specifying the values of
-    *  the key; the expression is evaluated once for each node that
-    *  matches the pattern."
-    */
-    if (useRes != NULL)
-        xmlXPathFreeObject(useRes);
-    useRes = xmlXPathCompiledEval(keyDef->usecomp, xpctxt);
-    if (useRes == NULL) {
-        xsltTransformError(ctxt, NULL, keyDef->inst,
-        "Failed to evaluate the 'use' expression.\n");
-        ctxt->state = XSLT_STATE_STOPPED;
-        break;
-    }
-    if (useRes->type == XPATH_NODESET) {
-        if ((useRes->nodesetval != NULL) &&
-        (useRes->nodesetval->nodeNr != 0))
-        {
-        len = useRes->nodesetval->nodeNr;
-        str = xmlXPathCastNodeToString(useRes->nodesetval->nodeTab[0]);
-        } else {
-        continue;
-        }
-    } else {
-        len = 1;
-        if (useRes->type == XPATH_STRING) {
+        xpctxt->node = cur;
         /*
-        * Consume the string value.
+        * Process the 'use' of the xsl:key.
+        * SPEC XSLT 1.0:
+        * "The use attribute is an expression specifying the values of
+        *  the key; the expression is evaluated once for each node that
+        *  matches the pattern."
         */
-        str = useRes->stringval;
-        useRes->stringval = NULL;
-        } else {
-        str = xmlXPathCastToString(useRes);
+        if (useRes != NULL)
+            xmlXPathFreeObject(useRes);
+        useRes = xmlXPathCompiledEval(keyDef->usecomp, xpctxt);
+        if (useRes == NULL) {
+            xsltTransformError(ctxt, NULL, keyDef->inst,
+                "Failed to evaluate the 'use' expression.\n");
+            ctxt->state = XSLT_STATE_STOPPED;
+            break;
         }
-    }
-    /*
-    * Process all strings.
-    */
-    k = 0;
-    while (1) {
-        if (str == NULL)
-        goto next_string;
+        if (useRes->type == XPATH_NODESET) {
+            if ((useRes->nodesetval != NULL) &&
+                (useRes->nodesetval->nodeNr != 0))
+            {
+                len = useRes->nodesetval->nodeNr;
+                str = xmlXPathCastNodeToString(useRes->nodesetval->nodeTab[0]);
+            } else {
+                continue;
+            }
+        } else {
+            len = 1;
+            if (useRes->type == XPATH_STRING) {
+                /*
+                * Consume the string value.
+                */
+                str = useRes->stringval;
+                useRes->stringval = NULL;
+            } else {
+                str = xmlXPathCastToString(useRes);
+            }
+        }
+        /*
+        * Process all strings.
+        */
+        k = 0;
+        while (1) {
+            if (str == NULL)
+                goto next_string;
 
 #ifdef WITH_XSLT_DEBUG_KEYS
-        XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
-        "xsl:key : node associated to ('%s', '%s')\n", keyDef->name, str));
+            XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext,
+                "xsl:key : node associated to ('%s', '%s')\n", keyDef->name, str));
 #endif
 
-        keylist = xmlHashLookup(table->keys, str);
-        if (keylist == NULL) {
-        keylist = xmlXPathNodeSetCreate(cur);
-        if (keylist == NULL)
-            goto error;
-        xmlHashAddEntry(table->keys, str, keylist);
-        } else {
-        /*
-        * TODO: How do we know if this function failed?
-        */
-        xmlXPathNodeSetAdd(keylist, cur);
-        }
-        switch (cur->type) {
-        case XML_ELEMENT_NODE:
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        case XML_PI_NODE:
-        case XML_COMMENT_NODE:
-            cur->psvi = keyDef;
-            break;
-        case XML_ATTRIBUTE_NODE:
-            ((xmlAttrPtr) cur)->psvi = keyDef;
-            break;
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-            ((xmlDocPtr) cur)->psvi = keyDef;
-            break;
-        default:
-            break;
-        }
-        xmlFree(str);
-        str = NULL;
+            keylist = xmlHashLookup(table->keys, str);
+            if (keylist == NULL) {
+                keylist = xmlXPathNodeSetCreate(cur);
+                if (keylist == NULL)
+                    goto error;
+                xmlHashAddEntry(table->keys, str, keylist);
+            } else {
+                /*
+                * TODO: How do we know if this function failed?
+                */
+                xmlXPathNodeSetAdd(keylist, cur);
+            }
+            switch (cur->type) {
+                case XML_ELEMENT_NODE:
+                case XML_TEXT_NODE:
+                case XML_CDATA_SECTION_NODE:
+                case XML_PI_NODE:
+                case XML_COMMENT_NODE:
+                    cur->psvi = keyDef;
+                    break;
+                case XML_ATTRIBUTE_NODE:
+                    ((xmlAttrPtr) cur)->psvi = keyDef;
+                    break;
+                case XML_DOCUMENT_NODE:
+                case XML_HTML_DOCUMENT_NODE:
+                    ((xmlDocPtr) cur)->psvi = keyDef;
+                    break;
+                default:
+                    break;
+            }
+            xmlFree(str);
+            str = NULL;
 
 next_string:
-        k++;
-        if (k >= len)
-        break;
-        str = xmlXPathCastNodeToString(useRes->nodesetval->nodeTab[k]);
-    }
+            k++;
+            if (k >= len)
+                break;
+            str = xmlXPathCastNodeToString(useRes->nodesetval->nodeTab[k]);
+        }
     }
 
 exit:
@@ -881,11 +881,11 @@ error:
     ctxt->inst = oldInst;
 
     if (str)
-    xmlFree(str);
+        xmlFree(str);
     if (useRes != NULL)
-    xmlXPathFreeObject(useRes);
+        xmlXPathFreeObject(useRes);
     if (matchRes != NULL)
-    xmlXPathFreeObject(matchRes);
+        xmlXPathFreeObject(matchRes);
     return(0);
 }
 
@@ -904,7 +904,7 @@ xsltInitCtxtKeys(xsltTransformContextPtr ctxt, xsltDocumentPtr idoc) {
     xsltKeyDefPtr keyDef;
 
     if ((ctxt == NULL) || (idoc == NULL))
-    return;
+        return;
 
 #ifdef KEY_INIT_DEBUG
 fprintf(stderr, "xsltInitCtxtKeys on document\n");
@@ -912,19 +912,19 @@ fprintf(stderr, "xsltInitCtxtKeys on document\n");
 
 #ifdef WITH_XSLT_DEBUG_KEYS
     if ((idoc->doc != NULL) && (idoc->doc->URL != NULL))
-    XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext, "Initializing keys on %s\n",
-             idoc->doc->URL));
+        XSLT_TRACE(ctxt,XSLT_TRACE_KEYS,xsltGenericDebug(xsltGenericDebugContext, "Initializing keys on %s\n",
+                     idoc->doc->URL));
 #endif
     style = ctxt->style;
     while (style != NULL) {
-    keyDef = (xsltKeyDefPtr) style->keys;
-    while (keyDef != NULL) {
-        xsltInitCtxtKey(ctxt, idoc, keyDef);
+        keyDef = (xsltKeyDefPtr) style->keys;
+        while (keyDef != NULL) {
+            xsltInitCtxtKey(ctxt, idoc, keyDef);
 
-        keyDef = keyDef->next;
-    }
+            keyDef = keyDef->next;
+        }
 
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
 
 #ifdef KEY_INIT_DEBUG

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/keys.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/keys.h
@@ -26,24 +26,24 @@ extern "C" {
 #define NODE_IS_KEYED (1 >> 15)
 
 XSLTPUBFUN int XSLTCALL
-        xsltAddKey      (xsltStylesheetPtr style,
-                     const xmlChar *name,
-                     const xmlChar *nameURI,
-                     const xmlChar *match,
-                     const xmlChar *use,
-                     xmlNodePtr inst);
+                xsltAddKey              (xsltStylesheetPtr style,
+                                         const xmlChar *name,
+                                         const xmlChar *nameURI,
+                                         const xmlChar *match,
+                                         const xmlChar *use,
+                                         xmlNodePtr inst);
 XSLTPUBFUN xmlNodeSetPtr XSLTCALL
-        xsltGetKey      (xsltTransformContextPtr ctxt,
-                     const xmlChar *name,
-                     const xmlChar *nameURI,
-                     const xmlChar *value);
+                xsltGetKey              (xsltTransformContextPtr ctxt,
+                                         const xmlChar *name,
+                                         const xmlChar *nameURI,
+                                         const xmlChar *value);
 XSLTPUBFUN void XSLTCALL
-        xsltInitCtxtKeys    (xsltTransformContextPtr ctxt,
-                     xsltDocumentPtr doc);
+                xsltInitCtxtKeys        (xsltTransformContextPtr ctxt,
+                                         xsltDocumentPtr doc);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeKeys        (xsltStylesheetPtr style);
+                xsltFreeKeys            (xsltStylesheetPtr style);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeDocumentKeys    (xsltDocumentPtr doc);
+                xsltFreeDocumentKeys    (xsltDocumentPtr doc);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/libxslt.3
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/libxslt.3
@@ -21,7 +21,7 @@ binary application to do XSL transformations on the command line
 .SH AUTHORS
 Daniel Veillard (daniel@veillard.com).
 If you download and install this package look at instructions on the
-Web site http://xmlsoft.org/XSLT/ .
+Web site https://gitlab.gnome.org/GNOME/libxslt .
 Manual page by Heiko W. Rupp (hwr@pilhuhn.de)
 .SH SEE ALSO
 .IR libexslt (3), 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/namespaces.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/namespaces.c
@@ -50,9 +50,9 @@
 #include "imports.h"
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef XSLT_REFACTORED
@@ -62,14 +62,14 @@ xsltNewNsAlias(xsltCompilerCtxtPtr cctxt)
     xsltNsAliasPtr ret;
 
     if (cctxt == NULL)
-    return(NULL);
+        return(NULL);
 
     ret = (xsltNsAliasPtr) xmlMalloc(sizeof(xsltNsAlias));
     if (ret == NULL) {
-    xsltTransformError(NULL, cctxt->style, NULL,
-        "Internal error in xsltNewNsAlias(): Memory allocation failed.\n");
-    cctxt->style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, cctxt->style, NULL,
+            "Internal error in xsltNewNsAlias(): Memory allocation failed.\n");
+        cctxt->style->errors++;
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltNsAlias));
     /*
@@ -101,7 +101,7 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
     xsltNsAliasPtr alias;
 
     if ((style == NULL) || (node == NULL))
-    return;
+        return;
 
     /*
     * SPEC XSLT 1.0:
@@ -127,43 +127,43 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
     */
     stylePrefix = xmlGetNsProp(node, (const xmlChar *)"stylesheet-prefix", NULL);
     if (stylePrefix == NULL) {
-    xsltTransformError(NULL, style, node,
-        "The attribute 'stylesheet-prefix' is missing.\n");
-    return;
+        xsltTransformError(NULL, style, node,
+            "The attribute 'stylesheet-prefix' is missing.\n");
+        return;
     }
     if (xmlStrEqual(stylePrefix, (const xmlChar *)"#default"))
-    literalNs = xmlSearchNs(node->doc, node, NULL);
+        literalNs = xmlSearchNs(node->doc, node, NULL);
     else {
-    literalNs = xmlSearchNs(node->doc, node, stylePrefix);
-    if (literalNs == NULL) {
-        xsltTransformError(NULL, style, node,
-            "Attribute 'stylesheet-prefix': There's no namespace "
-        "declaration in scope for the prefix '%s'.\n",
-            stylePrefix);
-        goto error;
-    }
+        literalNs = xmlSearchNs(node->doc, node, stylePrefix);
+        if (literalNs == NULL) {
+            xsltTransformError(NULL, style, node,
+                "Attribute 'stylesheet-prefix': There's no namespace "
+                "declaration in scope for the prefix '%s'.\n",
+                    stylePrefix);
+            goto error;
+        }
     }
     /*
     * Attribute "result-prefix".
     */
     resultPrefix = xmlGetNsProp(node, (const xmlChar *)"result-prefix", NULL);
     if (resultPrefix == NULL) {
-    xsltTransformError(NULL, style, node,
-        "The attribute 'result-prefix' is missing.\n");
-    goto error;
-    }
-    if (xmlStrEqual(resultPrefix, (const xmlChar *)"#default"))
-    targetNs = xmlSearchNs(node->doc, node, NULL);
-    else {
-    targetNs = xmlSearchNs(node->doc, node, resultPrefix);
-
-        if (targetNs == NULL) {
-       xsltTransformError(NULL, style, node,
-            "Attribute 'result-prefix': There's no namespace "
-        "declaration in scope for the prefix '%s'.\n",
-            stylePrefix);
+        xsltTransformError(NULL, style, node,
+            "The attribute 'result-prefix' is missing.\n");
         goto error;
     }
+    if (xmlStrEqual(resultPrefix, (const xmlChar *)"#default"))
+        targetNs = xmlSearchNs(node->doc, node, NULL);
+    else {
+        targetNs = xmlSearchNs(node->doc, node, resultPrefix);
+
+        if (targetNs == NULL) {
+           xsltTransformError(NULL, style, node,
+                "Attribute 'result-prefix': There's no namespace "
+                "declaration in scope for the prefix '%s'.\n",
+                    stylePrefix);
+            goto error;
+        }
     }
     /*
      *
@@ -204,7 +204,7 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
     */
     alias = xsltNewNsAlias(XSLT_CCTXT(style));
     if (alias == NULL)
-    return;
+        return;
     alias->literalNs = literalNs;
     alias->targetNs = targetNs;
     XSLT_CCTXT(style)->hasNsAliases = 1;
@@ -216,37 +216,37 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
 
 
     if ((style == NULL) || (node == NULL))
-    return;
+        return;
 
     stylePrefix = xmlGetNsProp(node, (const xmlChar *)"stylesheet-prefix", NULL);
     if (stylePrefix == NULL) {
-    xsltTransformError(NULL, style, node,
-        "namespace-alias: stylesheet-prefix attribute missing\n");
-    return;
+        xsltTransformError(NULL, style, node,
+            "namespace-alias: stylesheet-prefix attribute missing\n");
+        return;
     }
     resultPrefix = xmlGetNsProp(node, (const xmlChar *)"result-prefix", NULL);
     if (resultPrefix == NULL) {
-    xsltTransformError(NULL, style, node,
-        "namespace-alias: result-prefix attribute missing\n");
-    goto error;
+        xsltTransformError(NULL, style, node,
+            "namespace-alias: result-prefix attribute missing\n");
+        goto error;
     }
 
     if (xmlStrEqual(stylePrefix, (const xmlChar *)"#default")) {
-    literalNs = xmlSearchNs(node->doc, node, NULL);
-    if (literalNs == NULL) {
-        literalNsName = NULL;
-    } else
-        literalNsName = literalNs->href; /* Yes - set for nsAlias table */
+        literalNs = xmlSearchNs(node->doc, node, NULL);
+        if (literalNs == NULL) {
+            literalNsName = NULL;
+        } else
+            literalNsName = literalNs->href; /* Yes - set for nsAlias table */
     } else {
-    literalNs = xmlSearchNs(node->doc, node, stylePrefix);
+        literalNs = xmlSearchNs(node->doc, node, stylePrefix);
 
-    if ((literalNs == NULL) || (literalNs->href == NULL)) {
-        xsltTransformError(NULL, style, node,
-            "namespace-alias: prefix %s not bound to any namespace\n",
-                    stylePrefix);
-        goto error;
-    } else
-        literalNsName = literalNs->href;
+        if ((literalNs == NULL) || (literalNs->href == NULL)) {
+            xsltTransformError(NULL, style, node,
+                "namespace-alias: prefix %s not bound to any namespace\n",
+                                        stylePrefix);
+            goto error;
+        } else
+            literalNsName = literalNs->href;
     }
 
     /*
@@ -255,21 +255,21 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
      * put into the nsAliases table
      */
     if (xmlStrEqual(resultPrefix, (const xmlChar *)"#default")) {
-    targetNs = xmlSearchNs(node->doc, node, NULL);
-    if (targetNs == NULL) {
-        targetNsName = UNDEFINED_DEFAULT_NS;
-    } else
-        targetNsName = targetNs->href;
+        targetNs = xmlSearchNs(node->doc, node, NULL);
+        if (targetNs == NULL) {
+            targetNsName = UNDEFINED_DEFAULT_NS;
+        } else
+            targetNsName = targetNs->href;
     } else {
-    targetNs = xmlSearchNs(node->doc, node, resultPrefix);
+        targetNs = xmlSearchNs(node->doc, node, resultPrefix);
 
         if ((targetNs == NULL) || (targetNs->href == NULL)) {
-        xsltTransformError(NULL, style, node,
-            "namespace-alias: prefix %s not bound to any namespace\n",
-                    resultPrefix);
-        goto error;
-    } else
-        targetNsName = targetNs->href;
+            xsltTransformError(NULL, style, node,
+                "namespace-alias: prefix %s not bound to any namespace\n",
+                                        resultPrefix);
+            goto error;
+        } else
+            targetNsName = targetNs->href;
     }
     /*
      * Special case: if #default is used for
@@ -278,37 +278,37 @@ xsltNamespaceAlias(xsltStylesheetPtr style, xmlNodePtr node)
      */
     if (literalNsName == NULL) {
         if (targetNs != NULL) {
-        /*
-        * BUG TODO: Is it not sufficient to have only 1 field for
-        *  this, since subsequently alias declarations will
-        *  overwrite this.
-        *  Example:
-        *   <xsl:namespace-alias result-prefix="foo"
-        *                        stylesheet-prefix="#default"/>
-        *   <xsl:namespace-alias result-prefix="bar"
-        *                        stylesheet-prefix="#default"/>
-        *  The mapping for "foo" won't be visible anymore.
-        */
+            /*
+            * BUG TODO: Is it not sufficient to have only 1 field for
+            *  this, since subsequently alias declarations will
+            *  overwrite this.
+            *  Example:
+            *   <xsl:namespace-alias result-prefix="foo"
+            *                        stylesheet-prefix="#default"/>
+            *   <xsl:namespace-alias result-prefix="bar"
+            *                        stylesheet-prefix="#default"/>
+            *  The mapping for "foo" won't be visible anymore.
+            */
             style->defaultAlias = targetNs->href;
-    }
+        }
     } else {
         if (style->nsAliases == NULL)
-        style->nsAliases = xmlHashCreate(10);
+            style->nsAliases = xmlHashCreate(10);
         if (style->nsAliases == NULL) {
-        xsltTransformError(NULL, style, node,
-            "namespace-alias: cannot create hash table\n");
-        goto error;
+            xsltTransformError(NULL, style, node,
+                "namespace-alias: cannot create hash table\n");
+            goto error;
         }
-    xmlHashAddEntry((xmlHashTablePtr) style->nsAliases,
-        literalNsName, (void *) targetNsName);
+        xmlHashAddEntry((xmlHashTablePtr) style->nsAliases,
+            literalNsName, (void *) targetNsName);
     }
 #endif /* else of XSLT_REFACTORED */
 
 error:
     if (stylePrefix != NULL)
-    xmlFree(stylePrefix);
+        xmlFree(stylePrefix);
     if (resultPrefix != NULL)
-    xmlFree(resultPrefix);
+        xmlFree(resultPrefix);
 }
 
 /**
@@ -335,15 +335,15 @@ error:
  */
 xmlNsPtr
 xsltGetSpecialNamespace(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
-        const xmlChar *nsName, const xmlChar *nsPrefix,
-        xmlNodePtr target)
+                const xmlChar *nsName, const xmlChar *nsPrefix,
+                xmlNodePtr target)
 {
     xmlNsPtr ns;
     int prefixOccupied = 0;
 
     if ((ctxt == NULL) || (target == NULL) ||
-    (target->type != XML_ELEMENT_NODE))
-    return(NULL);
+        (target->type != XML_ELEMENT_NODE))
+        return(NULL);
 
     /*
     * NOTE: Namespace exclusion and ns-aliasing is performed at
@@ -360,219 +360,219 @@ xsltGetSpecialNamespace(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
     *  the ns-decls currently in-scope via a specialized context.
     */
     if ((nsPrefix == NULL) && ((nsName == NULL) || (nsName[0] == 0))) {
-    /*
-    * NOTE: the "undeclaration" of the default namespace was
-    * part of the logic of the old xsltGetSpecialNamespace() code,
-    * so we'll keep that mechanism.
-    * Related to the old code: bug #302020:
-    */
-    /*
-    * OPTIMIZE TODO: This all could be optimized by keeping track of
-    *  the ns-decls currently in-scope via a specialized context.
-    */
-    /*
-    * Search on the result element itself.
-    */
-    if (target->nsDef != NULL) {
-        ns = target->nsDef;
-        do {
-        if (ns->prefix == NULL) {
-            if ((ns->href != NULL) && (ns->href[0] != 0)) {
-            /*
-            * Raise a namespace normalization error.
-            */
-            xsltTransformError(ctxt, NULL, invocNode,
-                "Namespace normalization error: Cannot undeclare "
-                "the default namespace, since the default namespace "
-                "'%s' is already declared on the result element "
-                "'%s'.\n", ns->href, target->name);
-            return(NULL);
-            } else {
-            /*
-            * The default namespace was undeclared on the
-            * result element.
-            */
-            return(NULL);
-            }
-            break;
+        /*
+        * NOTE: the "undeclaration" of the default namespace was
+        * part of the logic of the old xsltGetSpecialNamespace() code,
+        * so we'll keep that mechanism.
+        * Related to the old code: bug #302020:
+        */
+        /*
+        * OPTIMIZE TODO: This all could be optimized by keeping track of
+        *  the ns-decls currently in-scope via a specialized context.
+        */
+        /*
+        * Search on the result element itself.
+        */
+        if (target->nsDef != NULL) {
+            ns = target->nsDef;
+            do {
+                if (ns->prefix == NULL) {
+                    if ((ns->href != NULL) && (ns->href[0] != 0)) {
+                        /*
+                        * Raise a namespace normalization error.
+                        */
+                        xsltTransformError(ctxt, NULL, invocNode,
+                            "Namespace normalization error: Cannot undeclare "
+                            "the default namespace, since the default namespace "
+                            "'%s' is already declared on the result element "
+                            "'%s'.\n", ns->href, target->name);
+                        return(NULL);
+                    } else {
+                        /*
+                        * The default namespace was undeclared on the
+                        * result element.
+                        */
+                        return(NULL);
+                    }
+                    break;
+                }
+                ns = ns->next;
+            } while (ns != NULL);
         }
-        ns = ns->next;
-        } while (ns != NULL);
-    }
-    if ((target->parent != NULL) &&
-        (target->parent->type == XML_ELEMENT_NODE))
-    {
-        /*
-        * The parent element is in no namespace, so assume
-        * that there is no default namespace in scope.
-        */
-        if (target->parent->ns == NULL)
-        return(NULL);
+        if ((target->parent != NULL) &&
+            (target->parent->type == XML_ELEMENT_NODE))
+        {
+            /*
+            * The parent element is in no namespace, so assume
+            * that there is no default namespace in scope.
+            */
+            if (target->parent->ns == NULL)
+                return(NULL);
 
-        ns = xmlSearchNs(target->doc, target->parent,
-        NULL);
-        /*
-        * Fine if there's no default ns is scope, or if the
-        * default ns was undeclared.
-        */
-        if ((ns == NULL) || (ns->href == NULL) || (ns->href[0] == 0))
-        return(NULL);
+            ns = xmlSearchNs(target->doc, target->parent,
+                NULL);
+            /*
+            * Fine if there's no default ns is scope, or if the
+            * default ns was undeclared.
+            */
+            if ((ns == NULL) || (ns->href == NULL) || (ns->href[0] == 0))
+                return(NULL);
 
-        /*
-        * Undeclare the default namespace.
-        */
-        xmlNewNs(target, BAD_CAST "", NULL);
-        /* TODO: Check result */
+            /*
+            * Undeclare the default namespace.
+            */
+            xmlNewNs(target, BAD_CAST "", NULL);
+            /* TODO: Check result */
+            return(NULL);
+        }
         return(NULL);
-    }
-    return(NULL);
     }
     /*
     * Handle the XML namespace.
     * QUESTION: Is this faster than using xmlStrEqual() anyway?
     */
     if ((nsPrefix != NULL) &&
-    (nsPrefix[0] == 'x') && (nsPrefix[1] == 'm') &&
-    (nsPrefix[2] == 'l') && (nsPrefix[3] == 0))
+        (nsPrefix[0] == 'x') && (nsPrefix[1] == 'm') &&
+        (nsPrefix[2] == 'l') && (nsPrefix[3] == 0))
     {
-    return(xmlSearchNs(target->doc, target, nsPrefix));
+        return(xmlSearchNs(target->doc, target, nsPrefix));
     }
     /*
     * First: search on the result element itself.
     */
     if (target->nsDef != NULL) {
-    ns = target->nsDef;
-    do {
-        if ((ns->prefix == NULL) == (nsPrefix == NULL)) {
-        if (ns->prefix == nsPrefix) {
-            if (xmlStrEqual(ns->href, nsName))
-            return(ns);
-            prefixOccupied = 1;
-            break;
-        } else if (xmlStrEqual(ns->prefix, nsPrefix)) {
-            if (xmlStrEqual(ns->href, nsName))
-            return(ns);
-            prefixOccupied = 1;
-            break;
-        }
-        }
-        ns = ns->next;
-    } while (ns != NULL);
+        ns = target->nsDef;
+        do {
+            if ((ns->prefix == NULL) == (nsPrefix == NULL)) {
+                if (ns->prefix == nsPrefix) {
+                    if (xmlStrEqual(ns->href, nsName))
+                        return(ns);
+                    prefixOccupied = 1;
+                    break;
+                } else if (xmlStrEqual(ns->prefix, nsPrefix)) {
+                    if (xmlStrEqual(ns->href, nsName))
+                        return(ns);
+                    prefixOccupied = 1;
+                    break;
+                }
+            }
+            ns = ns->next;
+        } while (ns != NULL);
     }
     if (prefixOccupied) {
-    /*
-    * If the ns-prefix is occupied by an other ns-decl on the
-    * result element, then this means:
-    * 1) The desired prefix is shadowed
-    * 2) There's no way around changing the prefix
-    *
-    * Try a desperate search for an in-scope ns-decl
-    * with a matching ns-name before we use the last option,
-    * which is to recreate the ns-decl with a modified prefix.
-    */
-    ns = xmlSearchNsByHref(target->doc, target, nsName);
-    if (ns != NULL)
-        return(ns);
-
-    /*
-    * Fallback to changing the prefix.
-    */
-    } else if ((target->parent != NULL) &&
-    (target->parent->type == XML_ELEMENT_NODE))
-    {
-    /*
-    * Try to find a matching ns-decl in the ancestor-axis.
-    *
-    * Check the common case: The parent element of the current
-    * result element is in the same namespace (with an equal ns-prefix).
-    */
-    if ((target->parent->ns != NULL) &&
-        ((target->parent->ns->prefix != NULL) == (nsPrefix != NULL)))
-    {
-        ns = target->parent->ns;
-
-        if (nsPrefix == NULL) {
-        if (xmlStrEqual(ns->href, nsName))
-            return(ns);
-        } else if (xmlStrEqual(ns->prefix, nsPrefix) &&
-        xmlStrEqual(ns->href, nsName))
-        {
-        return(ns);
-        }
-    }
-    /*
-    * Lookup the remaining in-scope namespaces.
-    */
-    ns = xmlSearchNs(target->doc, target->parent, nsPrefix);
-    if (ns != NULL) {
-        if (xmlStrEqual(ns->href, nsName))
-        return(ns);
         /*
-        * Now check for a nasty case: We need to ensure that the new
-        * ns-decl won't shadow a prefix in-use by an existing attribute.
-        * <foo xmlns:a="urn:test:a">
-        *   <bar a:a="val-a">
-        *     <xsl:attribute xmlns:a="urn:test:b" name="a:b">
-        *        val-b</xsl:attribute>
-        *   </bar>
-        * </foo>
+        * If the ns-prefix is occupied by an other ns-decl on the
+        * result element, then this means:
+        * 1) The desired prefix is shadowed
+        * 2) There's no way around changing the prefix
+        *
+        * Try a desperate search for an in-scope ns-decl
+        * with a matching ns-name before we use the last option,
+        * which is to recreate the ns-decl with a modified prefix.
         */
-        if (target->properties) {
-        xmlAttrPtr attr = target->properties;
-        do {
-            if ((attr->ns) &&
-            xmlStrEqual(attr->ns->prefix, nsPrefix))
+        ns = xmlSearchNsByHref(target->doc, target, nsName);
+        if (ns != NULL)
+            return(ns);
+
+        /*
+        * Fallback to changing the prefix.
+        */
+    } else if ((target->parent != NULL) &&
+        (target->parent->type == XML_ELEMENT_NODE))
+    {
+        /*
+        * Try to find a matching ns-decl in the ancestor-axis.
+        *
+        * Check the common case: The parent element of the current
+        * result element is in the same namespace (with an equal ns-prefix).
+        */
+        if ((target->parent->ns != NULL) &&
+            ((target->parent->ns->prefix != NULL) == (nsPrefix != NULL)))
+        {
+            ns = target->parent->ns;
+
+            if (nsPrefix == NULL) {
+                if (xmlStrEqual(ns->href, nsName))
+                    return(ns);
+            } else if (xmlStrEqual(ns->prefix, nsPrefix) &&
+                xmlStrEqual(ns->href, nsName))
             {
+                return(ns);
+            }
+        }
+        /*
+        * Lookup the remaining in-scope namespaces.
+        */
+        ns = xmlSearchNs(target->doc, target->parent, nsPrefix);
+        if (ns != NULL) {
+            if (xmlStrEqual(ns->href, nsName))
+                return(ns);
             /*
-            * Bad, this prefix is already in use.
-            * Since we'll change the prefix anyway, try
-            * a search for a matching ns-decl based on the
-            * namespace name.
+            * Now check for a nasty case: We need to ensure that the new
+            * ns-decl won't shadow a prefix in-use by an existing attribute.
+            * <foo xmlns:a="urn:test:a">
+            *   <bar a:a="val-a">
+            *     <xsl:attribute xmlns:a="urn:test:b" name="a:b">
+            *        val-b</xsl:attribute>
+            *   </bar>
+            * </foo>
             */
+            if (target->properties) {
+                xmlAttrPtr attr = target->properties;
+                do {
+                    if ((attr->ns) &&
+                        xmlStrEqual(attr->ns->prefix, nsPrefix))
+                    {
+                        /*
+                        * Bad, this prefix is already in use.
+                        * Since we'll change the prefix anyway, try
+                        * a search for a matching ns-decl based on the
+                        * namespace name.
+                        */
+                        ns = xmlSearchNsByHref(target->doc, target, nsName);
+                        if (ns != NULL)
+                            return(ns);
+                        goto declare_new_prefix;
+                    }
+                    attr = attr->next;
+                } while (attr != NULL);
+            }
+        } else {
+            /*
+            * Either no matching ns-prefix was found or the namespace is
+            * shadowed.
+            * Create a new ns-decl on the current result element.
+            *
+            * Hmm, we could also try to reuse an in-scope
+            * namespace with a matching ns-name but a different
+            * ns-prefix.
+            * What has higher priority?
+            *  1) If keeping the prefix: create a new ns-decl.
+            *  2) If reusal: first lookup ns-names; then fallback
+            *     to creation of a new ns-decl.
+            * REVISIT: this currently uses case 1) although
+            *  the old way was use xmlSearchNsByHref() and to let change
+            *  the prefix.
+            */
+#if 0
             ns = xmlSearchNsByHref(target->doc, target, nsName);
             if (ns != NULL)
                 return(ns);
-            goto declare_new_prefix;
-            }
-            attr = attr->next;
-        } while (attr != NULL);
+#endif
         }
+        /*
+        * Create the ns-decl on the current result element.
+        */
+        ns = xmlNewNs(target, nsName, nsPrefix);
+        /* TODO: check errors */
+        return(ns);
     } else {
         /*
-        * Either no matching ns-prefix was found or the namespace is
-        * shadowed.
-        * Create a new ns-decl on the current result element.
-        *
-        * Hmm, we could also try to reuse an in-scope
-        * namespace with a matching ns-name but a different
-        * ns-prefix.
-        * What has higher priority?
-        *  1) If keeping the prefix: create a new ns-decl.
-        *  2) If reusal: first lookup ns-names; then fallback
-        *     to creation of a new ns-decl.
-        * REVISIT: this currently uses case 1) although
-        *  the old way was use xmlSearchNsByHref() and to let change
-        *  the prefix.
+        * This is either the root of the tree or something weird is going on.
         */
-#if 0
-        ns = xmlSearchNsByHref(target->doc, target, nsName);
-        if (ns != NULL)
+        ns = xmlNewNs(target, nsName, nsPrefix);
+        /* TODO: Check result */
         return(ns);
-#endif
-    }
-    /*
-    * Create the ns-decl on the current result element.
-    */
-    ns = xmlNewNs(target, nsName, nsPrefix);
-    /* TODO: check errors */
-    return(ns);
-    } else {
-    /*
-    * This is either the root of the tree or something weird is going on.
-    */
-    ns = xmlNewNs(target, nsName, nsPrefix);
-    /* TODO: Check result */
-    return(ns);
     }
 
 declare_new_prefix:
@@ -581,27 +581,27 @@ declare_new_prefix:
     * on the result element.
     */
     {
-    xmlChar pref[30];
-    int counter = 1;
+        xmlChar pref[30];
+        int counter = 1;
 
-    if (nsPrefix == NULL) {
-        nsPrefix = BAD_CAST "ns";
-    }
-
-    do {
-        snprintf((char *) pref, 30, "%s_%d", nsPrefix, counter++);
-        ns = xmlSearchNs(target->doc, target, BAD_CAST pref);
-        if (counter > 1000) {
-        xsltTransformError(ctxt, NULL, invocNode,
-            "Internal error in xsltAcquireResultInScopeNs(): "
-            "Failed to compute a unique ns-prefix for the "
-            "generated element");
-        return(NULL);
+        if (nsPrefix == NULL) {
+            nsPrefix = BAD_CAST "ns";
         }
-    } while (ns != NULL);
-    ns = xmlNewNs(target, nsName, BAD_CAST pref);
-    /* TODO: Check result */
-    return(ns);
+
+        do {
+            snprintf((char *) pref, 30, "%s_%d", nsPrefix, counter++);
+            ns = xmlSearchNs(target->doc, target, BAD_CAST pref);
+            if (counter > 1000) {
+                xsltTransformError(ctxt, NULL, invocNode,
+                    "Internal error in xsltAcquireResultInScopeNs(): "
+                    "Failed to compute a unique ns-prefix for the "
+                    "generated element");
+                return(NULL);
+            }
+        } while (ns != NULL);
+        ns = xmlNewNs(target, nsName, BAD_CAST pref);
+        /* TODO: Check result */
+        return(ns);
     }
     return(NULL);
 }
@@ -632,11 +632,11 @@ declare_new_prefix:
  */
 xmlNsPtr
 xsltGetNamespace(xsltTransformContextPtr ctxt, xmlNodePtr cur, xmlNsPtr ns,
-             xmlNodePtr out)
+                 xmlNodePtr out)
 {
 
     if (ns == NULL)
-    return(NULL);
+        return(NULL);
 
 #ifdef XSLT_REFACTORED
     /*
@@ -648,43 +648,43 @@ xsltGetNamespace(xsltTransformContextPtr ctxt, xmlNodePtr cur, xmlNsPtr ns,
     return(xsltGetSpecialNamespace(ctxt, cur, ns->href, ns->prefix, out));
 #else
     {
-    xsltStylesheetPtr style;
-    const xmlChar *URI = NULL; /* the replacement URI */
+        xsltStylesheetPtr style;
+        const xmlChar *URI = NULL; /* the replacement URI */
 
-    if ((ctxt == NULL) || (cur == NULL) || (out == NULL))
-        return(NULL);
+        if ((ctxt == NULL) || (cur == NULL) || (out == NULL))
+            return(NULL);
 
-    style = ctxt->style;
-    while (style != NULL) {
-        if (style->nsAliases != NULL)
-        URI = (const xmlChar *)
-        xmlHashLookup(style->nsAliases, ns->href);
-        if (URI != NULL)
-        break;
+        style = ctxt->style;
+        while (style != NULL) {
+            if (style->nsAliases != NULL)
+                URI = (const xmlChar *)
+                xmlHashLookup(style->nsAliases, ns->href);
+            if (URI != NULL)
+                break;
 
-        style = xsltNextImport(style);
-    }
+            style = xsltNextImport(style);
+        }
 
 
-    if (URI == UNDEFINED_DEFAULT_NS) {
-        return(xsltGetSpecialNamespace(ctxt, cur, NULL, NULL, out));
+        if (URI == UNDEFINED_DEFAULT_NS) {
+            return(xsltGetSpecialNamespace(ctxt, cur, NULL, NULL, out));
 #if 0
-        /*
-        * TODO: Removed, since wrong. If there was no default
-        * namespace in the stylesheet then this must resolve to
-        * the NULL namespace.
-        */
-        xmlNsPtr dflt;
-        dflt = xmlSearchNs(cur->doc, cur, NULL);
-        if (dflt != NULL)
-        URI = dflt->href;
-        else
-        return NULL;
+            /*
+            * TODO: Removed, since wrong. If there was no default
+            * namespace in the stylesheet then this must resolve to
+            * the NULL namespace.
+            */
+            xmlNsPtr dflt;
+            dflt = xmlSearchNs(cur->doc, cur, NULL);
+            if (dflt != NULL)
+                URI = dflt->href;
+            else
+                return NULL;
 #endif
-    } else if (URI == NULL)
-        URI = ns->href;
+        } else if (URI == NULL)
+            URI = ns->href;
 
-    return(xsltGetSpecialNamespace(ctxt, cur, URI, ns->prefix, out));
+        return(xsltGetSpecialNamespace(ctxt, cur, URI, ns->prefix, out));
     }
 #endif
 }
@@ -733,81 +733,81 @@ xsltGetPlainNamespace(xsltTransformContextPtr ctxt, xmlNodePtr cur,
  */
 xmlNsPtr
 xsltCopyNamespaceList(xsltTransformContextPtr ctxt, xmlNodePtr node,
-                  xmlNsPtr cur) {
+                      xmlNsPtr cur) {
     xmlNsPtr ret = NULL, tmp;
     xmlNsPtr p = NULL,q;
 
     if (cur == NULL)
-    return(NULL);
+        return(NULL);
     if (cur->type != XML_NAMESPACE_DECL)
-    return(NULL);
+        return(NULL);
 
     /*
      * One can add namespaces only on element nodes
      */
     if ((node != NULL) && (node->type != XML_ELEMENT_NODE))
-    node = NULL;
+        node = NULL;
 
     while (cur != NULL) {
-    if (cur->type != XML_NAMESPACE_DECL)
-        break;
+        if (cur->type != XML_NAMESPACE_DECL)
+            break;
 
-    /*
-     * Avoid duplicating namespace declarations in the tree if
-     * a matching declaration is in scope.
-     */
-    if (node != NULL) {
-        if ((node->ns != NULL) &&
-        (xmlStrEqual(node->ns->prefix, cur->prefix)) &&
-    (xmlStrEqual(node->ns->href, cur->href))) {
-        cur = cur->next;
-        continue;
+        /*
+         * Avoid duplicating namespace declarations in the tree if
+         * a matching declaration is in scope.
+         */
+        if (node != NULL) {
+            if ((node->ns != NULL) &&
+                (xmlStrEqual(node->ns->prefix, cur->prefix)) &&
+        (xmlStrEqual(node->ns->href, cur->href))) {
+                cur = cur->next;
+                continue;
+            }
+            tmp = xmlSearchNs(node->doc, node, cur->prefix);
+            if ((tmp != NULL) && (xmlStrEqual(tmp->href, cur->href))) {
+                cur = cur->next;
+                continue;
+            }
         }
-        tmp = xmlSearchNs(node->doc, node, cur->prefix);
-        if ((tmp != NULL) && (xmlStrEqual(tmp->href, cur->href))) {
-        cur = cur->next;
-        continue;
-        }
-    }
 #ifdef XSLT_REFACTORED
-    /*
-    * Namespace exclusion and ns-aliasing is performed at
-    * compilation-time in the refactored code.
-    */
-    q = xmlNewNs(node, cur->href, cur->prefix);
-    if (p == NULL) {
-        ret = p = q;
-    } else {
-        p->next = q;
-        p = q;
-    }
-#else
-    /*
-    * TODO: Remove this if the refactored code gets enabled.
-    */
-    if (!xmlStrEqual(cur->href, XSLT_NAMESPACE)) {
-        const xmlChar *URI;
-        /* TODO apply cascading */
-        URI = (const xmlChar *) xmlHashLookup(ctxt->style->nsAliases,
-                                          cur->href);
-        if (URI == UNDEFINED_DEFAULT_NS) {
-        cur = cur->next;
-            continue;
-        }
-        if (URI != NULL) {
-        q = xmlNewNs(node, URI, cur->prefix);
-        } else {
+        /*
+        * Namespace exclusion and ns-aliasing is performed at
+        * compilation-time in the refactored code.
+        */
         q = xmlNewNs(node, cur->href, cur->prefix);
-        }
         if (p == NULL) {
-        ret = p = q;
+            ret = p = q;
         } else {
-        p->next = q;
-        p = q;
+            p->next = q;
+            p = q;
         }
-    }
+#else
+        /*
+        * TODO: Remove this if the refactored code gets enabled.
+        */
+        if (!xmlStrEqual(cur->href, XSLT_NAMESPACE)) {
+            const xmlChar *URI;
+            /* TODO apply cascading */
+            URI = (const xmlChar *) xmlHashLookup(ctxt->style->nsAliases,
+                                                  cur->href);
+            if (URI == UNDEFINED_DEFAULT_NS) {
+                cur = cur->next;
+                continue;
+            }
+            if (URI != NULL) {
+                q = xmlNewNs(node, URI, cur->prefix);
+            } else {
+                q = xmlNewNs(node, cur->href, cur->prefix);
+            }
+            if (p == NULL) {
+                ret = p = q;
+            } else {
+                p->next = q;
+                p = q;
+            }
+        }
 #endif
-    cur = cur->next;
+        cur = cur->next;
     }
     return(ret);
 }
@@ -825,17 +825,17 @@ xsltCopyNamespaceList(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 xmlNsPtr
 xsltCopyNamespace(xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
-          xmlNodePtr elem, xmlNsPtr ns)
+                  xmlNodePtr elem, xmlNsPtr ns)
 {
     if ((ns == NULL) || (ns->type != XML_NAMESPACE_DECL))
-    return(NULL);
+        return(NULL);
     /*
      * One can add namespaces only on element nodes
      */
     if ((elem != NULL) && (elem->type != XML_ELEMENT_NODE))
-    return(xmlNewNs(NULL, ns->href, ns->prefix));
+        return(xmlNewNs(NULL, ns->href, ns->prefix));
     else
-    return(xmlNewNs(elem, ns->href, ns->prefix));
+        return(xmlNewNs(elem, ns->href, ns->prefix));
 }
 
 
@@ -848,6 +848,6 @@ xsltCopyNamespace(xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
 void
 xsltFreeNamespaceAliasHashes(xsltStylesheetPtr style) {
     if (style->nsAliases != NULL)
-    xmlHashFree((xmlHashTablePtr) style->nsAliases, NULL);
+        xmlHashFree((xmlHashTablePtr) style->nsAliases, NULL);
     style->nsAliases = NULL;
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/namespaces.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/namespaces.h
@@ -30,35 +30,35 @@ extern "C" {
 #define UNDEFINED_DEFAULT_NS    (const xmlChar *) -1L
 
 XSLTPUBFUN void XSLTCALL
-        xsltNamespaceAlias  (xsltStylesheetPtr style,
-                     xmlNodePtr node);
+                xsltNamespaceAlias      (xsltStylesheetPtr style,
+                                         xmlNodePtr node);
 XSLTPUBFUN xmlNsPtr XSLTCALL
-        xsltGetNamespace    (xsltTransformContextPtr ctxt,
-                     xmlNodePtr cur,
-                     xmlNsPtr ns,
-                     xmlNodePtr out);
+                xsltGetNamespace        (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr cur,
+                                         xmlNsPtr ns,
+                                         xmlNodePtr out);
 XSLTPUBFUN xmlNsPtr XSLTCALL
-        xsltGetPlainNamespace   (xsltTransformContextPtr ctxt,
-                     xmlNodePtr cur,
-                     xmlNsPtr ns,
-                     xmlNodePtr out);
+                xsltGetPlainNamespace   (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr cur,
+                                         xmlNsPtr ns,
+                                         xmlNodePtr out);
 XSLTPUBFUN xmlNsPtr XSLTCALL
-        xsltGetSpecialNamespace (xsltTransformContextPtr ctxt,
-                     xmlNodePtr cur,
-                     const xmlChar *URI,
-                     const xmlChar *prefix,
-                     xmlNodePtr out);
+                xsltGetSpecialNamespace (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr cur,
+                                         const xmlChar *URI,
+                                         const xmlChar *prefix,
+                                         xmlNodePtr out);
 XSLTPUBFUN xmlNsPtr XSLTCALL
-        xsltCopyNamespace   (xsltTransformContextPtr ctxt,
-                     xmlNodePtr elem,
-                     xmlNsPtr ns);
+                xsltCopyNamespace       (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr elem,
+                                         xmlNsPtr ns);
 XSLTPUBFUN xmlNsPtr XSLTCALL
-        xsltCopyNamespaceList   (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xmlNsPtr cur);
+                xsltCopyNamespaceList   (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNsPtr cur);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeNamespaceAliasHashes
-                    (xsltStylesheetPtr style);
+                xsltFreeNamespaceAliasHashes
+                                        (xsltStylesheetPtr style);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/numbers.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/numbers.c
@@ -34,28 +34,28 @@
 # define TRUE (1 == 1)
 #endif
 
-#define SYMBOL_QUOTE        ((xmlChar)'\'')
+#define SYMBOL_QUOTE            ((xmlChar)'\'')
 
-#define DEFAULT_TOKEN       '0'
-#define DEFAULT_SEPARATOR   "."
+#define DEFAULT_TOKEN           '0'
+#define DEFAULT_SEPARATOR       "."
 
-#define MAX_TOKENS      1024
+#define MAX_TOKENS              1024
 
 typedef struct _xsltFormatToken xsltFormatToken;
 typedef xsltFormatToken *xsltFormatTokenPtr;
 struct _xsltFormatToken {
-    xmlChar *separator;
-    int      token;
-    int      width;
+    xmlChar     *separator;
+    int          token;
+    int          width;
 };
 
 typedef struct _xsltFormat xsltFormat;
 typedef xsltFormat *xsltFormatPtr;
 struct _xsltFormat {
-    xmlChar     *start;
-    xsltFormatToken  tokens[MAX_TOKENS];
-    int          nTokens;
-    xmlChar     *end;
+    xmlChar             *start;
+    xsltFormatToken      tokens[MAX_TOKENS];
+    int                  nTokens;
+    xmlChar             *end;
 };
 
 static char alpha_upper_list[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -94,13 +94,13 @@ xsltUTF8Charcmp(xmlChar *utf1, xmlChar *utf2) {
 
 /***** Stop temp insert *****/
 /************************************************************************
- *                                  *
- *          Utility functions               *
- *                                  *
+ *                                                                      *
+ *                      Utility functions                               *
+ *                                                                      *
  ************************************************************************/
 
-#define IS_SPECIAL(self,letter)         \
-    ((xsltUTF8Charcmp((letter), (self)->zeroDigit) == 0)        ||  \
+#define IS_SPECIAL(self,letter)                 \
+    ((xsltUTF8Charcmp((letter), (self)->zeroDigit) == 0)            ||  \
      (xsltUTF8Charcmp((letter), (self)->digit) == 0)        ||  \
      (xsltUTF8Charcmp((letter), (self)->decimalPoint) == 0)  || \
      (xsltUTF8Charcmp((letter), (self)->grouping) == 0)     ||  \
@@ -123,20 +123,20 @@ xsltIsDigitZero(unsigned int ch)
     case 0x09E6: case 0x0A66: case 0x0AE6: case 0x0B66:
     case 0x0C66: case 0x0CE6: case 0x0D66: case 0x0E50:
     case 0x0ED0: case 0x0F20:
-    return TRUE;
+        return TRUE;
     default:
-    return FALSE;
+        return FALSE;
     }
 }
 
 static void
 xsltNumberFormatDecimal(xmlBufferPtr buffer,
-            double number,
-            int digit_zero,
-            int width,
-            int digitsPerGroup,
-            int groupingCharacter,
-            int groupingCharacterLen)
+                        double number,
+                        int digit_zero,
+                        int width,
+                        int digitsPerGroup,
+                        int groupingCharacter,
+                        int groupingCharacterLen)
 {
     /*
      * This used to be
@@ -158,56 +158,56 @@ xsltNumberFormatDecimal(xmlBufferPtr buffer,
     *pointer = 0;
     i = 0;
     while (pointer > temp_string) {
-    if ((i >= width) && (fabs(number) < 1.0))
-        break; /* for */
-    if ((i > 0) && (groupingCharacter != 0) &&
-        (digitsPerGroup > 0) &&
-        ((i % digitsPerGroup) == 0)) {
-        if (pointer - groupingCharacterLen < temp_string) {
-            i = -1;     /* flag error */
-        break;
+        if ((i >= width) && (fabs(number) < 1.0))
+            break; /* for */
+        if ((i > 0) && (groupingCharacter != 0) &&
+            (digitsPerGroup > 0) &&
+            ((i % digitsPerGroup) == 0)) {
+            if (pointer - groupingCharacterLen < temp_string) {
+                i = -1;         /* flag error */
+                break;
+            }
+            pointer -= groupingCharacterLen;
+            xmlCopyCharMultiByte(pointer, groupingCharacter);
         }
-        pointer -= groupingCharacterLen;
-        xmlCopyCharMultiByte(pointer, groupingCharacter);
-    }
 
-    val = digit_zero + (int)fmod(number, 10.0);
-    if (val < 0x80) {           /* shortcut if ASCII */
-        if (pointer <= temp_string) {   /* Check enough room */
-            i = -1;
-        break;
+        val = digit_zero + (int)fmod(number, 10.0);
+        if (val < 0x80) {                       /* shortcut if ASCII */
+            if (pointer <= temp_string) {       /* Check enough room */
+                i = -1;
+                break;
+            }
+            *(--pointer) = (xmlChar)val;
         }
-        *(--pointer) = val;
-    }
-    else {
-    /*
-     * Here we have a multibyte character.  It's a little messy,
-     * because until we generate the char we don't know how long
-     * it is.  So, we generate it into the buffer temp_char, then
-     * copy from there into temp_string.
-     */
-        len = xmlCopyCharMultiByte(temp_char, val);
-        if ( (pointer - len) < temp_string ) {
-            i = -1;
-        break;
+        else {
+        /*
+         * Here we have a multibyte character.  It's a little messy,
+         * because until we generate the char we don't know how long
+         * it is.  So, we generate it into the buffer temp_char, then
+         * copy from there into temp_string.
+         */
+            len = xmlCopyCharMultiByte(temp_char, val);
+            if ( (pointer - len) < temp_string ) {
+                i = -1;
+                break;
+            }
+            pointer -= len;
+            memcpy(pointer, temp_char, len);
         }
-        pointer -= len;
-        memcpy(pointer, temp_char, len);
-    }
-    number /= 10.0;
-    ++i;
+        number /= 10.0;
+        ++i;
     }
     if (i < 0)
         xsltGenericError(xsltGenericErrorContext,
-        "xsltNumberFormatDecimal: Internal buffer size exceeded\n");
+                "xsltNumberFormatDecimal: Internal buffer size exceeded\n");
     xmlBufferCat(buffer, pointer);
 }
 
 static void
 xsltNumberFormatAlpha(xsltNumberDataPtr data,
-              xmlBufferPtr buffer,
-              double number,
-              int is_upper)
+                      xmlBufferPtr buffer,
+                      double number,
+                      int is_upper)
 {
     char temp_string[sizeof(double) * CHAR_BIT * sizeof(xmlChar) + 1];
     char *pointer;
@@ -241,20 +241,20 @@ xsltNumberFormatAlpha(xsltNumberDataPtr data,
     alpha_list = (is_upper) ? alpha_upper_list : alpha_lower_list;
 
     for (i = 1; i < (int)sizeof(temp_string); i++) {
-    number--;
-    *(--pointer) = alpha_list[((int)fmod(number, alpha_size))];
-    number /= alpha_size;
-    if (number < 1.0)
-        break; /* for */
+        number--;
+        *(--pointer) = alpha_list[((int)fmod(number, alpha_size))];
+        number /= alpha_size;
+        if (number < 1.0)
+            break; /* for */
     }
     xmlBufferCCat(buffer, pointer);
 }
 
 static void
 xsltNumberFormatRoman(xsltNumberDataPtr data,
-              xmlBufferPtr buffer,
-              double number,
-              int is_upper)
+                      xmlBufferPtr buffer,
+                      double number,
+                      int is_upper)
 {
     /*
      * See discussion in xsltNumberFormatAlpha. Also use a reasonable upper
@@ -272,62 +272,62 @@ xsltNumberFormatRoman(xsltNumberDataPtr data,
      * Based on an example by Jim Walsh
      */
     while (number >= 1000.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "M" : "m");
-    number -= 1000.0;
+        xmlBufferCCat(buffer, (is_upper) ? "M" : "m");
+        number -= 1000.0;
     }
     if (number >= 900.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "CM" : "cm");
-    number -= 900.0;
+        xmlBufferCCat(buffer, (is_upper) ? "CM" : "cm");
+        number -= 900.0;
     }
     while (number >= 500.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "D" : "d");
-    number -= 500.0;
+        xmlBufferCCat(buffer, (is_upper) ? "D" : "d");
+        number -= 500.0;
     }
     if (number >= 400.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "CD" : "cd");
-    number -= 400.0;
+        xmlBufferCCat(buffer, (is_upper) ? "CD" : "cd");
+        number -= 400.0;
     }
     while (number >= 100.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "C" : "c");
-    number -= 100.0;
+        xmlBufferCCat(buffer, (is_upper) ? "C" : "c");
+        number -= 100.0;
     }
     if (number >= 90.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "XC" : "xc");
-    number -= 90.0;
+        xmlBufferCCat(buffer, (is_upper) ? "XC" : "xc");
+        number -= 90.0;
     }
     while (number >= 50.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "L" : "l");
-    number -= 50.0;
+        xmlBufferCCat(buffer, (is_upper) ? "L" : "l");
+        number -= 50.0;
     }
     if (number >= 40.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "XL" : "xl");
-    number -= 40.0;
+        xmlBufferCCat(buffer, (is_upper) ? "XL" : "xl");
+        number -= 40.0;
     }
     while (number >= 10.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "X" : "x");
-    number -= 10.0;
+        xmlBufferCCat(buffer, (is_upper) ? "X" : "x");
+        number -= 10.0;
     }
     if (number >= 9.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "IX" : "ix");
-    number -= 9.0;
+        xmlBufferCCat(buffer, (is_upper) ? "IX" : "ix");
+        number -= 9.0;
     }
     while (number >= 5.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "V" : "v");
-    number -= 5.0;
+        xmlBufferCCat(buffer, (is_upper) ? "V" : "v");
+        number -= 5.0;
     }
     if (number >= 4.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "IV" : "iv");
-    number -= 4.0;
+        xmlBufferCCat(buffer, (is_upper) ? "IV" : "iv");
+        number -= 4.0;
     }
     while (number >= 1.0) {
-    xmlBufferCCat(buffer, (is_upper) ? "I" : "i");
-    number--;
+        xmlBufferCCat(buffer, (is_upper) ? "I" : "i");
+        number--;
     }
 }
 
 static void
 xsltNumberFormatTokenize(const xmlChar *format,
-             xsltFormatPtr tokens)
+                         xsltFormatPtr tokens)
 {
     int ix = 0;
     int j;
@@ -348,98 +348,98 @@ xsltNumberFormatTokenize(const xmlChar *format,
      * There is always such a token in the list, even if NULL
      */
     while (! (IS_LETTER(val=xmlStringCurrentChar(NULL, format+ix, &len)) ||
-          IS_DIGIT(val)) ) {
-    if (format[ix] == 0)        /* if end of format string */
-        break; /* while */
-    ix += len;
+              IS_DIGIT(val)) ) {
+        if (format[ix] == 0)            /* if end of format string */
+            break; /* while */
+        ix += len;
     }
     if (ix > 0)
-    tokens->start = xmlStrndup(format, ix);
+        tokens->start = xmlStrndup(format, ix);
 
 
     for (tokens->nTokens = 0; tokens->nTokens < MAX_TOKENS;
-     tokens->nTokens++) {
-    if (format[ix] == 0)
-        break; /* for */
+         tokens->nTokens++) {
+        if (format[ix] == 0)
+            break; /* for */
 
-    /*
-     * separator has already been parsed (except for the first
-     * number) in tokens->end, recover it.
-     */
-    if (tokens->nTokens > 0) {
-        tokens->tokens[tokens->nTokens].separator = tokens->end;
-        tokens->end = NULL;
-    }
-
-    val = xmlStringCurrentChar(NULL, format+ix, &len);
-    if (IS_DIGIT_ONE(val) ||
-         IS_DIGIT_ZERO(val)) {
-        tokens->tokens[tokens->nTokens].width = 1;
-        while (IS_DIGIT_ZERO(val)) {
-        tokens->tokens[tokens->nTokens].width++;
-        ix += len;
-        val = xmlStringCurrentChar(NULL, format+ix, &len);
+        /*
+         * separator has already been parsed (except for the first
+         * number) in tokens->end, recover it.
+         */
+        if (tokens->nTokens > 0) {
+            tokens->tokens[tokens->nTokens].separator = tokens->end;
+            tokens->end = NULL;
         }
-        if (IS_DIGIT_ONE(val)) {
-        tokens->tokens[tokens->nTokens].token = val - 1;
-        ix += len;
+
         val = xmlStringCurrentChar(NULL, format+ix, &len);
-        } else {
+        if (IS_DIGIT_ONE(val) ||
+                 IS_DIGIT_ZERO(val)) {
+            tokens->tokens[tokens->nTokens].width = 1;
+            while (IS_DIGIT_ZERO(val)) {
+                tokens->tokens[tokens->nTokens].width++;
+                ix += len;
+                val = xmlStringCurrentChar(NULL, format+ix, &len);
+            }
+            if (IS_DIGIT_ONE(val)) {
+                tokens->tokens[tokens->nTokens].token = val - 1;
+                ix += len;
+                val = xmlStringCurrentChar(NULL, format+ix, &len);
+            } else {
                 tokens->tokens[tokens->nTokens].token = '0';
                 tokens->tokens[tokens->nTokens].width = 1;
             }
-    } else if ( (val == 'A') ||
-            (val == 'a') ||
-            (val == 'I') ||
-            (val == 'i') ) {
-        tokens->tokens[tokens->nTokens].token = val;
-        ix += len;
-        val = xmlStringCurrentChar(NULL, format+ix, &len);
-    } else {
-        /* XSLT section 7.7
-         * "Any other format token indicates a numbering sequence
-         *  that starts with that token. If an implementation does
-         *  not support a numbering sequence that starts with that
-         *  token, it must use a format token of 1."
+        } else if ( (val == 'A') ||
+                    (val == 'a') ||
+                    (val == 'I') ||
+                    (val == 'i') ) {
+            tokens->tokens[tokens->nTokens].token = val;
+            ix += len;
+            val = xmlStringCurrentChar(NULL, format+ix, &len);
+        } else {
+            /* XSLT section 7.7
+             * "Any other format token indicates a numbering sequence
+             *  that starts with that token. If an implementation does
+             *  not support a numbering sequence that starts with that
+             *  token, it must use a format token of 1."
+             */
+            tokens->tokens[tokens->nTokens].token = '0';
+            tokens->tokens[tokens->nTokens].width = 1;
+        }
+        /*
+         * Skip over remaining alphanumeric characters from the Nd
+         * (Number, decimal digit), Nl (Number, letter), No (Number,
+         * other), Lu (Letter, uppercase), Ll (Letter, lowercase), Lt
+         * (Letters, titlecase), Lm (Letters, modifiers), and Lo
+         * (Letters, other (uncased)) Unicode categories. This happens
+         * to correspond to the Letter and Digit classes from XML (and
+         * one wonders why XSLT doesn't refer to these instead).
          */
-        tokens->tokens[tokens->nTokens].token = '0';
-        tokens->tokens[tokens->nTokens].width = 1;
-    }
-    /*
-     * Skip over remaining alphanumeric characters from the Nd
-     * (Number, decimal digit), Nl (Number, letter), No (Number,
-     * other), Lu (Letter, uppercase), Ll (Letter, lowercase), Lt
-     * (Letters, titlecase), Lm (Letters, modifiers), and Lo
-     * (Letters, other (uncased)) Unicode categories. This happens
-     * to correspond to the Letter and Digit classes from XML (and
-     * one wonders why XSLT doesn't refer to these instead).
-     */
-    while (IS_LETTER(val) || IS_DIGIT(val)) {
-        ix += len;
-        val = xmlStringCurrentChar(NULL, format+ix, &len);
-    }
+        while (IS_LETTER(val) || IS_DIGIT(val)) {
+            ix += len;
+            val = xmlStringCurrentChar(NULL, format+ix, &len);
+        }
 
-    /*
-     * Insert temporary non-alphanumeric final tooken.
-     */
-    j = ix;
-    while (! (IS_LETTER(val) || IS_DIGIT(val))) {
-        if (val == 0)
-        break; /* while */
-        ix += len;
-        val = xmlStringCurrentChar(NULL, format+ix, &len);
-    }
-    if (ix > j)
-        tokens->end = xmlStrndup(&format[j], ix - j);
+        /*
+         * Insert temporary non-alphanumeric final tooken.
+         */
+        j = ix;
+        while (! (IS_LETTER(val) || IS_DIGIT(val))) {
+            if (val == 0)
+                break; /* while */
+            ix += len;
+            val = xmlStringCurrentChar(NULL, format+ix, &len);
+        }
+        if (ix > j)
+            tokens->end = xmlStrndup(&format[j], ix - j);
     }
 }
 
 static void
 xsltNumberFormatInsertNumbers(xsltNumberDataPtr data,
-                  double *numbers,
-                  int numbers_max,
-                  xsltFormatPtr tokens,
-                  xmlBufferPtr buffer)
+                              double *numbers,
+                              int numbers_max,
+                              xsltFormatPtr tokens,
+                              xmlBufferPtr buffer)
 {
     int i = 0;
     double number;
@@ -449,11 +449,11 @@ xsltNumberFormatInsertNumbers(xsltNumberDataPtr data,
      * Handle initial non-alphanumeric token
      */
     if (tokens->start != NULL)
-     xmlBufferCat(buffer, tokens->start);
+         xmlBufferCat(buffer, tokens->start);
 
     for (i = 0; i < numbers_max; i++) {
-    /* Insert number */
-    number = numbers[(numbers_max - 1) - i];
+        /* Insert number */
+        number = numbers[(numbers_max - 1) - i];
         /* Round to nearest like XSLT 2.0 */
         number = floor(number + 0.5);
         /*
@@ -471,82 +471,82 @@ xsltNumberFormatInsertNumbers(xsltNumberDataPtr data,
             /* Recover by treating negative values as zero. */
             number = 0.0;
         }
-    if (i < tokens->nTokens) {
-      /*
-       * The "n"th format token will be used to format the "n"th
-       * number in the list
-       */
-      token = &(tokens->tokens[i]);
-    } else if (tokens->nTokens > 0) {
-      /*
-       * If there are more numbers than format tokens, then the
-       * last format token will be used to format the remaining
-       * numbers.
-       */
-      token = &(tokens->tokens[tokens->nTokens - 1]);
-    } else {
-      /*
-       * If there are no format tokens, then a format token of
-       * 1 is used to format all numbers.
-       */
-      token = &default_token;
-    }
-
-    /* Print separator, except for the first number */
-    if (i > 0) {
-        if (token->separator != NULL)
-        xmlBufferCat(buffer, token->separator);
-        else
-        xmlBufferCCat(buffer, DEFAULT_SEPARATOR);
-    }
-
-    switch (xmlXPathIsInf(number)) {
-    case -1:
-        xmlBufferCCat(buffer, "-Infinity");
-        break;
-    case 1:
-        xmlBufferCCat(buffer, "Infinity");
-        break;
-    default:
-        if (xmlXPathIsNaN(number)) {
-        xmlBufferCCat(buffer, "NaN");
+        if (i < tokens->nTokens) {
+          /*
+           * The "n"th format token will be used to format the "n"th
+           * number in the list
+           */
+          token = &(tokens->tokens[i]);
+        } else if (tokens->nTokens > 0) {
+          /*
+           * If there are more numbers than format tokens, then the
+           * last format token will be used to format the remaining
+           * numbers.
+           */
+          token = &(tokens->tokens[tokens->nTokens - 1]);
         } else {
+          /*
+           * If there are no format tokens, then a format token of
+           * 1 is used to format all numbers.
+           */
+          token = &default_token;
+        }
 
-        switch (token->token) {
-        case 'A':
-            xsltNumberFormatAlpha(data, buffer, number, TRUE);
+        /* Print separator, except for the first number */
+        if (i > 0) {
+            if (token->separator != NULL)
+                xmlBufferCat(buffer, token->separator);
+            else
+                xmlBufferCCat(buffer, DEFAULT_SEPARATOR);
+        }
+
+        switch (xmlXPathIsInf(number)) {
+        case -1:
+            xmlBufferCCat(buffer, "-Infinity");
             break;
-        case 'a':
-            xsltNumberFormatAlpha(data, buffer, number, FALSE);
-            break;
-        case 'I':
-            xsltNumberFormatRoman(data, buffer, number, TRUE);
-            break;
-        case 'i':
-            xsltNumberFormatRoman(data, buffer, number, FALSE);
+        case 1:
+            xmlBufferCCat(buffer, "Infinity");
             break;
         default:
-            if (IS_DIGIT_ZERO(token->token)) {
-            xsltNumberFormatDecimal(buffer,
-                        number,
-                        token->token,
-                        token->width,
-                        data->digitsPerGroup,
-                        data->groupingCharacter,
-                        data->groupingCharacterLen);
-            }
-            break;
-        }
-        }
+            if (xmlXPathIsNaN(number)) {
+                xmlBufferCCat(buffer, "NaN");
+            } else {
 
-    }
+                switch (token->token) {
+                case 'A':
+                    xsltNumberFormatAlpha(data, buffer, number, TRUE);
+                    break;
+                case 'a':
+                    xsltNumberFormatAlpha(data, buffer, number, FALSE);
+                    break;
+                case 'I':
+                    xsltNumberFormatRoman(data, buffer, number, TRUE);
+                    break;
+                case 'i':
+                    xsltNumberFormatRoman(data, buffer, number, FALSE);
+                    break;
+                default:
+                    if (IS_DIGIT_ZERO(token->token)) {
+                        xsltNumberFormatDecimal(buffer,
+                                                number,
+                                                token->token,
+                                                token->width,
+                                                data->digitsPerGroup,
+                                                data->groupingCharacter,
+                                                data->groupingCharacterLen);
+                    }
+                    break;
+                }
+            }
+
+        }
     }
 
     /*
      * Handle final non-alphanumeric token
      */
     if (tokens->end != NULL)
-     xmlBufferCat(buffer, tokens->end);
+         xmlBufferCat(buffer, tokens->end);
 
 }
 
@@ -589,31 +589,31 @@ xsltTestCompMatchCount(xsltTransformContextPtr context,
 
 static int
 xsltNumberFormatGetAnyLevel(xsltTransformContextPtr context,
-                xmlNodePtr node,
-                xsltCompMatchPtr countPat,
-                xsltCompMatchPtr fromPat,
-                double *array)
+                            xmlNodePtr node,
+                            xsltCompMatchPtr countPat,
+                            xsltCompMatchPtr fromPat,
+                            double *array)
 {
     int amount = 0;
     int cnt = 0;
     xmlNodePtr cur = node;
 
     while (cur != NULL) {
-    /* process current node */
-    if (xsltTestCompMatchCount(context, cur, countPat, node))
-        cnt++;
-    if ((fromPat != NULL) &&
-        xsltTestCompMatchList(context, cur, fromPat)) {
-        break; /* while */
-    }
+        /* process current node */
+        if (xsltTestCompMatchCount(context, cur, countPat, node))
+            cnt++;
+        if ((fromPat != NULL) &&
+            xsltTestCompMatchList(context, cur, fromPat)) {
+            break; /* while */
+        }
 
-    /* Skip to next preceding or ancestor */
-    if ((cur->type == XML_DOCUMENT_NODE) ||
+        /* Skip to next preceding or ancestor */
+        if ((cur->type == XML_DOCUMENT_NODE) ||
 #ifdef LIBXML_DOCB_ENABLED
             (cur->type == XML_DOCB_DOCUMENT_NODE) ||
 #endif
             (cur->type == XML_HTML_DOCUMENT_NODE))
-        break; /* while */
+            break; /* while */
 
         if (cur->type == XML_NAMESPACE_DECL) {
             /*
@@ -643,11 +643,11 @@ xsltNumberFormatGetAnyLevel(xsltTransformContextPtr context,
 
 static int
 xsltNumberFormatGetMultipleLevel(xsltTransformContextPtr context,
-                 xmlNodePtr node,
-                 xsltCompMatchPtr countPat,
-                 xsltCompMatchPtr fromPat,
-                 double *array,
-                 int max)
+                                 xmlNodePtr node,
+                                 xsltCompMatchPtr countPat,
+                                 xsltCompMatchPtr fromPat,
+                                 double *array,
+                                 int max)
 {
     int amount = 0;
     int cnt;
@@ -659,12 +659,12 @@ xsltNumberFormatGetMultipleLevel(xsltTransformContextPtr context,
     oldCtxtNode = context->xpathCtxt->node;
     parser = xmlXPathNewParserContext(NULL, context->xpathCtxt);
     if (parser) {
-    /* ancestor-or-self::*[count] */
-    ancestor = node;
-    while ((ancestor != NULL) && (ancestor->type != XML_DOCUMENT_NODE)) {
-        if ((fromPat != NULL) &&
-        xsltTestCompMatchList(context, ancestor, fromPat))
-        break; /* for */
+        /* ancestor-or-self::*[count] */
+        ancestor = node;
+        while ((ancestor != NULL) && (ancestor->type != XML_DOCUMENT_NODE)) {
+            if ((fromPat != NULL) &&
+                xsltTestCompMatchList(context, ancestor, fromPat))
+                break; /* for */
 
             /*
              * The xmlXPathNext* iterators require that the context node is
@@ -673,27 +673,27 @@ xsltNumberFormatGetMultipleLevel(xsltTransformContextPtr context,
              * that the context node is reset before each iterator invocation.
              */
 
-        if (xsltTestCompMatchCount(context, ancestor, countPat, node)) {
-        /* count(preceding-sibling::*) */
-        cnt = 1;
+            if (xsltTestCompMatchCount(context, ancestor, countPat, node)) {
+                /* count(preceding-sibling::*) */
+                cnt = 1;
                 context->xpathCtxt->node = ancestor;
                 preceding = xmlXPathNextPrecedingSibling(parser, ancestor);
                 while (preceding != NULL) {
-                if (xsltTestCompMatchCount(context, preceding, countPat,
+                    if (xsltTestCompMatchCount(context, preceding, countPat,
                                                node))
-            cnt++;
+                        cnt++;
                     context->xpathCtxt->node = ancestor;
                     preceding =
                         xmlXPathNextPrecedingSibling(parser, preceding);
-        }
-        array[amount++] = (double)cnt;
-        if (amount >= max)
-            break; /* for */
-        }
+                }
+                array[amount++] = (double)cnt;
+                if (amount >= max)
+                    break; /* for */
+            }
             context->xpathCtxt->node = node;
             ancestor = xmlXPathNextAncestor(parser, ancestor);
-    }
-    xmlXPathFreeParserContext(parser);
+        }
+        xmlXPathFreeParserContext(parser);
     }
     context->xpathCtxt->node = oldCtxtNode;
     return amount;
@@ -701,9 +701,9 @@ xsltNumberFormatGetMultipleLevel(xsltTransformContextPtr context,
 
 static int
 xsltNumberFormatGetValue(xmlXPathContextPtr context,
-             xmlNodePtr node,
-             const xmlChar *value,
-             double *number)
+                         xmlNodePtr node,
+                         const xmlChar *value,
+                         double *number)
 {
     int amount = 0;
     xmlBufferPtr pattern;
@@ -711,18 +711,18 @@ xsltNumberFormatGetValue(xmlXPathContextPtr context,
 
     pattern = xmlBufferCreate();
     if (pattern != NULL) {
-    xmlBufferCCat(pattern, "number(");
-    xmlBufferCat(pattern, value);
-    xmlBufferCCat(pattern, ")");
-    context->node = node;
-    obj = xmlXPathEvalExpression(xmlBufferContent(pattern),
-                     context);
-    if (obj != NULL) {
-        *number = obj->floatval;
-        amount++;
-        xmlXPathFreeObject(obj);
-    }
-    xmlBufferFree(pattern);
+        xmlBufferCCat(pattern, "number(");
+        xmlBufferCat(pattern, value);
+        xmlBufferCCat(pattern, ")");
+        context->node = node;
+        obj = xmlXPathEvalExpression(xmlBufferContent(pattern),
+                                     context);
+        if (obj != NULL) {
+            *number = obj->floatval;
+            amount++;
+            xmlXPathFreeObject(obj);
+        }
+        xmlBufferFree(pattern);
     }
     return amount;
 }
@@ -737,8 +737,8 @@ xsltNumberFormatGetValue(xmlXPathContextPtr context,
  */
 void
 xsltNumberFormat(xsltTransformContextPtr ctxt,
-         xsltNumberDataPtr data,
-         xmlNodePtr node)
+                 xsltNumberDataPtr data,
+                 xmlNodePtr node)
 {
     xmlBufferPtr output = NULL;
     int amount, i;
@@ -751,84 +751,84 @@ xsltNumberFormat(xsltTransformContextPtr ctxt,
     else {
         xmlChar *format;
 
-    /* The format needs to be recomputed each time */
+        /* The format needs to be recomputed each time */
         if (data->has_format == 0)
             return;
-    format = xsltEvalAttrValueTemplate(ctxt, data->node,
-                         (const xmlChar *) "format",
-                         XSLT_NAMESPACE);
+        format = xsltEvalAttrValueTemplate(ctxt, data->node,
+                                             (const xmlChar *) "format",
+                                             XSLT_NAMESPACE);
         if (format == NULL)
             return;
         xsltNumberFormatTokenize(format, &tokens);
-    xmlFree(format);
+        xmlFree(format);
     }
 
     output = xmlBufferCreate();
     if (output == NULL)
-    goto XSLT_NUMBER_FORMAT_END;
+        goto XSLT_NUMBER_FORMAT_END;
 
     /*
      * Evaluate the XPath expression to find the value(s)
      */
     if (data->value) {
-    amount = xsltNumberFormatGetValue(ctxt->xpathCtxt,
-                      node,
-                      data->value,
-                      &number);
-    if (amount == 1) {
-        xsltNumberFormatInsertNumbers(data,
-                      &number,
-                      1,
-                      &tokens,
-                      output);
-    }
+        amount = xsltNumberFormatGetValue(ctxt->xpathCtxt,
+                                          node,
+                                          data->value,
+                                          &number);
+        if (amount == 1) {
+            xsltNumberFormatInsertNumbers(data,
+                                          &number,
+                                          1,
+                                          &tokens,
+                                          output);
+        }
 
     } else if (data->level) {
 
-    if (xmlStrEqual(data->level, (const xmlChar *) "single")) {
-        amount = xsltNumberFormatGetMultipleLevel(ctxt,
-                              node,
-                              data->countPat,
-                              data->fromPat,
-                              &number,
-                              1);
-        if (amount == 1) {
-        xsltNumberFormatInsertNumbers(data,
-                          &number,
-                          1,
-                          &tokens,
-                          output);
+        if (xmlStrEqual(data->level, (const xmlChar *) "single")) {
+            amount = xsltNumberFormatGetMultipleLevel(ctxt,
+                                                      node,
+                                                      data->countPat,
+                                                      data->fromPat,
+                                                      &number,
+                                                      1);
+            if (amount == 1) {
+                xsltNumberFormatInsertNumbers(data,
+                                              &number,
+                                              1,
+                                              &tokens,
+                                              output);
+            }
+        } else if (xmlStrEqual(data->level, (const xmlChar *) "multiple")) {
+            double numarray[1024];
+            int max = sizeof(numarray)/sizeof(numarray[0]);
+            amount = xsltNumberFormatGetMultipleLevel(ctxt,
+                                                      node,
+                                                      data->countPat,
+                                                      data->fromPat,
+                                                      numarray,
+                                                      max);
+            if (amount > 0) {
+                xsltNumberFormatInsertNumbers(data,
+                                              numarray,
+                                              amount,
+                                              &tokens,
+                                              output);
+            }
+        } else if (xmlStrEqual(data->level, (const xmlChar *) "any")) {
+            amount = xsltNumberFormatGetAnyLevel(ctxt,
+                                                 node,
+                                                 data->countPat,
+                                                 data->fromPat,
+                                                 &number);
+            if (amount > 0) {
+                xsltNumberFormatInsertNumbers(data,
+                                              &number,
+                                              1,
+                                              &tokens,
+                                              output);
+            }
         }
-    } else if (xmlStrEqual(data->level, (const xmlChar *) "multiple")) {
-        double numarray[1024];
-        int max = sizeof(numarray)/sizeof(numarray[0]);
-        amount = xsltNumberFormatGetMultipleLevel(ctxt,
-                              node,
-                              data->countPat,
-                              data->fromPat,
-                              numarray,
-                              max);
-        if (amount > 0) {
-        xsltNumberFormatInsertNumbers(data,
-                          numarray,
-                          amount,
-                          &tokens,
-                          output);
-        }
-    } else if (xmlStrEqual(data->level, (const xmlChar *) "any")) {
-        amount = xsltNumberFormatGetAnyLevel(ctxt,
-                         node,
-                         data->countPat,
-                         data->fromPat,
-                         &number);
-        if (amount > 0) {
-        xsltNumberFormatInsertNumbers(data,
-                          &number,
-                          1,
-                          &tokens,
-                          output);
-        }
-    }
 
         /*
          * Unlike `match` patterns, `count` and `from` patterns can contain
@@ -847,12 +847,12 @@ xsltNumberFormat(xsltTransformContextPtr ctxt,
 
 XSLT_NUMBER_FORMAT_END:
     if (tokens.start != NULL)
-    xmlFree(tokens.start);
+        xmlFree(tokens.start);
     if (tokens.end != NULL)
-    xmlFree(tokens.end);
+        xmlFree(tokens.end);
     for (i = 0;i < tokens.nTokens;i++) {
-    if (tokens.tokens[i].separator != NULL)
-        xmlFree(tokens.tokens[i].separator);
+        if (tokens.tokens[i].separator != NULL)
+            xmlFree(tokens.tokens[i].separator);
     }
 }
 
@@ -864,45 +864,45 @@ xsltFormatNumberPreSuffix(xsltDecimalFormatPtr self, xmlChar **format, xsltForma
     int len;
 
     while (1) {
-    /*
-     * prefix / suffix ends at end of string or at
-     * first 'special' character
-     */
-    if (**format == 0)
-        return count;
-    /* if next character 'escaped' just count it */
-    if (**format == SYMBOL_QUOTE) {
-        if (*++(*format) == 0)
-        return -1;
-    }
-    else if (IS_SPECIAL(self, *format))
-        return count;
-    /*
-     * else treat percent/per-mille as special cases,
-     * depending on whether +ve or -ve
-     */
-    else {
         /*
-         * for +ve prefix/suffix, allow only a
-         * single occurence of either
+         * prefix / suffix ends at end of string or at
+         * first 'special' character
          */
-        if (xsltUTF8Charcmp(*format, self->percent) == 0) {
-        if (info->is_multiplier_set)
-            return -1;
-        info->multiplier = 100;
-        info->is_multiplier_set = TRUE;
-        } else if (xsltUTF8Charcmp(*format, self->permille) == 0) {
-        if (info->is_multiplier_set)
-            return -1;
-        info->multiplier = 1000;
-        info->is_multiplier_set = TRUE;
+        if (**format == 0)
+            return count;
+        /* if next character 'escaped' just count it */
+        if (**format == SYMBOL_QUOTE) {
+            if (*++(*format) == 0)
+                return -1;
         }
-    }
+        else if (IS_SPECIAL(self, *format))
+            return count;
+        /*
+         * else treat percent/per-mille as special cases,
+         * depending on whether +ve or -ve
+         */
+        else {
+            /*
+             * for +ve prefix/suffix, allow only a
+             * single occurence of either
+             */
+            if (xsltUTF8Charcmp(*format, self->percent) == 0) {
+                if (info->is_multiplier_set)
+                    return -1;
+                info->multiplier = 100;
+                info->is_multiplier_set = TRUE;
+            } else if (xsltUTF8Charcmp(*format, self->permille) == 0) {
+                if (info->is_multiplier_set)
+                    return -1;
+                info->multiplier = 1000;
+                info->is_multiplier_set = TRUE;
+            }
+        }
 
-    if ((len=xmlUTF8Strsize(*format, 1)) < 1)
-        return -1;
-    count += len;
-    *format += len;
+        if ((len=xmlUTF8Strsize(*format, 1)) < 1)
+            return -1;
+        count += len;
+        *format += len;
     }
 }
 
@@ -950,9 +950,9 @@ xsltFormatNumberPreSuffix(xsltDecimalFormatPtr self, xmlChar **format, xsltForma
  */
 xmlXPathError
 xsltFormatNumberConversion(xsltDecimalFormatPtr self,
-               xmlChar *format,
-               double number,
-               xmlChar **result)
+                           xmlChar *format,
+                           double number,
+                           xmlChar **result)
 {
     xmlXPathError status = XPATH_EXPRESSION_OK;
     xmlBufferPtr buffer;
@@ -960,51 +960,51 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
     xmlChar *nprefix, *nsuffix = NULL;
     int     prefix_length, suffix_length = 0, nprefix_length, nsuffix_length;
     double  scale;
-    int     j, len;
+    int     j, len = 0;
     int     self_grouping_len;
     xsltFormatNumberInfo format_info;
     /*
      * delayed_multiplier allows a 'trailing' percent or
      * permille to be treated as suffix
      */
-    int     delayed_multiplier = 0;
+    int         delayed_multiplier = 0;
     /* flag to show no -ve format present for -ve number */
-    char    default_sign = 0;
+    char        default_sign = 0;
     /* flag to show error found, should use default format */
-    char    found_error = 0;
+    char        found_error = 0;
 
     if (xmlStrlen(format) <= 0) {
-    xsltTransformError(NULL, NULL, NULL,
+        xsltTransformError(NULL, NULL, NULL,
                 "xsltFormatNumberConversion : "
-        "Invalid format (0-length)\n");
+                "Invalid format (0-length)\n");
     }
     *result = NULL;
     switch (xmlXPathIsInf(number)) {
-    case -1:
-        if (self->minusSign == NULL)
-        *result = xmlStrdup(BAD_CAST "-");
-        else
-        *result = xmlStrdup(self->minusSign);
-        /* Intentional fall-through */
-    case 1:
-        if ((self == NULL) || (self->infinity == NULL))
-        *result = xmlStrcat(*result, BAD_CAST "Infinity");
-        else
-        *result = xmlStrcat(*result, self->infinity);
-        return(status);
-    default:
-        if (xmlXPathIsNaN(number)) {
-        if ((self == NULL) || (self->noNumber == NULL))
-            *result = xmlStrdup(BAD_CAST "NaN");
-        else
-            *result = xmlStrdup(self->noNumber);
-        return(status);
-        }
+        case -1:
+            if (self->minusSign == NULL)
+                *result = xmlStrdup(BAD_CAST "-");
+            else
+                *result = xmlStrdup(self->minusSign);
+            /* Intentional fall-through */
+        case 1:
+            if ((self == NULL) || (self->infinity == NULL))
+                *result = xmlStrcat(*result, BAD_CAST "Infinity");
+            else
+                *result = xmlStrcat(*result, self->infinity);
+            return(status);
+        default:
+            if (xmlXPathIsNaN(number)) {
+                if ((self == NULL) || (self->noNumber == NULL))
+                    *result = xmlStrdup(BAD_CAST "NaN");
+                else
+                    *result = xmlStrdup(self->noNumber);
+                return(status);
+            }
     }
 
     buffer = xmlBufferCreate();
     if (buffer == NULL) {
-    return XPATH_MEMORY_ERROR;
+        return XPATH_MEMORY_ERROR;
     }
 
     format_info.integer_hash = 0;
@@ -1026,8 +1026,8 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
     prefix = the_format;
     prefix_length = xsltFormatNumberPreSuffix(self, &the_format, &format_info);
     if (prefix_length < 0) {
-    found_error = 1;
-    goto OUTPUT_NUMBER;
+        found_error = 1;
+        goto OUTPUT_NUMBER;
     }
 
     /*
@@ -1039,52 +1039,52 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
      */
     self_grouping_len = xmlStrlen(self->grouping);
     while ((*the_format != 0) &&
-       (xsltUTF8Charcmp(the_format, self->decimalPoint) != 0) &&
-       (xsltUTF8Charcmp(the_format, self->patternSeparator) != 0)) {
+           (xsltUTF8Charcmp(the_format, self->decimalPoint) != 0) &&
+           (xsltUTF8Charcmp(the_format, self->patternSeparator) != 0)) {
 
-    if (delayed_multiplier != 0) {
-        format_info.multiplier = delayed_multiplier;
-        format_info.is_multiplier_set = TRUE;
-        delayed_multiplier = 0;
-    }
-    if (xsltUTF8Charcmp(the_format, self->digit) == 0) {
-        if (format_info.integer_digits > 0) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
+        if (delayed_multiplier != 0) {
+            format_info.multiplier = delayed_multiplier;
+            format_info.is_multiplier_set = TRUE;
+            delayed_multiplier = 0;
         }
-        format_info.integer_hash++;
-        if (format_info.group >= 0)
-        format_info.group++;
-    } else if (xsltUTF8Charcmp(the_format, self->zeroDigit) == 0) {
-        format_info.integer_digits++;
-        if (format_info.group >= 0)
-        format_info.group++;
-    } else if ((self_grouping_len > 0) &&
-        (!xmlStrncmp(the_format, self->grouping, self_grouping_len))) {
-        /* Reset group count */
-        format_info.group = 0;
-        the_format += self_grouping_len;
-        continue;
-    } else if (xsltUTF8Charcmp(the_format, self->percent) == 0) {
-        if (format_info.is_multiplier_set) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-        }
-        delayed_multiplier = 100;
-    } else  if (xsltUTF8Charcmp(the_format, self->permille) == 0) {
-        if (format_info.is_multiplier_set) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-        }
-        delayed_multiplier = 1000;
-    } else
-        break; /* while */
+        if (xsltUTF8Charcmp(the_format, self->digit) == 0) {
+            if (format_info.integer_digits > 0) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            format_info.integer_hash++;
+            if (format_info.group >= 0)
+                format_info.group++;
+        } else if (xsltUTF8Charcmp(the_format, self->zeroDigit) == 0) {
+            format_info.integer_digits++;
+            if (format_info.group >= 0)
+                format_info.group++;
+        } else if ((self_grouping_len > 0) &&
+            (!xmlStrncmp(the_format, self->grouping, self_grouping_len))) {
+            /* Reset group count */
+            format_info.group = 0;
+            the_format += self_grouping_len;
+            continue;
+        } else if (xsltUTF8Charcmp(the_format, self->percent) == 0) {
+            if (format_info.is_multiplier_set) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            delayed_multiplier = 100;
+        } else  if (xsltUTF8Charcmp(the_format, self->permille) == 0) {
+            if (format_info.is_multiplier_set) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            delayed_multiplier = 1000;
+        } else
+            break; /* while */
 
-    if ((len=xmlUTF8Strsize(the_format, 1)) < 1) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-    }
-    the_format += len;
+        if ((len=xmlUTF8Strsize(the_format, 1)) < 1) {
+            found_error = 1;
+            goto OUTPUT_NUMBER;
+        }
+        the_format += len;
 
     }
 
@@ -1096,56 +1096,56 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
             found_error = 1;
             goto OUTPUT_NUMBER;
         }
-    the_format += len;  /* Skip over the decimal */
+        the_format += len;      /* Skip over the decimal */
     }
 
     while (*the_format != 0) {
 
-    if (xsltUTF8Charcmp(the_format, self->zeroDigit) == 0) {
-        if (format_info.frac_hash != 0) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
+        if (xsltUTF8Charcmp(the_format, self->zeroDigit) == 0) {
+            if (format_info.frac_hash != 0) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            format_info.frac_digits++;
+        } else if (xsltUTF8Charcmp(the_format, self->digit) == 0) {
+            format_info.frac_hash++;
+        } else if (xsltUTF8Charcmp(the_format, self->percent) == 0) {
+            if (format_info.is_multiplier_set) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            delayed_multiplier = 100;
+            if ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            the_format += len;
+            continue; /* while */
+        } else if (xsltUTF8Charcmp(the_format, self->permille) == 0) {
+            if (format_info.is_multiplier_set) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            delayed_multiplier = 1000;
+            if  ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            the_format += len;
+            continue; /* while */
+        } else if (xsltUTF8Charcmp(the_format, self->grouping) != 0) {
+            break; /* while */
         }
-        format_info.frac_digits++;
-    } else if (xsltUTF8Charcmp(the_format, self->digit) == 0) {
-        format_info.frac_hash++;
-    } else if (xsltUTF8Charcmp(the_format, self->percent) == 0) {
-        if (format_info.is_multiplier_set) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-        }
-        delayed_multiplier = 100;
         if ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
             found_error = 1;
-        goto OUTPUT_NUMBER;
+            goto OUTPUT_NUMBER;
         }
         the_format += len;
-        continue; /* while */
-    } else if (xsltUTF8Charcmp(the_format, self->permille) == 0) {
-        if (format_info.is_multiplier_set) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
+        if (delayed_multiplier != 0) {
+            format_info.multiplier = delayed_multiplier;
+            delayed_multiplier = 0;
+            format_info.is_multiplier_set = TRUE;
         }
-        delayed_multiplier = 1000;
-        if  ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
-            found_error = 1;
-        goto OUTPUT_NUMBER;
-        }
-        the_format += len;
-        continue; /* while */
-    } else if (xsltUTF8Charcmp(the_format, self->grouping) != 0) {
-        break; /* while */
-    }
-    if ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-    }
-    the_format += len;
-    if (delayed_multiplier != 0) {
-        format_info.multiplier = delayed_multiplier;
-        delayed_multiplier = 0;
-        format_info.is_multiplier_set = TRUE;
-    }
     }
 
     /*
@@ -1153,17 +1153,17 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
      * "number" part, should be in suffix
      */
     if (delayed_multiplier != 0) {
-    the_format -= len;
-    delayed_multiplier = 0;
+        the_format -= len;
+        delayed_multiplier = 0;
     }
 
     suffix = the_format;
     suffix_length = xsltFormatNumberPreSuffix(self, &the_format, &format_info);
     if ( (suffix_length < 0) ||
-     ((*the_format != 0) &&
-      (xsltUTF8Charcmp(the_format, self->patternSeparator) != 0)) ) {
-    found_error = 1;
-    goto OUTPUT_NUMBER;
+         ((*the_format != 0) &&
+          (xsltUTF8Charcmp(the_format, self->patternSeparator) != 0)) ) {
+        found_error = 1;
+        goto OUTPUT_NUMBER;
     }
 
     /*
@@ -1172,118 +1172,118 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
      */
     if (number < 0) {
         /*
-     * Note that j is the number of UTF8 chars before the separator,
-     * not the number of bytes! (bug 151975)
-     */
+         * Note that j is the number of UTF8 chars before the separator,
+         * not the number of bytes! (bug 151975)
+         */
         j =  xmlUTF8Strloc(format, self->patternSeparator);
-    if (j < 0) {
-    /* No -ve pattern present, so use default signing */
-        default_sign = 1;
-    }
-    else {
-        /* Skip over pattern separator (accounting for UTF8) */
-        the_format = (xmlChar *)xmlUTF8Strpos(format, j + 1);
-        /*
-         * Flag changes interpretation of percent/permille
-         * in -ve pattern
-         */
-        format_info.is_negative_pattern = TRUE;
-        format_info.is_multiplier_set = FALSE;
-
-        /* First do the -ve prefix */
-        nprefix = the_format;
-        nprefix_length = xsltFormatNumberPreSuffix(self,
-                    &the_format, &format_info);
-        if (nprefix_length<0) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
+        if (j < 0) {
+        /* No -ve pattern present, so use default signing */
+            default_sign = 1;
         }
+        else {
+            /* Skip over pattern separator (accounting for UTF8) */
+            the_format = (xmlChar *)xmlUTF8Strpos(format, j + 1);
+            /*
+             * Flag changes interpretation of percent/permille
+             * in -ve pattern
+             */
+            format_info.is_negative_pattern = TRUE;
+            format_info.is_multiplier_set = FALSE;
 
-        while (*the_format != 0) {
-        if ( (xsltUTF8Charcmp(the_format, (self)->percent) == 0) ||
-             (xsltUTF8Charcmp(the_format, (self)->permille)== 0) ) {
-            if (format_info.is_multiplier_set) {
-            found_error = 1;
-            goto OUTPUT_NUMBER;
+            /* First do the -ve prefix */
+            nprefix = the_format;
+            nprefix_length = xsltFormatNumberPreSuffix(self,
+                                        &the_format, &format_info);
+            if (nprefix_length<0) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
             }
-            format_info.is_multiplier_set = TRUE;
-            delayed_multiplier = 1;
-        }
-        else if (IS_SPECIAL(self, the_format))
-            delayed_multiplier = 0;
-        else
-            break; /* while */
-        if ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
-            found_error = 1;
-            goto OUTPUT_NUMBER;
-        }
-        the_format += len;
-        }
-        if (delayed_multiplier != 0) {
-        format_info.is_multiplier_set = FALSE;
-        the_format -= len;
-        }
 
-        /* Finally do the -ve suffix */
-        if (*the_format != 0) {
-        nsuffix = the_format;
-        nsuffix_length = xsltFormatNumberPreSuffix(self,
-                    &the_format, &format_info);
-        if (nsuffix_length < 0) {
-            found_error = 1;
-            goto OUTPUT_NUMBER;
+            while (*the_format != 0) {
+                if ( (xsltUTF8Charcmp(the_format, (self)->percent) == 0) ||
+                     (xsltUTF8Charcmp(the_format, (self)->permille)== 0) ) {
+                    if (format_info.is_multiplier_set) {
+                        found_error = 1;
+                        goto OUTPUT_NUMBER;
+                    }
+                    format_info.is_multiplier_set = TRUE;
+                    delayed_multiplier = 1;
+                }
+                else if (IS_SPECIAL(self, the_format))
+                    delayed_multiplier = 0;
+                else
+                    break; /* while */
+                if ((len = xmlUTF8Strsize(the_format, 1)) < 1) {
+                    found_error = 1;
+                    goto OUTPUT_NUMBER;
+                }
+                the_format += len;
+            }
+            if (delayed_multiplier != 0) {
+                format_info.is_multiplier_set = FALSE;
+                the_format -= len;
+            }
+
+            /* Finally do the -ve suffix */
+            if (*the_format != 0) {
+                nsuffix = the_format;
+                nsuffix_length = xsltFormatNumberPreSuffix(self,
+                                        &the_format, &format_info);
+                if (nsuffix_length < 0) {
+                    found_error = 1;
+                    goto OUTPUT_NUMBER;
+                }
+            }
+            else
+                nsuffix_length = 0;
+            if (*the_format != 0) {
+                found_error = 1;
+                goto OUTPUT_NUMBER;
+            }
+            /*
+             * Here's another Java peculiarity:
+             * if -ve prefix/suffix == +ve ones, discard & use default
+             */
+            if ((nprefix_length != prefix_length) ||
+                (nsuffix_length != suffix_length) ||
+                ((nprefix_length > 0) &&
+                 (xmlStrncmp(nprefix, prefix, prefix_length) !=0 )) ||
+                ((nsuffix_length > 0) &&
+                 (xmlStrncmp(nsuffix, suffix, suffix_length) !=0 ))) {
+                prefix = nprefix;
+                prefix_length = nprefix_length;
+                suffix = nsuffix;
+                suffix_length = nsuffix_length;
+            } /* else {
+                default_sign = 1;
+            }
+            */
         }
-        }
-        else
-        nsuffix_length = 0;
-        if (*the_format != 0) {
-        found_error = 1;
-        goto OUTPUT_NUMBER;
-        }
-        /*
-         * Here's another Java peculiarity:
-         * if -ve prefix/suffix == +ve ones, discard & use default
-         */
-        if ((nprefix_length != prefix_length) ||
-        (nsuffix_length != suffix_length) ||
-        ((nprefix_length > 0) &&
-         (xmlStrncmp(nprefix, prefix, prefix_length) !=0 )) ||
-        ((nsuffix_length > 0) &&
-         (xmlStrncmp(nsuffix, suffix, suffix_length) !=0 ))) {
-        prefix = nprefix;
-        prefix_length = nprefix_length;
-        suffix = nsuffix;
-        suffix_length = nsuffix_length;
-        } /* else {
-        default_sign = 1;
-        }
-        */
-    }
     }
 
 OUTPUT_NUMBER:
     if (found_error != 0) {
-    xsltTransformError(NULL, NULL, NULL,
+        xsltTransformError(NULL, NULL, NULL,
                 "xsltFormatNumberConversion : "
-        "error in format string '%s', using default\n", format);
-    default_sign = (number < 0.0) ? 1 : 0;
-    prefix_length = suffix_length = 0;
-    format_info.integer_hash = 0;
-    format_info.integer_digits = 1;
-    format_info.frac_digits = 1;
-    format_info.frac_hash = 4;
-    format_info.group = -1;
-    format_info.multiplier = 1;
-    format_info.add_decimal = TRUE;
+                "error in format string '%s', using default\n", format);
+        default_sign = (number < 0.0) ? 1 : 0;
+        prefix_length = suffix_length = 0;
+        format_info.integer_hash = 0;
+        format_info.integer_digits = 1;
+        format_info.frac_digits = 1;
+        format_info.frac_hash = 4;
+        format_info.group = -1;
+        format_info.multiplier = 1;
+        format_info.add_decimal = TRUE;
     }
 
     /* Ready to output our number.  First see if "default sign" is required */
     if (default_sign != 0)
-    xmlBufferAdd(buffer, self->minusSign, xmlUTF8Strsize(self->minusSign, 1));
+        xmlBufferAdd(buffer, self->minusSign, xmlUTF8Strsize(self->minusSign, 1));
 
     /* Put the prefix into the buffer */
     for (j = 0; j < prefix_length; ) {
-    if (*prefix == SYMBOL_QUOTE)
+        if (*prefix == SYMBOL_QUOTE)
             prefix++;
         len = xmlUTF8Strsize(prefix, 1);
         xmlBufferAdd(buffer, prefix, len);
@@ -1299,56 +1299,56 @@ OUTPUT_NUMBER:
         (self->grouping[0] != 0)) {
         int gchar;
 
-    len = xmlStrlen(self->grouping);
-    gchar = xsltGetUTF8Char(self->grouping, &len);
-    xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
-                format_info.integer_digits,
-                format_info.group,
-                gchar, len);
+        len = xmlStrlen(self->grouping);
+        gchar = xsltGetUTF8Char(self->grouping, &len);
+        xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
+                                format_info.integer_digits,
+                                format_info.group,
+                                gchar, len);
     } else
-    xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
-                format_info.integer_digits,
-                format_info.group,
-                ',', 1);
+        xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
+                                format_info.integer_digits,
+                                format_info.group,
+                                ',', 1);
 
     /* Special case: java treats '.#' like '.0', '.##' like '.0#', etc. */
     if ((format_info.integer_digits + format_info.integer_hash +
-     format_info.frac_digits == 0) && (format_info.frac_hash > 0)) {
+         format_info.frac_digits == 0) && (format_info.frac_hash > 0)) {
         ++format_info.frac_digits;
-    --format_info.frac_hash;
+        --format_info.frac_hash;
     }
 
     /* Add leading zero, if required */
     if ((floor(number) == 0) &&
-    (format_info.integer_digits + format_info.frac_digits == 0)) {
+        (format_info.integer_digits + format_info.frac_digits == 0)) {
         xmlBufferAdd(buffer, self->zeroDigit, xmlUTF8Strsize(self->zeroDigit, 1));
     }
 
     /* Next the fractional part, if required */
     if (format_info.frac_digits + format_info.frac_hash == 0) {
         if (format_info.add_decimal)
-        xmlBufferAdd(buffer, self->decimalPoint,
-             xmlUTF8Strsize(self->decimalPoint, 1));
+            xmlBufferAdd(buffer, self->decimalPoint,
+                         xmlUTF8Strsize(self->decimalPoint, 1));
     }
     else {
       number -= floor(number);
-    if ((number != 0) || (format_info.frac_digits != 0)) {
-        xmlBufferAdd(buffer, self->decimalPoint,
-             xmlUTF8Strsize(self->decimalPoint, 1));
-        number = floor(scale * number + 0.5);
-        for (j = format_info.frac_hash; j > 0; j--) {
-        if (fmod(number, 10.0) >= 1.0)
-            break; /* for */
-        number /= 10.0;
+        if ((number != 0) || (format_info.frac_digits != 0)) {
+            xmlBufferAdd(buffer, self->decimalPoint,
+                         xmlUTF8Strsize(self->decimalPoint, 1));
+            number = floor(scale * number + 0.5);
+            for (j = format_info.frac_hash; j > 0; j--) {
+                if (fmod(number, 10.0) >= 1.0)
+                    break; /* for */
+                number /= 10.0;
+            }
+            xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
+                                format_info.frac_digits + j,
+                                0, 0, 0);
         }
-        xsltNumberFormatDecimal(buffer, floor(number), self->zeroDigit[0],
-                format_info.frac_digits + j,
-                0, 0, 0);
-    }
     }
     /* Put the suffix into the buffer */
     for (j = 0; j < suffix_length; ) {
-    if (*suffix == SYMBOL_QUOTE)
+        if (*suffix == SYMBOL_QUOTE)
             suffix++;
         len = xmlUTF8Strsize(suffix, 1);
         xmlBufferAdd(buffer, suffix, len);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/numbersInternals.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/numbersInternals.h
@@ -56,13 +56,13 @@ typedef struct _xsltFormatNumberInfo xsltFormatNumberInfo;
 typedef xsltFormatNumberInfo *xsltFormatNumberInfoPtr;
 
 struct _xsltFormatNumberInfo {
-    int     integer_hash;   /* Number of '#' in integer part */
-    int     integer_digits; /* Number of '0' in integer part */
-    int     frac_digits;    /* Number of '0' in fractional part */
-    int     frac_hash;      /* Number of '#' in fractional part */
-    int     group;      /* Number of chars per display 'group' */
-    int     multiplier;     /* Scaling for percent or permille */
-    char    add_decimal;    /* Flag for whether decimal point appears in pattern */
+    int     integer_hash;       /* Number of '#' in integer part */
+    int     integer_digits;     /* Number of '0' in integer part */
+    int     frac_digits;        /* Number of '0' in fractional part */
+    int     frac_hash;          /* Number of '#' in fractional part */
+    int     group;              /* Number of chars per display 'group' */
+    int     multiplier;         /* Scaling for percent or permille */
+    char    add_decimal;        /* Flag for whether decimal point appears in pattern */
     char    is_multiplier_set;  /* Flag to catch multiple occurences of percent/permille */
     char    is_negative_pattern;/* Flag for processing -ve prefix/suffix */
 };

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/pattern.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/pattern.c
@@ -110,28 +110,28 @@ struct _xsltCompMatch {
     /* TODO fix the statically allocated size steps[] */
     int nbStep;
     int maxStep;
-    xmlNsPtr *nsList;       /* the namespaces in scope */
-    int nsNr;           /* the number of namespaces in scope */
+    xmlNsPtr *nsList;           /* the namespaces in scope */
+    int nsNr;                   /* the number of namespaces in scope */
     xsltStepOpPtr steps;        /* ops for computation */
 };
 
 typedef struct _xsltParserContext xsltParserContext;
 typedef xsltParserContext *xsltParserContextPtr;
 struct _xsltParserContext {
-    xsltStylesheetPtr style;        /* the stylesheet */
-    xsltTransformContextPtr ctxt;   /* the transformation or NULL */
-    const xmlChar *cur;         /* the current char being parsed */
-    const xmlChar *base;        /* the full expression */
-    xmlDocPtr      doc;         /* the source document */
-    xmlNodePtr    elem;         /* the source element */
-    int error;              /* error code */
-    xsltCompMatchPtr comp;      /* the result */
+    xsltStylesheetPtr style;            /* the stylesheet */
+    xsltTransformContextPtr ctxt;       /* the transformation or NULL */
+    const xmlChar *cur;                 /* the current char being parsed */
+    const xmlChar *base;                /* the full expression */
+    xmlDocPtr      doc;                 /* the source document */
+    xmlNodePtr    elem;                 /* the source element */
+    int error;                          /* error code */
+    xsltCompMatchPtr comp;              /* the result */
 };
 
 /************************************************************************
- *                                  *
- *          Type functions                  *
- *                                  *
+ *                                                                      *
+ *                      Type functions                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -147,9 +147,9 @@ xsltNewCompMatch(void) {
 
     cur = (xsltCompMatchPtr) xmlMalloc(sizeof(xsltCompMatch));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewCompMatch : out of memory error\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewCompMatch : out of memory error\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltCompMatch));
     cur->maxStep = 10;
@@ -157,10 +157,10 @@ xsltNewCompMatch(void) {
     cur-> steps = (xsltStepOpPtr) xmlMalloc(sizeof(xsltStepOp) *
                                             cur->maxStep);
     if (cur->steps == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewCompMatch : out of memory error\n");
-    xmlFree(cur);
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewCompMatch : out of memory error\n");
+        xmlFree(cur);
+        return(NULL);
     }
     cur->nsNr = 0;
     cur->nsList = NULL;
@@ -180,21 +180,21 @@ xsltFreeCompMatch(xsltCompMatchPtr comp) {
     int i;
 
     if (comp == NULL)
-    return;
+        return;
     if (comp->pattern != NULL)
-    xmlFree((xmlChar *)comp->pattern);
+        xmlFree((xmlChar *)comp->pattern);
     if (comp->nsList != NULL)
-    xmlFree(comp->nsList);
+        xmlFree(comp->nsList);
     for (i = 0;i < comp->nbStep;i++) {
-    op = &comp->steps[i];
-    if (op->value != NULL)
-        xmlFree(op->value);
-    if (op->value2 != NULL)
-        xmlFree(op->value2);
-    if (op->value3 != NULL)
-        xmlFree(op->value3);
-    if (op->comp != NULL)
-        xmlXPathFreeCompExpr(op->comp);
+        op = &comp->steps[i];
+        if (op->value != NULL)
+            xmlFree(op->value);
+        if (op->value2 != NULL)
+            xmlFree(op->value2);
+        if (op->value3 != NULL)
+            xmlFree(op->value3);
+        if (op->comp != NULL)
+            xmlXPathFreeCompExpr(op->comp);
     }
     xmlFree(comp->steps);
     memset(comp, -1, sizeof(xsltCompMatch));
@@ -212,9 +212,9 @@ xsltFreeCompMatchList(xsltCompMatchPtr comp) {
     xsltCompMatchPtr cur;
 
     while (comp != NULL) {
-    cur = comp;
-    comp = comp->next;
-    xsltFreeCompMatch(cur);
+        cur = comp;
+        comp = comp->next;
+        xsltFreeCompMatch(cur);
     }
 }
 
@@ -261,9 +261,9 @@ xsltNewParserContext(xsltStylesheetPtr style, xsltTransformContextPtr ctxt) {
 
     cur = (xsltParserContextPtr) xmlMalloc(sizeof(xsltParserContext));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewParserContext : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewParserContext : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltParserContext));
     cur->style = style;
@@ -280,7 +280,7 @@ xsltNewParserContext(xsltStylesheetPtr style, xsltTransformContextPtr ctxt) {
 static void
 xsltFreeParserContext(xsltParserContextPtr ctxt) {
     if (ctxt == NULL)
-    return;
+        return;
     memset(ctxt, -1, sizeof(xsltParserContext));
     xmlFree(ctxt);
 }
@@ -304,21 +304,21 @@ xsltCompMatchAdd(xsltParserContextPtr ctxt, xsltCompMatchPtr comp,
     if (comp->nbStep >= comp->maxStep) {
         xsltStepOpPtr tmp;
 
-    tmp = (xsltStepOpPtr) xmlRealloc(comp->steps, comp->maxStep * 2 *
-                                     sizeof(xsltStepOp));
-    if (tmp == NULL) {
-        xsltGenericError(xsltGenericErrorContext,
-         "xsltCompMatchAdd: memory re-allocation failure.\n");
-        if (ctxt->style != NULL)
-        ctxt->style->errors++;
-        if (value)
-            xmlFree(value);
-        if (value2)
-            xmlFree(value2);
-        return (-1);
-    }
+        tmp = (xsltStepOpPtr) xmlRealloc(comp->steps, comp->maxStep * 2 *
+                                         sizeof(xsltStepOp));
+        if (tmp == NULL) {
+            xsltGenericError(xsltGenericErrorContext,
+             "xsltCompMatchAdd: memory re-allocation failure.\n");
+            if (ctxt->style != NULL)
+                ctxt->style->errors++;
+            if (value)
+                xmlFree(value);
+            if (value2)
+                xmlFree(value2);
+            return (-1);
+        }
         comp->maxStep *= 2;
-    comp->steps = tmp;
+        comp->steps = tmp;
     }
     comp->steps[comp->nbStep].op = op;
     comp->steps[comp->nbStep].value = value;
@@ -326,35 +326,35 @@ xsltCompMatchAdd(xsltParserContextPtr ctxt, xsltCompMatchPtr comp,
     comp->steps[comp->nbStep].value3 = NULL;
     comp->steps[comp->nbStep].comp = NULL;
     if (ctxt->ctxt != NULL) {
-    comp->steps[comp->nbStep].previousExtra =
-        xsltAllocateExtraCtxt(ctxt->ctxt);
-    comp->steps[comp->nbStep].indexExtra =
-        xsltAllocateExtraCtxt(ctxt->ctxt);
-    comp->steps[comp->nbStep].lenExtra =
-        xsltAllocateExtraCtxt(ctxt->ctxt);
+        comp->steps[comp->nbStep].previousExtra =
+            xsltAllocateExtraCtxt(ctxt->ctxt);
+        comp->steps[comp->nbStep].indexExtra =
+            xsltAllocateExtraCtxt(ctxt->ctxt);
+        comp->steps[comp->nbStep].lenExtra =
+            xsltAllocateExtraCtxt(ctxt->ctxt);
     } else {
-    comp->steps[comp->nbStep].previousExtra =
-        xsltAllocateExtra(ctxt->style);
-    comp->steps[comp->nbStep].indexExtra =
-        xsltAllocateExtra(ctxt->style);
-    comp->steps[comp->nbStep].lenExtra =
-        xsltAllocateExtra(ctxt->style);
+        comp->steps[comp->nbStep].previousExtra =
+            xsltAllocateExtra(ctxt->style);
+        comp->steps[comp->nbStep].indexExtra =
+            xsltAllocateExtra(ctxt->style);
+        comp->steps[comp->nbStep].lenExtra =
+            xsltAllocateExtra(ctxt->style);
     }
     if (op == XSLT_OP_PREDICATE) {
         int flags = 0;
 
 #ifdef XML_XPATH_NOVAR
-    if (novar != 0)
-        flags = XML_XPATH_NOVAR;
+        if (novar != 0)
+            flags = XML_XPATH_NOVAR;
 #endif
-    comp->steps[comp->nbStep].comp = xsltXPathCompileFlags(ctxt->style,
+        comp->steps[comp->nbStep].comp = xsltXPathCompileFlags(ctxt->style,
                 value, flags);
-    if (comp->steps[comp->nbStep].comp == NULL) {
-        xsltTransformError(NULL, ctxt->style, ctxt->elem,
-            "Failed to compile predicate\n");
-        if (ctxt->style != NULL)
-        ctxt->style->errors++;
-    }
+        if (comp->steps[comp->nbStep].comp == NULL) {
+            xsltTransformError(NULL, ctxt->style, ctxt->elem,
+                    "Failed to compile predicate\n");
+            if (ctxt->style != NULL)
+                ctxt->style->errors++;
+        }
     }
     comp->nbStep++;
     return (0);
@@ -372,35 +372,35 @@ xsltSwapTopCompMatch(xsltCompMatchPtr comp) {
     int j = comp->nbStep - 1;
 
     if (j > 0) {
-    register xmlChar *tmp;
-    register xsltOp op;
-    register xmlXPathCompExprPtr expr;
-    register int t;
-    i = j - 1;
-    tmp = comp->steps[i].value;
-    comp->steps[i].value = comp->steps[j].value;
-    comp->steps[j].value = tmp;
-    tmp = comp->steps[i].value2;
-    comp->steps[i].value2 = comp->steps[j].value2;
-    comp->steps[j].value2 = tmp;
-    tmp = comp->steps[i].value3;
-    comp->steps[i].value3 = comp->steps[j].value3;
-    comp->steps[j].value3 = tmp;
-    op = comp->steps[i].op;
-    comp->steps[i].op = comp->steps[j].op;
-    comp->steps[j].op = op;
-    expr = comp->steps[i].comp;
-    comp->steps[i].comp = comp->steps[j].comp;
-    comp->steps[j].comp = expr;
-    t = comp->steps[i].previousExtra;
-    comp->steps[i].previousExtra = comp->steps[j].previousExtra;
-    comp->steps[j].previousExtra = t;
-    t = comp->steps[i].indexExtra;
-    comp->steps[i].indexExtra = comp->steps[j].indexExtra;
-    comp->steps[j].indexExtra = t;
-    t = comp->steps[i].lenExtra;
-    comp->steps[i].lenExtra = comp->steps[j].lenExtra;
-    comp->steps[j].lenExtra = t;
+        register xmlChar *tmp;
+        register xsltOp op;
+        register xmlXPathCompExprPtr expr;
+        register int t;
+        i = j - 1;
+        tmp = comp->steps[i].value;
+        comp->steps[i].value = comp->steps[j].value;
+        comp->steps[j].value = tmp;
+        tmp = comp->steps[i].value2;
+        comp->steps[i].value2 = comp->steps[j].value2;
+        comp->steps[j].value2 = tmp;
+        tmp = comp->steps[i].value3;
+        comp->steps[i].value3 = comp->steps[j].value3;
+        comp->steps[j].value3 = tmp;
+        op = comp->steps[i].op;
+        comp->steps[i].op = comp->steps[j].op;
+        comp->steps[j].op = op;
+        expr = comp->steps[i].comp;
+        comp->steps[i].comp = comp->steps[j].comp;
+        comp->steps[j].comp = expr;
+        t = comp->steps[i].previousExtra;
+        comp->steps[i].previousExtra = comp->steps[j].previousExtra;
+        comp->steps[j].previousExtra = t;
+        t = comp->steps[i].indexExtra;
+        comp->steps[i].indexExtra = comp->steps[j].indexExtra;
+        comp->steps[j].indexExtra = t;
+        t = comp->steps[i].lenExtra;
+        comp->steps[i].lenExtra = comp->steps[j].lenExtra;
+        comp->steps[j].lenExtra = t;
     }
 }
 
@@ -417,70 +417,67 @@ xsltReverseCompMatch(xsltParserContextPtr ctxt, xsltCompMatchPtr comp) {
     int j = comp->nbStep - 1;
 
     while (j > i) {
-    register xmlChar *tmp;
-    register xsltOp op;
-    register xmlXPathCompExprPtr expr;
-    register int t;
+        register xmlChar *tmp;
+        register xsltOp op;
+        register xmlXPathCompExprPtr expr;
+        register int t;
 
-    tmp = comp->steps[i].value;
-    comp->steps[i].value = comp->steps[j].value;
-    comp->steps[j].value = tmp;
-    tmp = comp->steps[i].value2;
-    comp->steps[i].value2 = comp->steps[j].value2;
-    comp->steps[j].value2 = tmp;
-    tmp = comp->steps[i].value3;
-    comp->steps[i].value3 = comp->steps[j].value3;
-    comp->steps[j].value3 = tmp;
-    op = comp->steps[i].op;
-    comp->steps[i].op = comp->steps[j].op;
-    comp->steps[j].op = op;
-    expr = comp->steps[i].comp;
-    comp->steps[i].comp = comp->steps[j].comp;
-    comp->steps[j].comp = expr;
-    t = comp->steps[i].previousExtra;
-    comp->steps[i].previousExtra = comp->steps[j].previousExtra;
-    comp->steps[j].previousExtra = t;
-    t = comp->steps[i].indexExtra;
-    comp->steps[i].indexExtra = comp->steps[j].indexExtra;
-    comp->steps[j].indexExtra = t;
-    t = comp->steps[i].lenExtra;
-    comp->steps[i].lenExtra = comp->steps[j].lenExtra;
-    comp->steps[j].lenExtra = t;
-    j--;
-    i++;
+        tmp = comp->steps[i].value;
+        comp->steps[i].value = comp->steps[j].value;
+        comp->steps[j].value = tmp;
+        tmp = comp->steps[i].value2;
+        comp->steps[i].value2 = comp->steps[j].value2;
+        comp->steps[j].value2 = tmp;
+        tmp = comp->steps[i].value3;
+        comp->steps[i].value3 = comp->steps[j].value3;
+        comp->steps[j].value3 = tmp;
+        op = comp->steps[i].op;
+        comp->steps[i].op = comp->steps[j].op;
+        comp->steps[j].op = op;
+        expr = comp->steps[i].comp;
+        comp->steps[i].comp = comp->steps[j].comp;
+        comp->steps[j].comp = expr;
+        t = comp->steps[i].previousExtra;
+        comp->steps[i].previousExtra = comp->steps[j].previousExtra;
+        comp->steps[j].previousExtra = t;
+        t = comp->steps[i].indexExtra;
+        comp->steps[i].indexExtra = comp->steps[j].indexExtra;
+        comp->steps[j].indexExtra = t;
+        t = comp->steps[i].lenExtra;
+        comp->steps[i].lenExtra = comp->steps[j].lenExtra;
+        comp->steps[j].lenExtra = t;
+        j--;
+        i++;
     }
     xsltCompMatchAdd(ctxt, comp, XSLT_OP_END, NULL, NULL, 0);
 
     /*
-     * Detect consecutive XSLT_OP_PREDICATE and predicates on ops which
-     * haven't been optimized yet indicating a direct matching should be done.
+     * Detect consecutive XSLT_OP_PREDICATE indicating a direct matching
+     * should be done.
      */
     for (i = 0;i < comp->nbStep - 1;i++) {
-        xsltOp op = comp->steps[i].op;
+        if ((comp->steps[i].op == XSLT_OP_PREDICATE) &&
+            (comp->steps[i + 1].op == XSLT_OP_PREDICATE)) {
 
-        if ((op != XSLT_OP_ELEM) &&
-            (op != XSLT_OP_ALL) &&
-        (comp->steps[i + 1].op == XSLT_OP_PREDICATE)) {
+            comp->direct = 1;
+            if (comp->pattern[0] != '/') {
+                xmlChar *query;
 
-        comp->direct = 1;
-        if (comp->pattern[0] != '/') {
-        xmlChar *query;
+                query = xmlStrdup((const xmlChar *)"//");
+                query = xmlStrcat(query, comp->pattern);
 
-        query = xmlStrdup((const xmlChar *)"//");
-        query = xmlStrcat(query, comp->pattern);
-
-        xmlFree((xmlChar *) comp->pattern);
-        comp->pattern = query;
+                xmlFree((xmlChar *) comp->pattern);
+                comp->pattern = query;
+            }
+            break;
         }
-        break;
-    }
     }
 }
 
 /************************************************************************
- *                                  *
- *      The interpreter for the precompiled patterns        *
- *                                  *
+ *                                                                      *
+ *              The interpreter for the precompiled patterns            *
+ *                                                                      *
  ************************************************************************/
 
 static int
@@ -488,22 +485,22 @@ xsltPatPushState(xsltTransformContextPtr ctxt, xsltStepStates *states,
                  int step, xmlNodePtr node) {
     if ((states->states == NULL) || (states->maxstates <= 0)) {
         states->maxstates = 4;
-    states->nbstates = 0;
-    states->states = xmlMalloc(4 * sizeof(xsltStepState));
+        states->nbstates = 0;
+        states->states = xmlMalloc(4 * sizeof(xsltStepState));
     }
     else if (states->maxstates <= states->nbstates) {
         xsltStepState *tmp;
 
-    tmp = (xsltStepStatePtr) xmlRealloc(states->states,
-                   2 * states->maxstates * sizeof(xsltStepState));
-    if (tmp == NULL) {
-        xsltGenericError(xsltGenericErrorContext,
-         "xsltPatPushState: memory re-allocation failure.\n");
-        ctxt->state = XSLT_STATE_STOPPED;
-        return(-1);
-    }
-    states->states = tmp;
-    states->maxstates *= 2;
+        tmp = (xsltStepStatePtr) xmlRealloc(states->states,
+                               2 * states->maxstates * sizeof(xsltStepState));
+        if (tmp == NULL) {
+            xsltGenericError(xsltGenericErrorContext,
+             "xsltPatPushState: memory re-allocation failure.\n");
+            ctxt->state = XSLT_STATE_STOPPED;
+            return(-1);
+        }
+        states->states = tmp;
+        states->maxstates *= 2;
     }
     states->states[states->nbstates].step = step;
     states->states[states->nbstates++].node = node;
@@ -533,7 +530,7 @@ xmlXPathFreeObjectWrapper(void *obj) {
  */
 static int
 xsltTestCompMatchDirect(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
-                    xmlNodePtr node, xmlNsPtr *nsList, int nsNr) {
+                        xmlNodePtr node, xmlNsPtr *nsList, int nsNr) {
     xsltStepOpPtr sel = NULL;
     xmlDocPtr prevdoc;
     xmlDocPtr doc;
@@ -544,89 +541,235 @@ xsltTestCompMatchDirect(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
 
     doc = node->doc;
     if (XSLT_IS_RES_TREE_FRAG(doc))
-    isRVT = 1;
+        isRVT = 1;
     else
-    isRVT = 0;
+        isRVT = 0;
     sel = &comp->steps[0]; /* store extra in first step arbitrarily */
 
     prevdoc = (xmlDocPtr)
-    XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr);
+        XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr);
     ix = XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival);
     list = (xmlXPathObjectPtr)
-    XSLT_RUNTIME_EXTRA_LST(ctxt, sel->lenExtra);
+        XSLT_RUNTIME_EXTRA_LST(ctxt, sel->lenExtra);
 
     if ((list == NULL) || (prevdoc != doc)) {
-    xmlXPathObjectPtr newlist;
-    xmlNodePtr parent = node->parent;
-    xmlDocPtr olddoc;
-    xmlNodePtr oldnode;
-    int oldNsNr, oldContextSize, oldProximityPosition;
-    xmlNsPtr *oldNamespaces;
+        xmlXPathObjectPtr newlist;
+        xmlNodePtr parent = node->parent;
+        xmlDocPtr olddoc;
+        xmlNodePtr oldnode;
+        int oldNsNr, oldContextSize, oldProximityPosition;
+        xmlNsPtr *oldNamespaces;
 
-    oldnode = ctxt->xpathCtxt->node;
-    olddoc = ctxt->xpathCtxt->doc;
-    oldNsNr = ctxt->xpathCtxt->nsNr;
-    oldNamespaces = ctxt->xpathCtxt->namespaces;
-    oldContextSize = ctxt->xpathCtxt->contextSize;
-    oldProximityPosition = ctxt->xpathCtxt->proximityPosition;
-    ctxt->xpathCtxt->node = node;
-    ctxt->xpathCtxt->doc = doc;
-    ctxt->xpathCtxt->namespaces = nsList;
-    ctxt->xpathCtxt->nsNr = nsNr;
-    newlist = xmlXPathEval(comp->pattern, ctxt->xpathCtxt);
-    ctxt->xpathCtxt->node = oldnode;
-    ctxt->xpathCtxt->doc = olddoc;
-    ctxt->xpathCtxt->namespaces = oldNamespaces;
-    ctxt->xpathCtxt->nsNr = oldNsNr;
-    ctxt->xpathCtxt->contextSize = oldContextSize;
-    ctxt->xpathCtxt->proximityPosition = oldProximityPosition;
-    if (newlist == NULL)
-        return(-1);
-    if (newlist->type != XPATH_NODESET) {
-        xmlXPathFreeObject(newlist);
-        return(-1);
-    }
-    ix = 0;
+        oldnode = ctxt->xpathCtxt->node;
+        olddoc = ctxt->xpathCtxt->doc;
+        oldNsNr = ctxt->xpathCtxt->nsNr;
+        oldNamespaces = ctxt->xpathCtxt->namespaces;
+        oldContextSize = ctxt->xpathCtxt->contextSize;
+        oldProximityPosition = ctxt->xpathCtxt->proximityPosition;
+        ctxt->xpathCtxt->node = node;
+        ctxt->xpathCtxt->doc = doc;
+        ctxt->xpathCtxt->namespaces = nsList;
+        ctxt->xpathCtxt->nsNr = nsNr;
+        newlist = xmlXPathEval(comp->pattern, ctxt->xpathCtxt);
+        ctxt->xpathCtxt->node = oldnode;
+        ctxt->xpathCtxt->doc = olddoc;
+        ctxt->xpathCtxt->namespaces = oldNamespaces;
+        ctxt->xpathCtxt->nsNr = oldNsNr;
+        ctxt->xpathCtxt->contextSize = oldContextSize;
+        ctxt->xpathCtxt->proximityPosition = oldProximityPosition;
+        if (newlist == NULL)
+            return(-1);
+        if (newlist->type != XPATH_NODESET) {
+            xmlXPathFreeObject(newlist);
+            return(-1);
+        }
+        ix = 0;
 
-    if ((parent == NULL) || (node->doc == NULL) || isRVT)
-        nocache = 1;
+        if ((parent == NULL) || (node->doc == NULL) || isRVT)
+            nocache = 1;
 
-    if (nocache == 0) {
-        if (list != NULL)
-        xmlXPathFreeObject(list);
-        list = newlist;
+        if (nocache == 0) {
+            if (list != NULL)
+                xmlXPathFreeObject(list);
+            list = newlist;
 
-        XSLT_RUNTIME_EXTRA_LST(ctxt, sel->lenExtra) =
-        (void *) list;
-        XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr) =
-        (void *) doc;
-        XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival) =
-        0;
-        XSLT_RUNTIME_EXTRA_FREE(ctxt, sel->lenExtra) =
-        xmlXPathFreeObjectWrapper;
-    } else
-        list = newlist;
+            XSLT_RUNTIME_EXTRA_LST(ctxt, sel->lenExtra) =
+                (void *) list;
+            XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr) =
+                (void *) doc;
+            XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival) =
+                0;
+            XSLT_RUNTIME_EXTRA_FREE(ctxt, sel->lenExtra) =
+                xmlXPathFreeObjectWrapper;
+        } else
+            list = newlist;
     }
     if ((list->nodesetval == NULL) ||
-    (list->nodesetval->nodeNr <= 0)) {
-    if (nocache == 1)
-        xmlXPathFreeObject(list);
-    return(0);
+        (list->nodesetval->nodeNr <= 0)) {
+        if (nocache == 1)
+            xmlXPathFreeObject(list);
+        return(0);
     }
     /* TODO: store the index and use it for the scan */
     if (ix == 0) {
-    for (j = 0;j < list->nodesetval->nodeNr;j++) {
-        if (list->nodesetval->nodeTab[j] == node) {
-        if (nocache == 1)
-            xmlXPathFreeObject(list);
-        return(1);
+        for (j = 0;j < list->nodesetval->nodeNr;j++) {
+            if (list->nodesetval->nodeTab[j] == node) {
+                if (nocache == 1)
+                    xmlXPathFreeObject(list);
+                return(1);
+            }
         }
-    }
     } else {
     }
     if (nocache == 1)
-    xmlXPathFreeObject(list);
+        xmlXPathFreeObject(list);
     return(0);
+}
+
+/**
+ * xsltTestStepMatch:
+ * @ctxt:  a XSLT process context
+ * @node: a node
+ * @step:  the step
+ *
+ * Test whether the node matches the step.
+ *
+ * Returns 1 if it matches, 0 if it doesn't and -1 in case of failure
+ */
+static int
+xsltTestStepMatch(xsltTransformContextPtr ctxt, xmlNodePtr node,
+                  xsltStepOpPtr step) {
+    switch (step->op) {
+        case XSLT_OP_ROOT:
+            if ((node->type == XML_DOCUMENT_NODE) ||
+#ifdef LIBXML_DOCB_ENABLED
+                (node->type == XML_DOCB_DOCUMENT_NODE) ||
+#endif
+                (node->type == XML_HTML_DOCUMENT_NODE))
+                return(1);
+            if ((node->type == XML_ELEMENT_NODE) && (node->name[0] == ' '))
+                return(1);
+            return(0);
+        case XSLT_OP_ELEM:
+            if (node->type != XML_ELEMENT_NODE)
+                return(0);
+            if (step->value == NULL)
+                return(1);
+            if (step->value[0] != node->name[0])
+                return(0);
+            if (!xmlStrEqual(step->value, node->name))
+                return(0);
+
+            /* Namespace test */
+            if (node->ns == NULL) {
+                if (step->value2 != NULL)
+                    return(0);
+            } else if (node->ns->href != NULL) {
+                if (step->value2 == NULL)
+                    return(0);
+                if (!xmlStrEqual(step->value2, node->ns->href))
+                    return(0);
+            }
+            return(1);
+        case XSLT_OP_ATTR:
+            if (node->type != XML_ATTRIBUTE_NODE)
+                return(0);
+            if (step->value != NULL) {
+                if (step->value[0] != node->name[0])
+                    return(0);
+                if (!xmlStrEqual(step->value, node->name))
+                    return(0);
+            }
+            /* Namespace test */
+            if (node->ns == NULL) {
+                if (step->value2 != NULL)
+                    return(0);
+            } else if (step->value2 != NULL) {
+                if (!xmlStrEqual(step->value2, node->ns->href))
+                    return(0);
+            }
+            return(1);
+        case XSLT_OP_ID: {
+            /* TODO Handle IDs decently, must be done differently */
+            xmlAttrPtr id;
+
+            if (node->type != XML_ELEMENT_NODE)
+                return(0);
+
+            id = xmlGetID(node->doc, step->value);
+            if ((id == NULL) || (id->parent != node))
+                return(0);
+            break;
+        }
+        case XSLT_OP_KEY: {
+            xmlNodeSetPtr list;
+            int indx;
+
+            list = xsltGetKey(ctxt, step->value,
+                              step->value3, step->value2);
+            if (list == NULL)
+                return(0);
+            for (indx = 0;indx < list->nodeNr;indx++)
+                if (list->nodeTab[indx] == node)
+                    break;
+            if (indx >= list->nodeNr)
+                return(0);
+            break;
+        }
+        case XSLT_OP_NS:
+            if (node->type != XML_ELEMENT_NODE)
+                return(0);
+            if (node->ns == NULL) {
+                if (step->value != NULL)
+                    return(0);
+            } else if (node->ns->href != NULL) {
+                if (step->value == NULL)
+                    return(0);
+                if (!xmlStrEqual(step->value, node->ns->href))
+                    return(0);
+            }
+            break;
+        case XSLT_OP_ALL:
+            if (node->type != XML_ELEMENT_NODE)
+                return(0);
+            break;
+        case XSLT_OP_PI:
+            if (node->type != XML_PI_NODE)
+                return(0);
+            if (step->value != NULL) {
+                if (!xmlStrEqual(step->value, node->name))
+                    return(0);
+            }
+            break;
+        case XSLT_OP_COMMENT:
+            if (node->type != XML_COMMENT_NODE)
+                return(0);
+            break;
+        case XSLT_OP_TEXT:
+            if ((node->type != XML_TEXT_NODE) &&
+                (node->type != XML_CDATA_SECTION_NODE))
+                return(0);
+            break;
+        case XSLT_OP_NODE:
+            switch (node->type) {
+                case XML_ELEMENT_NODE:
+                case XML_CDATA_SECTION_NODE:
+                case XML_PI_NODE:
+                case XML_COMMENT_NODE:
+                case XML_TEXT_NODE:
+                    break;
+                default:
+                    return(0);
+            }
+            break;
+        default:
+            xsltTransformError(ctxt, NULL, node,
+                    "xsltTestStepMatch: unexpected step op %d\n",
+                    step->op);
+            return(-1);
+    }
+
+    return(1);
 }
 
 /**
@@ -656,6 +799,8 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
         return(0);
     if (step->comp == NULL)
         return(0);
+    if (sel == NULL)
+        return(0);
 
     doc = node->doc;
     if (XSLT_IS_RES_TREE_FRAG(doc))
@@ -666,16 +811,16 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
     /*
      * Recompute contextSize and proximityPosition.
      *
-     * TODO: Make this work for additional ops. Currently, only XSLT_OP_ELEM
-     * and XSLT_OP_ALL are supported.
+     * This could be improved in the following ways:
+     *
+     * - Skip recomputation if predicates don't use position() or last()
+     * - Keep data for multiple parents. This would require a hash table
+     *   or an unused member in xmlNode.
+     * - Store node test results in a bitmap to avoid computing them twice.
      */
     oldCS = ctxt->xpathCtxt->contextSize;
     oldCP = ctxt->xpathCtxt->proximityPosition;
-    if ((sel != NULL) &&
-        (sel->op == XSLT_OP_ELEM) &&
-        (sel->value != NULL) &&
-        (node->type == XML_ELEMENT_NODE) &&
-        (node->parent != NULL)) {
+    {
         xmlNodePtr previous;
         int nocache = 0;
 
@@ -692,17 +837,8 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
             while (sibling != NULL) {
                 if (sibling == previous)
                     break;
-                if ((sibling->type == XML_ELEMENT_NODE) &&
-                    (previous->name != NULL) &&
-                    (sibling->name != NULL) &&
-                    (previous->name[0] == sibling->name[0]) &&
-                    (xmlStrEqual(previous->name, sibling->name)))
-                {
-                    if ((sel->value2 == NULL) ||
-                        ((sibling->ns != NULL) &&
-                         (xmlStrEqual(sel->value2, sibling->ns->href))))
-                        indx++;
-                }
+                if (xsltTestStepMatch(ctxt, sibling, sel))
+                    indx++;
                 sibling = sibling->prev;
             }
             if (sibling == NULL) {
@@ -712,20 +848,8 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
                 while (sibling != NULL) {
                     if (sibling == previous)
                         break;
-                    if ((sibling->type == XML_ELEMENT_NODE) &&
-                        (previous->name != NULL) &&
-                        (sibling->name != NULL) &&
-                        (previous->name[0] == sibling->name[0]) &&
-                        (xmlStrEqual(previous->name, sibling->name)))
-                    {
-                        if ((sel->value2 == NULL) ||
-                            ((sibling->ns != NULL) &&
-                            (xmlStrEqual(sel->value2,
-                            sibling->ns->href))))
-                        {
-                            indx--;
-                        }
-                    }
+                    if (xsltTestStepMatch(ctxt, sibling, sel))
+                        indx--;
                     sibling = sibling->next;
                 }
             }
@@ -756,19 +880,11 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
             if (parent) siblings = parent->children;
 
             while (siblings != NULL) {
-                if (siblings->type == XML_ELEMENT_NODE) {
-                    if (siblings == node) {
-                        len++;
-                        pos = len;
-                    } else if ((node->name != NULL) &&
-                               (siblings->name != NULL) &&
-                        (node->name[0] == siblings->name[0]) &&
-                        (xmlStrEqual(node->name, siblings->name))) {
-                        if ((sel->value2 == NULL) ||
-                            ((siblings->ns != NULL) &&
-                             (xmlStrEqual(sel->value2, siblings->ns->href))))
-                            len++;
-                    }
+                if (siblings == node) {
+                    len++;
+                    pos = len;
+                } else if (xsltTestStepMatch(ctxt, siblings, sel)) {
+                    len++;
                 }
                 siblings = siblings->next;
             }
@@ -792,96 +908,6 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
              */
             if ((!isRVT) && (node->doc != NULL) &&
                 (nocache == 0)) {
-                XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr) = node;
-                XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival) = pos;
-                XSLT_RUNTIME_EXTRA(ctxt, sel->lenExtra, ival) = len;
-            }
-        }
-    } else if ((sel != NULL) && (sel->op == XSLT_OP_ALL) &&
-               (node->type == XML_ELEMENT_NODE)) {
-        xmlNodePtr previous;
-        int nocache = 0;
-
-        previous = (xmlNodePtr)
-            XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr);
-        if ((previous != NULL) &&
-            (previous->parent == node->parent)) {
-            /*
-             * just walk back to adjust the index
-             */
-            int indx = 0;
-            xmlNodePtr sibling = node;
-
-            while (sibling != NULL) {
-                if (sibling == previous)
-                    break;
-                if (sibling->type == XML_ELEMENT_NODE)
-                    indx++;
-                sibling = sibling->prev;
-            }
-            if (sibling == NULL) {
-                /* hum going backward in document order ... */
-                indx = 0;
-                sibling = node;
-                while (sibling != NULL) {
-                    if (sibling == previous)
-                        break;
-                    if (sibling->type == XML_ELEMENT_NODE)
-                        indx--;
-                    sibling = sibling->next;
-                }
-            }
-            if (sibling != NULL) {
-                pos = XSLT_RUNTIME_EXTRA(ctxt,
-                    sel->indexExtra, ival) + indx;
-                /*
-                 * If the node is in a Value Tree we cannot
-                 * cache it !
-                 */
-                if ((node->doc != NULL) && !isRVT) {
-                    len = XSLT_RUNTIME_EXTRA(ctxt, sel->lenExtra, ival);
-                    XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr) = node;
-                    XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival) = pos;
-                }
-            } else
-                pos = 0;
-        } else {
-            /*
-             * recompute the index
-             */
-            xmlNodePtr parent = node->parent;
-            xmlNodePtr siblings = NULL;
-
-            if (parent) siblings = parent->children;
-
-            while (siblings != NULL) {
-                if (siblings->type == XML_ELEMENT_NODE) {
-                    len++;
-                    if (siblings == node) {
-                        pos = len;
-                    }
-                }
-                siblings = siblings->next;
-            }
-            if ((parent == NULL) || (node->doc == NULL))
-                nocache = 1;
-            else {
-                while (parent->parent != NULL)
-                    parent = parent->parent;
-                if (((parent->type != XML_DOCUMENT_NODE) &&
-                     (parent->type != XML_HTML_DOCUMENT_NODE)) ||
-                     (parent != (xmlNodePtr) node->doc))
-                    nocache = 1;
-            }
-        }
-        if (pos != 0) {
-            ctxt->xpathCtxt->contextSize = len;
-            ctxt->xpathCtxt->proximityPosition = pos;
-            /*
-             * If the node is in a Value Tree we cannot
-             * cache it !
-             */
-            if ((node->doc != NULL) && (nocache == 0) && !isRVT) {
                 XSLT_RUNTIME_EXTRA(ctxt, sel->previousExtra, ptr) = node;
                 XSLT_RUNTIME_EXTRA(ctxt, sel->indexExtra, ival) = pos;
                 XSLT_RUNTIME_EXTRA(ctxt, sel->lenExtra, ival) = len;
@@ -917,8 +943,8 @@ xsltTestPredicateMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
  */
 static int
 xsltTestCompMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
-              xmlNodePtr matchNode, const xmlChar *mode,
-          const xmlChar *modeURI) {
+                  xmlNodePtr matchNode, const xmlChar *mode,
+                  const xmlChar *modeURI) {
     int i;
     int found = 0;
     xmlNodePtr node = matchNode;
@@ -927,33 +953,33 @@ xsltTestCompMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
     xsltStepStates states = {0, 0, NULL}; /* // may require backtrack */
 
     if ((comp == NULL) || (node == NULL) || (ctxt == NULL)) {
-    xsltTransformError(ctxt, NULL, node,
-        "xsltTestCompMatch: null arg\n");
+        xsltTransformError(ctxt, NULL, node,
+                "xsltTestCompMatch: null arg\n");
         return(-1);
     }
     if (mode != NULL) {
-    if (comp->mode == NULL)
-        return(0);
-    /*
-     * both mode strings must be interned on the stylesheet dictionary
-     */
-    if (comp->mode != mode)
-        return(0);
+        if (comp->mode == NULL)
+            return(0);
+        /*
+         * both mode strings must be interned on the stylesheet dictionary
+         */
+        if (comp->mode != mode)
+            return(0);
     } else {
-    if (comp->mode != NULL)
-        return(0);
+        if (comp->mode != NULL)
+            return(0);
     }
     if (modeURI != NULL) {
-    if (comp->modeURI == NULL)
-        return(0);
-    /*
-     * both modeURI strings must be interned on the stylesheet dictionary
-     */
-    if (comp->modeURI != modeURI)
-        return(0);
+        if (comp->modeURI == NULL)
+            return(0);
+        /*
+         * both modeURI strings must be interned on the stylesheet dictionary
+         */
+        if (comp->modeURI != modeURI)
+            return(0);
     } else {
-    if (comp->modeURI != NULL)
-        return(0);
+        if (comp->modeURI != NULL)
+            return(0);
     }
 
     /* Some XPath functions rely on inst being set correctly. */
@@ -963,235 +989,118 @@ xsltTestCompMatch(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp,
     i = 0;
 restart:
     for (;i < comp->nbStep;i++) {
-    step = &comp->steps[i];
-    if (step->op != XSLT_OP_PREDICATE)
-        sel = step;
-    switch (step->op) {
+        step = &comp->steps[i];
+        if (step->op != XSLT_OP_PREDICATE)
+            sel = step;
+        switch (step->op) {
             case XSLT_OP_END:
-        goto found;
-            case XSLT_OP_ROOT:
-        if ((node->type == XML_DOCUMENT_NODE) ||
-#ifdef LIBXML_DOCB_ENABLED
-            (node->type == XML_DOCB_DOCUMENT_NODE) ||
-#endif
-            (node->type == XML_HTML_DOCUMENT_NODE))
-            continue;
-        if ((node->type == XML_ELEMENT_NODE) && (node->name[0] == ' '))
-            continue;
-        goto rollback;
-            case XSLT_OP_ELEM:
-        if (node->type != XML_ELEMENT_NODE)
-            goto rollback;
-        if (step->value == NULL)
-            continue;
-        if (step->value[0] != node->name[0])
-            goto rollback;
-        if (!xmlStrEqual(step->value, node->name))
-            goto rollback;
-
-        /* Namespace test */
-        if (node->ns == NULL) {
-            if (step->value2 != NULL)
-            goto rollback;
-        } else if (node->ns->href != NULL) {
-            if (step->value2 == NULL)
-            goto rollback;
-            if (!xmlStrEqual(step->value2, node->ns->href))
-            goto rollback;
-        }
-        continue;
-            case XSLT_OP_ATTR:
-        if (node->type != XML_ATTRIBUTE_NODE)
-            goto rollback;
-        if (step->value != NULL) {
-            if (step->value[0] != node->name[0])
-            goto rollback;
-            if (!xmlStrEqual(step->value, node->name))
-            goto rollback;
-        }
-        /* Namespace test */
-        if (node->ns == NULL) {
-            if (step->value2 != NULL)
-            goto rollback;
-        } else if (step->value2 != NULL) {
-            if (!xmlStrEqual(step->value2, node->ns->href))
-            goto rollback;
-        }
-        continue;
+                goto found;
             case XSLT_OP_PARENT:
-        if ((node->type == XML_DOCUMENT_NODE) ||
-            (node->type == XML_HTML_DOCUMENT_NODE) ||
+                if ((node->type == XML_DOCUMENT_NODE) ||
+                    (node->type == XML_HTML_DOCUMENT_NODE) ||
 #ifdef LIBXML_DOCB_ENABLED
-            (node->type == XML_DOCB_DOCUMENT_NODE) ||
+                    (node->type == XML_DOCB_DOCUMENT_NODE) ||
 #endif
-            (node->type == XML_NAMESPACE_DECL))
-            goto rollback;
-        node = node->parent;
-        if (node == NULL)
-            goto rollback;
-        if (step->value == NULL)
-            continue;
-        if (step->value[0] != node->name[0])
-            goto rollback;
-        if (!xmlStrEqual(step->value, node->name))
-            goto rollback;
-        /* Namespace test */
-        if (node->ns == NULL) {
-            if (step->value2 != NULL)
-            goto rollback;
-        } else if (node->ns->href != NULL) {
-            if (step->value2 == NULL)
-            goto rollback;
-            if (!xmlStrEqual(step->value2, node->ns->href))
-            goto rollback;
-        }
-        continue;
+                    (node->type == XML_NAMESPACE_DECL))
+                    goto rollback;
+                node = node->parent;
+                if (node == NULL)
+                    goto rollback;
+                if (step->value == NULL)
+                    continue;
+                if (step->value[0] != node->name[0])
+                    goto rollback;
+                if (!xmlStrEqual(step->value, node->name))
+                    goto rollback;
+                /* Namespace test */
+                if (node->ns == NULL) {
+                    if (step->value2 != NULL)
+                        goto rollback;
+                } else if (node->ns->href != NULL) {
+                    if (step->value2 == NULL)
+                        goto rollback;
+                    if (!xmlStrEqual(step->value2, node->ns->href))
+                        goto rollback;
+                }
+                continue;
             case XSLT_OP_ANCESTOR:
-        /* TODO: implement coalescing of ANCESTOR/NODE ops */
-        if (step->value == NULL) {
-            step = &comp->steps[i+1];
-            if (step->op == XSLT_OP_ROOT)
-            goto found;
-            /* added NS, ID and KEY as a result of bug 168208 */
-            if ((step->op != XSLT_OP_ELEM) &&
-            (step->op != XSLT_OP_ALL) &&
-            (step->op != XSLT_OP_NS) &&
-            (step->op != XSLT_OP_ID) &&
-            (step->op != XSLT_OP_KEY))
-            goto rollback;
-        }
-        if (node == NULL)
-            goto rollback;
-        if ((node->type == XML_DOCUMENT_NODE) ||
-            (node->type == XML_HTML_DOCUMENT_NODE) ||
+                /* TODO: implement coalescing of ANCESTOR/NODE ops */
+                if (step->value == NULL) {
+                    step = &comp->steps[i+1];
+                    if (step->op == XSLT_OP_ROOT)
+                        goto found;
+                    /* added NS, ID and KEY as a result of bug 168208 */
+                    if ((step->op != XSLT_OP_ELEM) &&
+                        (step->op != XSLT_OP_ALL) &&
+                        (step->op != XSLT_OP_NS) &&
+                        (step->op != XSLT_OP_ID) &&
+                        (step->op != XSLT_OP_KEY))
+                        goto rollback;
+                }
+                if (node == NULL)
+                    goto rollback;
+                if ((node->type == XML_DOCUMENT_NODE) ||
+                    (node->type == XML_HTML_DOCUMENT_NODE) ||
 #ifdef LIBXML_DOCB_ENABLED
-            (node->type == XML_DOCB_DOCUMENT_NODE) ||
+                    (node->type == XML_DOCB_DOCUMENT_NODE) ||
 #endif
-            (node->type == XML_NAMESPACE_DECL))
-            goto rollback;
-        node = node->parent;
-        if ((step->op != XSLT_OP_ELEM) && step->op != XSLT_OP_ALL) {
-            xsltPatPushState(ctxt, &states, i, node);
-            continue;
-        }
-        i++;
-        if (step->value == NULL) {
-            xsltPatPushState(ctxt, &states, i - 1, node);
-            continue;
-        }
-        while (node != NULL) {
-            if ((node->type == XML_ELEMENT_NODE) &&
-            (step->value[0] == node->name[0]) &&
-            (xmlStrEqual(step->value, node->name))) {
-            /* Namespace test */
-            if (node->ns == NULL) {
-                if (step->value2 == NULL)
-                break;
-            } else if (node->ns->href != NULL) {
-                if ((step->value2 != NULL) &&
-                    (xmlStrEqual(step->value2, node->ns->href)))
-                break;
-            }
-            }
-            node = node->parent;
-        }
-        if (node == NULL)
-            goto rollback;
-        xsltPatPushState(ctxt, &states, i - 1, node);
-        continue;
-            case XSLT_OP_ID: {
-        /* TODO Handle IDs decently, must be done differently */
-        xmlAttrPtr id;
-
-        if (node->type != XML_ELEMENT_NODE)
-            goto rollback;
-
-        id = xmlGetID(node->doc, step->value);
-        if ((id == NULL) || (id->parent != node))
-            goto rollback;
-        break;
-        }
-            case XSLT_OP_KEY: {
-        xmlNodeSetPtr list;
-        int indx;
-
-        list = xsltGetKey(ctxt, step->value,
-                      step->value3, step->value2);
-        if (list == NULL)
-            goto rollback;
-        for (indx = 0;indx < list->nodeNr;indx++)
-            if (list->nodeTab[indx] == node)
-            break;
-        if (indx >= list->nodeNr)
-            goto rollback;
-        break;
-        }
-            case XSLT_OP_NS:
-        if (node->type != XML_ELEMENT_NODE)
-            goto rollback;
-        if (node->ns == NULL) {
-            if (step->value != NULL)
-            goto rollback;
-        } else if (node->ns->href != NULL) {
-            if (step->value == NULL)
-            goto rollback;
-            if (!xmlStrEqual(step->value, node->ns->href))
-            goto rollback;
-        }
-        break;
-            case XSLT_OP_ALL:
-        if (node->type != XML_ELEMENT_NODE)
-            goto rollback;
-        break;
-        case XSLT_OP_PREDICATE: {
-        /*
-         * When there is cascading XSLT_OP_PREDICATE or a predicate
-         * after an op which hasn't been optimized yet, then use a
-         * direct computation approach. It's not done directly
-         * at the beginning of the routine to filter out as much
-         * as possible this costly computation.
-         */
-        if (comp->direct) {
-            found = xsltTestCompMatchDirect(ctxt, comp, matchNode,
-                            comp->nsList, comp->nsNr);
+                    (node->type == XML_NAMESPACE_DECL))
+                    goto rollback;
+                node = node->parent;
+                if ((step->op != XSLT_OP_ELEM) && step->op != XSLT_OP_ALL) {
+                    xsltPatPushState(ctxt, &states, i, node);
+                    continue;
+                }
+                i++;
+                sel = step;
+                if (step->value == NULL) {
+                    xsltPatPushState(ctxt, &states, i - 1, node);
+                    continue;
+                }
+                while (node != NULL) {
+                    if ((node->type == XML_ELEMENT_NODE) &&
+                        (step->value[0] == node->name[0]) &&
+                        (xmlStrEqual(step->value, node->name))) {
+                        /* Namespace test */
+                        if (node->ns == NULL) {
+                            if (step->value2 == NULL)
+                                break;
+                        } else if (node->ns->href != NULL) {
+                            if ((step->value2 != NULL) &&
+                                (xmlStrEqual(step->value2, node->ns->href)))
+                                break;
+                        }
+                    }
+                    node = node->parent;
+                }
+                if (node == NULL)
+                    goto rollback;
+                xsltPatPushState(ctxt, &states, i - 1, node);
+                continue;
+            case XSLT_OP_PREDICATE: {
+                /*
+                 * When there is cascading XSLT_OP_PREDICATE or a predicate
+                 * after an op which hasn't been optimized yet, then use a
+                 * direct computation approach. It's not done directly
+                 * at the beginning of the routine to filter out as much
+                 * as possible this costly computation.
+                 */
+                if (comp->direct) {
+                    found = xsltTestCompMatchDirect(ctxt, comp, matchNode,
+                                                    comp->nsList, comp->nsNr);
                     goto exit;
-        }
+                }
 
-        if (!xsltTestPredicateMatch(ctxt, comp, node, step, sel))
-            goto rollback;
+                if (!xsltTestPredicateMatch(ctxt, comp, node, step, sel))
+                    goto rollback;
 
-        break;
-        }
-            case XSLT_OP_PI:
-        if (node->type != XML_PI_NODE)
-            goto rollback;
-        if (step->value != NULL) {
-            if (!xmlStrEqual(step->value, node->name))
-            goto rollback;
-        }
-        break;
-            case XSLT_OP_COMMENT:
-        if (node->type != XML_COMMENT_NODE)
-            goto rollback;
-        break;
-            case XSLT_OP_TEXT:
-        if ((node->type != XML_TEXT_NODE) &&
-            (node->type != XML_CDATA_SECTION_NODE))
-            goto rollback;
-        break;
-            case XSLT_OP_NODE:
-        switch (node->type) {
-            case XML_ELEMENT_NODE:
-            case XML_CDATA_SECTION_NODE:
-            case XML_PI_NODE:
-            case XML_COMMENT_NODE:
-            case XML_TEXT_NODE:
-            break;
+                break;
+            }
             default:
-            goto rollback;
+                if (xsltTestStepMatch(ctxt, node, step) != 1)
+                    goto rollback;
+                break;
         }
-        break;
-    }
     }
 found:
     found = 1;
@@ -1199,14 +1108,14 @@ exit:
     ctxt->inst = oldInst;
     if (states.states != NULL) {
         /* Free the rollback states */
-    xmlFree(states.states);
+        xmlFree(states.states);
     }
     return found;
 rollback:
     /* got an error try to rollback */
     if (states.states == NULL || states.nbstates <= 0) {
         found = 0;
-    goto exit;
+        goto exit;
     }
     states.nbstates--;
     i = states.states[states.nbstates].step;
@@ -1229,16 +1138,16 @@ rollback:
  */
 int
 xsltTestCompMatchList(xsltTransformContextPtr ctxt, xmlNodePtr node,
-                  xsltCompMatchPtr comp) {
+                      xsltCompMatchPtr comp) {
     int ret;
 
     if ((ctxt == NULL) || (node == NULL))
-    return(-1);
+        return(-1);
     while (comp != NULL) {
-    ret = xsltTestCompMatch(ctxt, comp, node, NULL, NULL);
-    if (ret == 1)
-        return(1);
-    comp = comp->next;
+        ret = xsltTestCompMatch(ctxt, comp, node, NULL, NULL);
+        if (ret == 1)
+            return(1);
+        comp = comp->next;
     }
     return(0);
 }
@@ -1272,9 +1181,9 @@ xsltCompMatchClearCache(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp) {
 }
 
 /************************************************************************
- *                                  *
- *          Dedicated parser for templates          *
- *                                  *
+ *                                                                      *
+ *                      Dedicated parser for templates                  *
+ *                                                                      *
  ************************************************************************/
 
 #define CUR (*ctxt->cur)
@@ -1282,25 +1191,25 @@ xsltCompMatchClearCache(xsltTransformContextPtr ctxt, xsltCompMatchPtr comp) {
 #define NXT(val) ctxt->cur[(val)]
 #define CUR_PTR ctxt->cur
 
-#define SKIP_BLANKS                         \
+#define SKIP_BLANKS                                                     \
     while (IS_BLANK_CH(CUR)) NEXT
 
 #define CURRENT (*ctxt->cur)
 #define NEXT ((*ctxt->cur) ?  ctxt->cur++: ctxt->cur)
 
 
-#define PUSH(op, val, val2, novar)                      \
+#define PUSH(op, val, val2, novar)                                              \
     if (xsltCompMatchAdd(ctxt, ctxt->comp, (op), (val), (val2), (novar))) goto error;
 
-#define SWAP()                      \
+#define SWAP()                                          \
     xsltSwapTopCompMatch(ctxt->comp);
 
-#define XSLT_ERROR(X)                           \
-    { xsltError(ctxt, __FILE__, __LINE__, X);           \
+#define XSLT_ERROR(X)                                                   \
+    { xsltError(ctxt, __FILE__, __LINE__, X);                   \
       ctxt->error = (X); return; }
 
-#define XSLT_ERROR0(X)                          \
-    { xsltError(ctxt, __FILE__, __LINE__, X);           \
+#define XSLT_ERROR0(X)                                                  \
+    { xsltError(ctxt, __FILE__, __LINE__, X);                   \
       ctxt->error = (X); return(0); }
 
 /**
@@ -1324,40 +1233,40 @@ xsltScanLiteral(xsltParserContextPtr ctxt) {
     SKIP_BLANKS;
     if (CUR == '"') {
         NEXT;
-    cur = q = CUR_PTR;
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    while ((IS_CHAR(val)) && (val != '"')) {
-        cur += len;
+        cur = q = CUR_PTR;
         val = xmlStringCurrentChar(NULL, cur, &len);
-    }
-    if (!IS_CHAR(val)) {
-        ctxt->error = 1;
-        return(NULL);
-    } else {
-        ret = xmlStrndup(q, cur - q);
+        while ((IS_CHAR(val)) && (val != '"')) {
+            cur += len;
+            val = xmlStringCurrentChar(NULL, cur, &len);
         }
-    cur += len;
-    CUR_PTR = cur;
+        if (!IS_CHAR(val)) {
+            ctxt->error = 1;
+            return(NULL);
+        } else {
+            ret = xmlStrndup(q, cur - q);
+        }
+        cur += len;
+        CUR_PTR = cur;
     } else if (CUR == '\'') {
         NEXT;
-    cur = q = CUR_PTR;
-    val = xmlStringCurrentChar(NULL, cur, &len);
-    while ((IS_CHAR(val)) && (val != '\'')) {
-        cur += len;
+        cur = q = CUR_PTR;
         val = xmlStringCurrentChar(NULL, cur, &len);
-    }
-    if (!IS_CHAR(val)) {
+        while ((IS_CHAR(val)) && (val != '\'')) {
+            cur += len;
+            val = xmlStringCurrentChar(NULL, cur, &len);
+        }
+        if (!IS_CHAR(val)) {
+            ctxt->error = 1;
+            return(NULL);
+        } else {
+            ret = xmlStrndup(q, cur - q);
+        }
+        cur += len;
+        CUR_PTR = cur;
+    } else {
+        /* XP_ERROR(XPATH_START_LITERAL_ERROR); */
         ctxt->error = 1;
         return(NULL);
-    } else {
-        ret = xmlStrndup(q, cur - q);
-        }
-    cur += len;
-    CUR_PTR = cur;
-    } else {
-    /* XP_ERROR(XPATH_START_LITERAL_ERROR); */
-    ctxt->error = 1;
-    return(NULL);
     }
     return(ret);
 }
@@ -1382,15 +1291,15 @@ xsltScanNCName(xsltParserContextPtr ctxt) {
     cur = q = CUR_PTR;
     val = xmlStringCurrentChar(NULL, cur, &len);
     if (!IS_LETTER(val) && (val != '_'))
-    return(NULL);
+        return(NULL);
 
     while ((IS_LETTER(val)) || (IS_DIGIT(val)) ||
            (val == '.') || (val == '-') ||
-       (val == '_') ||
-       (IS_COMBINING(val)) ||
-       (IS_EXTENDER(val))) {
-    cur += len;
-    val = xmlStringCurrentChar(NULL, cur, &len);
+           (val == '_') ||
+           (IS_COMBINING(val)) ||
+           (IS_EXTENDER(val))) {
+        cur += len;
+        val = xmlStringCurrentChar(NULL, cur, &len);
     }
     ret = xmlStrndup(q, cur - q);
     CUR_PTR = cur;
@@ -1416,158 +1325,161 @@ xsltScanNCName(xsltParserContextPtr ctxt) {
  */
 static void
 xsltCompileIdKeyPattern(xsltParserContextPtr ctxt, xmlChar *name,
-        int aid, int novar, xsltAxis axis) {
+                int aid, int novar, xsltAxis axis) {
     xmlChar *lit = NULL;
     xmlChar *lit2 = NULL;
 
     if (CUR != '(') {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltCompileIdKeyPattern : ( expected\n");
-    ctxt->error = 1;
-    return;
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltCompileIdKeyPattern : ( expected\n");
+        ctxt->error = 1;
+        return;
     }
     if ((aid) && (xmlStrEqual(name, (const xmlChar *)"id"))) {
-    if (axis != 0) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : NodeTest expected\n");
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    SKIP_BLANKS;
-        lit = xsltScanLiteral(ctxt);
-    if (ctxt->error) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : Literal expected\n");
-        return;
-    }
-    SKIP_BLANKS;
-    if (CUR != ')') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
-        xmlFree(lit);
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    PUSH(XSLT_OP_ID, lit, NULL, novar);
-    lit = NULL;
-    } else if ((aid) && (xmlStrEqual(name, (const xmlChar *)"key"))) {
-    if (axis != 0) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : NodeTest expected\n");
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    SKIP_BLANKS;
-        lit = xsltScanLiteral(ctxt);
-    if (ctxt->error) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : Literal expected\n");
-        return;
-    }
-    SKIP_BLANKS;
-    if (CUR != ',') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : , expected\n");
-        xmlFree(lit);
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    SKIP_BLANKS;
-        lit2 = xsltScanLiteral(ctxt);
-    if (ctxt->error) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : Literal expected\n");
-        xmlFree(lit);
-        return;
-    }
-    SKIP_BLANKS;
-    if (CUR != ')') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
-        xmlFree(lit);
-        xmlFree(lit2);
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    /* URGENT TODO: support namespace in keys */
-    PUSH(XSLT_OP_KEY, lit, lit2, novar);
-    lit = NULL;
-    lit2 = NULL;
-    } else if (xmlStrEqual(name, (const xmlChar *)"processing-instruction")) {
-    NEXT;
-    SKIP_BLANKS;
-    if (CUR != ')') {
+        if (axis != 0) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : NodeTest expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        SKIP_BLANKS;
         lit = xsltScanLiteral(ctxt);
         if (ctxt->error) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : Literal expected\n");
-        return;
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : Literal expected\n");
+            xmlFree(lit);
+            return;
         }
         SKIP_BLANKS;
         if (CUR != ')') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
-        ctxt->error = 1;
-                xmlFree(lit);
-        return;
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : ) expected\n");
+            xmlFree(lit);
+            ctxt->error = 1;
+            return;
         }
-    }
-    NEXT;
-    PUSH(XSLT_OP_PI, lit, NULL, novar);
-    lit = NULL;
+        NEXT;
+        PUSH(XSLT_OP_ID, lit, NULL, novar);
+        lit = NULL;
+    } else if ((aid) && (xmlStrEqual(name, (const xmlChar *)"key"))) {
+        if (axis != 0) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : NodeTest expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        SKIP_BLANKS;
+        lit = xsltScanLiteral(ctxt);
+        if (ctxt->error) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : Literal expected\n");
+            xmlFree(lit);
+            return;
+        }
+        SKIP_BLANKS;
+        if (CUR != ',') {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : , expected\n");
+            xmlFree(lit);
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        SKIP_BLANKS;
+        lit2 = xsltScanLiteral(ctxt);
+        if (ctxt->error) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : Literal expected\n");
+            xmlFree(lit);
+            return;
+        }
+        SKIP_BLANKS;
+        if (CUR != ')') {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : ) expected\n");
+            xmlFree(lit);
+            xmlFree(lit2);
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        /* URGENT TODO: support namespace in keys */
+        PUSH(XSLT_OP_KEY, lit, lit2, novar);
+        lit = NULL;
+        lit2 = NULL;
+    } else if (xmlStrEqual(name, (const xmlChar *)"processing-instruction")) {
+        NEXT;
+        SKIP_BLANKS;
+        if (CUR != ')') {
+            lit = xsltScanLiteral(ctxt);
+            if (ctxt->error) {
+                xsltTransformError(NULL, NULL, NULL,
+                        "xsltCompileIdKeyPattern : Literal expected\n");
+                xmlFree(lit);
+                return;
+            }
+            SKIP_BLANKS;
+            if (CUR != ')') {
+                xsltTransformError(NULL, NULL, NULL,
+                        "xsltCompileIdKeyPattern : ) expected\n");
+                ctxt->error = 1;
+                xmlFree(lit);
+                return;
+            }
+        }
+        NEXT;
+        PUSH(XSLT_OP_PI, lit, NULL, novar);
+        lit = NULL;
     } else if (xmlStrEqual(name, (const xmlChar *)"text")) {
-    NEXT;
-    SKIP_BLANKS;
-    if (CUR != ')') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    PUSH(XSLT_OP_TEXT, NULL, NULL, novar);
+        NEXT;
+        SKIP_BLANKS;
+        if (CUR != ')') {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : ) expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        PUSH(XSLT_OP_TEXT, NULL, NULL, novar);
     } else if (xmlStrEqual(name, (const xmlChar *)"comment")) {
-    NEXT;
-    SKIP_BLANKS;
-    if (CUR != ')') {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
-        ctxt->error = 1;
-        return;
-    }
-    NEXT;
-    PUSH(XSLT_OP_COMMENT, NULL, NULL, novar);
+        NEXT;
+        SKIP_BLANKS;
+        if (CUR != ')') {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : ) expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        PUSH(XSLT_OP_COMMENT, NULL, NULL, novar);
     } else if (xmlStrEqual(name, (const xmlChar *)"node")) {
-    NEXT;
-    SKIP_BLANKS;
-    if (CUR != ')') {
+        NEXT;
+        SKIP_BLANKS;
+        if (CUR != ')') {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileIdKeyPattern : ) expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        NEXT;
+        if (axis == AXIS_ATTRIBUTE) {
+            PUSH(XSLT_OP_ATTR, NULL, NULL, novar);
+        }
+        else {
+            PUSH(XSLT_OP_NODE, NULL, NULL, novar);
+        }
+    } else if (aid) {
         xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileIdKeyPattern : ) expected\n");
+            "xsltCompileIdKeyPattern : expecting 'key' or 'id' or node type\n");
         ctxt->error = 1;
         return;
-    }
-    NEXT;
-    if (axis == AXIS_ATTRIBUTE) {
-        PUSH(XSLT_OP_ATTR, NULL, NULL, novar);
-    }
-    else {
-        PUSH(XSLT_OP_NODE, NULL, NULL, novar);
-    }
-    } else if (aid) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltCompileIdKeyPattern : expecting 'key' or 'id' or node type\n");
-    ctxt->error = 1;
-    return;
     } else {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltCompileIdKeyPattern : node type\n");
-    ctxt->error = 1;
-    return;
+        xsltTransformError(NULL, NULL, NULL,
+            "xsltCompileIdKeyPattern : node type\n");
+        ctxt->error = 1;
+        return;
     }
 error:
     return;
@@ -1605,184 +1517,184 @@ xsltCompileStepPattern(xsltParserContextPtr ctxt, xmlChar *token, int novar) {
 
     SKIP_BLANKS;
     if ((token == NULL) && (CUR == '@')) {
-    NEXT;
+        NEXT;
         axis = AXIS_ATTRIBUTE;
     }
 parse_node_test:
     if (token == NULL)
-    token = xsltScanNCName(ctxt);
+        token = xsltScanNCName(ctxt);
     if (token == NULL) {
-    if (CUR == '*') {
-        NEXT;
-        if (axis == AXIS_ATTRIBUTE) {
+        if (CUR == '*') {
+            NEXT;
+            if (axis == AXIS_ATTRIBUTE) {
                 PUSH(XSLT_OP_ATTR, NULL, NULL, novar);
             }
             else {
                 PUSH(XSLT_OP_ALL, NULL, NULL, novar);
             }
-        goto parse_predicate;
-    } else {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileStepPattern : Name expected\n");
-        ctxt->error = 1;
-        goto error;
-    }
+            goto parse_predicate;
+        } else {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileStepPattern : Name expected\n");
+            ctxt->error = 1;
+            goto error;
+        }
     }
 
 
     SKIP_BLANKS;
     if (CUR == '(') {
-    xsltCompileIdKeyPattern(ctxt, token, 0, novar, axis);
-    xmlFree(token);
-    token = NULL;
-    if (ctxt->error)
-        goto error;
+        xsltCompileIdKeyPattern(ctxt, token, 0, novar, axis);
+        xmlFree(token);
+        token = NULL;
+        if (ctxt->error)
+            goto error;
     } else if (CUR == ':') {
-    NEXT;
-    if (CUR != ':') {
-        xmlChar *prefix = token;
-        xmlNsPtr ns;
+        NEXT;
+        if (CUR != ':') {
+            xmlChar *prefix = token;
+            xmlNsPtr ns;
 
-        /*
-         * This is a namespace match
-         */
-        token = xsltScanNCName(ctxt);
-        ns = xmlSearchNs(ctxt->doc, ctxt->elem, prefix);
-        if (ns == NULL) {
-        xsltTransformError(NULL, NULL, NULL,
-        "xsltCompileStepPattern : no namespace bound to prefix %s\n",
-                 prefix);
-        xmlFree(prefix);
-        prefix=NULL;
-        ctxt->error = 1;
-        goto error;
-        } else {
-        URL = xmlStrdup(ns->href);
-        }
-        xmlFree(prefix);
-        prefix=NULL;
-        if (token == NULL) {
-        if (CUR == '*') {
-            NEXT;
+            /*
+             * This is a namespace match
+             */
+            token = xsltScanNCName(ctxt);
+            ns = xmlSearchNs(ctxt->doc, ctxt->elem, prefix);
+            if (ns == NULL) {
+                xsltTransformError(NULL, NULL, NULL,
+            "xsltCompileStepPattern : no namespace bound to prefix %s\n",
+                                 prefix);
+                xmlFree(prefix);
+                prefix=NULL;
+                ctxt->error = 1;
+                goto error;
+            } else {
+                URL = xmlStrdup(ns->href);
+            }
+            xmlFree(prefix);
+            prefix=NULL;
+            if (token == NULL) {
+                if (CUR == '*') {
+                    NEXT;
                     if (axis == AXIS_ATTRIBUTE) {
                         PUSH(XSLT_OP_ATTR, NULL, URL, novar);
-            URL = NULL;
+                        URL = NULL;
                     }
                     else {
                         PUSH(XSLT_OP_NS, URL, NULL, novar);
-            URL = NULL;
+                        URL = NULL;
                     }
-        } else {
-            xsltTransformError(NULL, NULL, NULL,
-                "xsltCompileStepPattern : Name expected\n");
-            ctxt->error = 1;
+                } else {
+                    xsltTransformError(NULL, NULL, NULL,
+                            "xsltCompileStepPattern : Name expected\n");
+                    ctxt->error = 1;
                     xmlFree(URL);
-            goto error;
-        }
-        } else {
+                    goto error;
+                }
+            } else {
                 if (axis == AXIS_ATTRIBUTE) {
                     PUSH(XSLT_OP_ATTR, token, URL, novar);
-            token = NULL;
-            URL = NULL;
+                    token = NULL;
+                    URL = NULL;
                 }
                 else {
                     PUSH(XSLT_OP_ELEM, token, URL, novar);
-            token = NULL;
-            URL = NULL;
+                    token = NULL;
+                    URL = NULL;
                 }
-        }
-    } else {
-        if (axis != 0) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileStepPattern : NodeTest expected\n");
-        ctxt->error = 1;
-        goto error;
-        }
-        NEXT;
-        if (xmlStrEqual(token, (const xmlChar *) "child")) {
-            axis = AXIS_CHILD;
-        } else if (xmlStrEqual(token, (const xmlChar *) "attribute")) {
-            axis = AXIS_ATTRIBUTE;
+            }
         } else {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileStepPattern : 'child' or 'attribute' expected\n");
-        ctxt->error = 1;
-        goto error;
-        }
-        xmlFree(token);
-        token = NULL;
+            if (axis != 0) {
+                xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileStepPattern : NodeTest expected\n");
+                ctxt->error = 1;
+                goto error;
+            }
+            NEXT;
+            if (xmlStrEqual(token, (const xmlChar *) "child")) {
+                axis = AXIS_CHILD;
+            } else if (xmlStrEqual(token, (const xmlChar *) "attribute")) {
+                axis = AXIS_ATTRIBUTE;
+            } else {
+                xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileStepPattern : 'child' or 'attribute' expected\n");
+                ctxt->error = 1;
+                goto error;
+            }
+            xmlFree(token);
+            token = NULL;
             SKIP_BLANKS;
             token = xsltScanNCName(ctxt);
-        goto parse_node_test;
-    }
+            goto parse_node_test;
+        }
     } else {
-    URI = xsltGetQNameURI(ctxt->elem, &token);
-    if (token == NULL) {
-        ctxt->error = 1;
-        goto error;
-    }
-    if (URI != NULL)
-        URL = xmlStrdup(URI);
+        URI = xsltGetQNameURI(ctxt->elem, &token);
+        if (token == NULL) {
+            ctxt->error = 1;
+            goto error;
+        }
+        if (URI != NULL)
+            URL = xmlStrdup(URI);
         if (axis == AXIS_ATTRIBUTE) {
             PUSH(XSLT_OP_ATTR, token, URL, novar);
-        token = NULL;
-        URL = NULL;
+            token = NULL;
+            URL = NULL;
         }
         else {
             PUSH(XSLT_OP_ELEM, token, URL, novar);
-        token = NULL;
-        URL = NULL;
+            token = NULL;
+            URL = NULL;
         }
     }
 parse_predicate:
     SKIP_BLANKS;
     level = 0;
     while (CUR == '[') {
-    const xmlChar *q;
-    xmlChar *ret = NULL;
+        const xmlChar *q;
+        xmlChar *ret = NULL;
 
-    level++;
-    NEXT;
-    q = CUR_PTR;
-    while (CUR != 0) {
-        /* Skip over nested predicates */
-        if (CUR == '[')
         level++;
-        else if (CUR == ']') {
-        level--;
-        if (level == 0)
-            break;
-        } else if (CUR == '"') {
         NEXT;
-        while ((CUR != 0) && (CUR != '"'))
-            NEXT;
-        } else if (CUR == '\'') {
-        NEXT;
-        while ((CUR != 0) && (CUR != '\''))
+        q = CUR_PTR;
+        while (CUR != 0) {
+            /* Skip over nested predicates */
+            if (CUR == '[')
+                level++;
+            else if (CUR == ']') {
+                level--;
+                if (level == 0)
+                    break;
+            } else if (CUR == '"') {
+                NEXT;
+                while ((CUR != 0) && (CUR != '"'))
+                    NEXT;
+            } else if (CUR == '\'') {
+                NEXT;
+                while ((CUR != 0) && (CUR != '\''))
+                    NEXT;
+            }
             NEXT;
         }
-        NEXT;
-    }
-    if (CUR == 0) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileStepPattern : ']' expected\n");
-        ctxt->error = 1;
-        return;
+        if (CUR == 0) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileStepPattern : ']' expected\n");
+            ctxt->error = 1;
+            return;
         }
-    ret = xmlStrndup(q, CUR_PTR - q);
-    PUSH(XSLT_OP_PREDICATE, ret, NULL, novar);
-    ret = NULL;
-    /* push the predicate lower than local test */
-    SWAP();
-    NEXT;
-    SKIP_BLANKS;
+        ret = xmlStrndup(q, CUR_PTR - q);
+        PUSH(XSLT_OP_PREDICATE, ret, NULL, novar);
+        ret = NULL;
+        /* push the predicate lower than local test */
+        SWAP();
+        NEXT;
+        SKIP_BLANKS;
     }
     return;
 error:
     if (token != NULL)
-    xmlFree(token);
+        xmlFree(token);
     if (name != NULL)
-    xmlFree(name);
+        xmlFree(name);
 }
 
 /**
@@ -1802,26 +1714,26 @@ static void
 xsltCompileRelativePathPattern(xsltParserContextPtr ctxt, xmlChar *token, int novar) {
     xsltCompileStepPattern(ctxt, token, novar);
     if (ctxt->error)
-    goto error;
-    SKIP_BLANKS;
-    while ((CUR != 0) && (CUR != '|')) {
-    if ((CUR == '/') && (NXT(1) == '/')) {
-        PUSH(XSLT_OP_ANCESTOR, NULL, NULL, novar);
-        NEXT;
-        NEXT;
-        SKIP_BLANKS;
-        xsltCompileStepPattern(ctxt, NULL, novar);
-    } else if (CUR == '/') {
-        PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
-        NEXT;
-        SKIP_BLANKS;
-        xsltCompileStepPattern(ctxt, NULL, novar);
-    } else {
-        ctxt->error = 1;
-    }
-    if (ctxt->error)
         goto error;
     SKIP_BLANKS;
+    while ((CUR != 0) && (CUR != '|')) {
+        if ((CUR == '/') && (NXT(1) == '/')) {
+            PUSH(XSLT_OP_ANCESTOR, NULL, NULL, novar);
+            NEXT;
+            NEXT;
+            SKIP_BLANKS;
+            xsltCompileStepPattern(ctxt, NULL, novar);
+        } else if (CUR == '/') {
+            PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
+            NEXT;
+            SKIP_BLANKS;
+            xsltCompileStepPattern(ctxt, NULL, novar);
+        } else {
+            ctxt->error = 1;
+        }
+        if (ctxt->error)
+            goto error;
+        SKIP_BLANKS;
     }
 error:
     return;
@@ -1843,60 +1755,60 @@ static void
 xsltCompileLocationPathPattern(xsltParserContextPtr ctxt, int novar) {
     SKIP_BLANKS;
     if ((CUR == '/') && (NXT(1) == '/')) {
-    /*
-     * since we reverse the query
-     * a leading // can be safely ignored
-     */
-    NEXT;
-    NEXT;
-    ctxt->comp->priority = 0.5; /* '//' means not 0 priority */
-    xsltCompileRelativePathPattern(ctxt, NULL, novar);
-    } else if (CUR == '/') {
-    /*
-     * We need to find root as the parent
-     */
-    NEXT;
-    SKIP_BLANKS;
-    PUSH(XSLT_OP_ROOT, NULL, NULL, novar);
-    if ((CUR != 0) && (CUR != '|')) {
-        PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
+        /*
+         * since we reverse the query
+         * a leading // can be safely ignored
+         */
+        NEXT;
+        NEXT;
+        ctxt->comp->priority = 0.5;     /* '//' means not 0 priority */
         xsltCompileRelativePathPattern(ctxt, NULL, novar);
-    }
+    } else if (CUR == '/') {
+        /*
+         * We need to find root as the parent
+         */
+        NEXT;
+        SKIP_BLANKS;
+        PUSH(XSLT_OP_ROOT, NULL, NULL, novar);
+        if ((CUR != 0) && (CUR != '|')) {
+            PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
+            xsltCompileRelativePathPattern(ctxt, NULL, novar);
+        }
     } else if (CUR == '*') {
-    xsltCompileRelativePathPattern(ctxt, NULL, novar);
+        xsltCompileRelativePathPattern(ctxt, NULL, novar);
     } else if (CUR == '@') {
-    xsltCompileRelativePathPattern(ctxt, NULL, novar);
+        xsltCompileRelativePathPattern(ctxt, NULL, novar);
     } else {
-    xmlChar *name;
-    name = xsltScanNCName(ctxt);
-    if (name == NULL) {
-        xsltTransformError(NULL, NULL, NULL,
-            "xsltCompileLocationPathPattern : Name expected\n");
-        ctxt->error = 1;
-        return;
-    }
-    SKIP_BLANKS;
-    if ((CUR == '(') && !xmlXPathIsNodeType(name)) {
-        xsltCompileIdKeyPattern(ctxt, name, 1, novar, 0);
-        xmlFree(name);
-        name = NULL;
+        xmlChar *name;
+        name = xsltScanNCName(ctxt);
+        if (name == NULL) {
+            xsltTransformError(NULL, NULL, NULL,
+                    "xsltCompileLocationPathPattern : Name expected\n");
+            ctxt->error = 1;
+            return;
+        }
+        SKIP_BLANKS;
+        if ((CUR == '(') && !xmlXPathIsNodeType(name)) {
+            xsltCompileIdKeyPattern(ctxt, name, 1, novar, 0);
+            xmlFree(name);
+            name = NULL;
             if (ctxt->error)
                 return;
-        if ((CUR == '/') && (NXT(1) == '/')) {
-        PUSH(XSLT_OP_ANCESTOR, NULL, NULL, novar);
-        NEXT;
-        NEXT;
-        SKIP_BLANKS;
-        xsltCompileRelativePathPattern(ctxt, NULL, novar);
-        } else if (CUR == '/') {
-        PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
-        NEXT;
-        SKIP_BLANKS;
-        xsltCompileRelativePathPattern(ctxt, NULL, novar);
+            if ((CUR == '/') && (NXT(1) == '/')) {
+                PUSH(XSLT_OP_ANCESTOR, NULL, NULL, novar);
+                NEXT;
+                NEXT;
+                SKIP_BLANKS;
+                xsltCompileRelativePathPattern(ctxt, NULL, novar);
+            } else if (CUR == '/') {
+                PUSH(XSLT_OP_PARENT, NULL, NULL, novar);
+                NEXT;
+                SKIP_BLANKS;
+                xsltCompileRelativePathPattern(ctxt, NULL, novar);
+            }
+            return;
         }
-        return;
-    }
-    xsltCompileRelativePathPattern(ctxt, name, novar);
+        xsltCompileRelativePathPattern(ctxt, name, novar);
     }
 error:
     return;
@@ -1921,151 +1833,151 @@ error:
 
 static xsltCompMatchPtr
 xsltCompilePatternInternal(const xmlChar *pattern, xmlDocPtr doc,
-               xmlNodePtr node, xsltStylesheetPtr style,
-           xsltTransformContextPtr runtime, int novar) {
+                   xmlNodePtr node, xsltStylesheetPtr style,
+                   xsltTransformContextPtr runtime, int novar) {
     xsltParserContextPtr ctxt = NULL;
     xsltCompMatchPtr element, first = NULL, previous = NULL;
     int current, start, end, level, j;
 
     if (pattern == NULL) {
-    xsltTransformError(NULL, NULL, node,
-             "xsltCompilePattern : NULL pattern\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, node,
+                         "xsltCompilePattern : NULL pattern\n");
+        return(NULL);
     }
 
     ctxt = xsltNewParserContext(style, runtime);
     if (ctxt == NULL)
-    return(NULL);
+        return(NULL);
     ctxt->doc = doc;
     ctxt->elem = node;
     current = end = 0;
     while (pattern[current] != 0) {
-    start = current;
-    while (IS_BLANK_CH(pattern[current]))
-        current++;
-    end = current;
-    level = 0;
-    while ((pattern[end] != 0) && ((pattern[end] != '|') || (level != 0))) {
-        if (pattern[end] == '[')
-        level++;
-        else if (pattern[end] == ']')
-        level--;
-        else if (pattern[end] == '\'') {
-        end++;
-        while ((pattern[end] != 0) && (pattern[end] != '\''))
-            end++;
-        } else if (pattern[end] == '"') {
-        end++;
-        while ((pattern[end] != 0) && (pattern[end] != '"'))
+        start = current;
+        while (IS_BLANK_CH(pattern[current]))
+            current++;
+        end = current;
+        level = 0;
+        while ((pattern[end] != 0) && ((pattern[end] != '|') || (level != 0))) {
+            if (pattern[end] == '[')
+                level++;
+            else if (pattern[end] == ']')
+                level--;
+            else if (pattern[end] == '\'') {
+                end++;
+                while ((pattern[end] != 0) && (pattern[end] != '\''))
+                    end++;
+            } else if (pattern[end] == '"') {
+                end++;
+                while ((pattern[end] != 0) && (pattern[end] != '"'))
+                    end++;
+            }
+            if (pattern[end] == 0)
+                break;
             end++;
         }
-        if (pattern[end] == 0)
-            break;
-        end++;
-    }
-    if (current == end) {
-        xsltTransformError(NULL, NULL, node,
-                 "xsltCompilePattern : NULL pattern\n");
-        goto error;
-    }
-    element = xsltNewCompMatch();
-    if (element == NULL) {
-        goto error;
-    }
-    if (first == NULL)
-        first = element;
-    else if (previous != NULL)
-        previous->next = element;
-    previous = element;
+        if (current == end) {
+            xsltTransformError(NULL, NULL, node,
+                             "xsltCompilePattern : NULL pattern\n");
+            goto error;
+        }
+        element = xsltNewCompMatch();
+        if (element == NULL) {
+            goto error;
+        }
+        if (first == NULL)
+            first = element;
+        else if (previous != NULL)
+            previous->next = element;
+        previous = element;
 
-    ctxt->comp = element;
-    ctxt->base = xmlStrndup(&pattern[start], end - start);
-    if (ctxt->base == NULL)
-        goto error;
-    ctxt->cur = &(ctxt->base)[current - start];
-    element->pattern = ctxt->base;
+        ctxt->comp = element;
+        ctxt->base = xmlStrndup(&pattern[start], end - start);
+        if (ctxt->base == NULL)
+            goto error;
+        ctxt->cur = &(ctxt->base)[current - start];
+        element->pattern = ctxt->base;
         element->node = node;
-    element->nsList = xmlGetNsList(doc, node);
-    j = 0;
-    if (element->nsList != NULL) {
-        while (element->nsList[j] != NULL)
-        j++;
-    }
-    element->nsNr = j;
-
-
-#ifdef WITH_XSLT_DEBUG_PATTERN
-    xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCompilePattern : parsing '%s'\n",
-             element->pattern);
-#endif
-    /*
-     Preset default priority to be zero.
-     This may be changed by xsltCompileLocationPathPattern.
-     */
-    element->priority = 0;
-    xsltCompileLocationPathPattern(ctxt, novar);
-    if (ctxt->error) {
-        xsltTransformError(NULL, style, node,
-                 "xsltCompilePattern : failed to compile '%s'\n",
-                 element->pattern);
-        if (style != NULL) style->errors++;
-        goto error;
-    }
-
-    /*
-     * Reverse for faster interpretation.
-     */
-    xsltReverseCompMatch(ctxt, element);
-
-    /*
-     * Set-up the priority
-     */
-    if (element->priority == 0) {   /* if not yet determined */
-        if (((element->steps[0].op == XSLT_OP_ELEM) ||
-         (element->steps[0].op == XSLT_OP_ATTR) ||
-         (element->steps[0].op == XSLT_OP_PI)) &&
-        (element->steps[0].value != NULL) &&
-        (element->steps[1].op == XSLT_OP_END)) {
-        ;   /* previously preset */
-        } else if ((element->steps[0].op == XSLT_OP_ATTR) &&
-               (element->steps[0].value2 != NULL) &&
-               (element->steps[1].op == XSLT_OP_END)) {
-            element->priority = -0.25;
-        } else if ((element->steps[0].op == XSLT_OP_NS) &&
-               (element->steps[0].value != NULL) &&
-               (element->steps[1].op == XSLT_OP_END)) {
-            element->priority = -0.25;
-        } else if ((element->steps[0].op == XSLT_OP_ATTR) &&
-               (element->steps[0].value == NULL) &&
-               (element->steps[0].value2 == NULL) &&
-               (element->steps[1].op == XSLT_OP_END)) {
-            element->priority = -0.5;
-        } else if (((element->steps[0].op == XSLT_OP_PI) ||
-               (element->steps[0].op == XSLT_OP_TEXT) ||
-               (element->steps[0].op == XSLT_OP_ALL) ||
-               (element->steps[0].op == XSLT_OP_NODE) ||
-               (element->steps[0].op == XSLT_OP_COMMENT)) &&
-               (element->steps[1].op == XSLT_OP_END)) {
-            element->priority = -0.5;
-        } else {
-        element->priority = 0.5;
+        element->nsList = xmlGetNsList(doc, node);
+        j = 0;
+        if (element->nsList != NULL) {
+            while (element->nsList[j] != NULL)
+                j++;
         }
-    }
+        element->nsNr = j;
+
+
 #ifdef WITH_XSLT_DEBUG_PATTERN
-    xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCompilePattern : parsed %s, default priority %f\n",
-             element->pattern, element->priority);
+        xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltCompilePattern : parsing '%s'\n",
+                         element->pattern);
 #endif
-    if (pattern[end] == '|')
-        end++;
-    current = end;
+        /*
+         Preset default priority to be zero.
+         This may be changed by xsltCompileLocationPathPattern.
+         */
+        element->priority = 0;
+        xsltCompileLocationPathPattern(ctxt, novar);
+        if (ctxt->error) {
+            xsltTransformError(NULL, style, node,
+                             "xsltCompilePattern : failed to compile '%s'\n",
+                             element->pattern);
+            if (style != NULL) style->errors++;
+            goto error;
+        }
+
+        /*
+         * Reverse for faster interpretation.
+         */
+        xsltReverseCompMatch(ctxt, element);
+
+        /*
+         * Set-up the priority
+         */
+        if (element->priority == 0) {   /* if not yet determined */
+            if (((element->steps[0].op == XSLT_OP_ELEM) ||
+                 (element->steps[0].op == XSLT_OP_ATTR) ||
+                 (element->steps[0].op == XSLT_OP_PI)) &&
+                (element->steps[0].value != NULL) &&
+                (element->steps[1].op == XSLT_OP_END)) {
+                ;       /* previously preset */
+            } else if ((element->steps[0].op == XSLT_OP_ATTR) &&
+                       (element->steps[0].value2 != NULL) &&
+                       (element->steps[1].op == XSLT_OP_END)) {
+                        element->priority = -0.25;
+            } else if ((element->steps[0].op == XSLT_OP_NS) &&
+                       (element->steps[0].value != NULL) &&
+                       (element->steps[1].op == XSLT_OP_END)) {
+                        element->priority = -0.25;
+            } else if ((element->steps[0].op == XSLT_OP_ATTR) &&
+                       (element->steps[0].value == NULL) &&
+                       (element->steps[0].value2 == NULL) &&
+                       (element->steps[1].op == XSLT_OP_END)) {
+                        element->priority = -0.5;
+            } else if (((element->steps[0].op == XSLT_OP_PI) ||
+                       (element->steps[0].op == XSLT_OP_TEXT) ||
+                       (element->steps[0].op == XSLT_OP_ALL) ||
+                       (element->steps[0].op == XSLT_OP_NODE) ||
+                       (element->steps[0].op == XSLT_OP_COMMENT)) &&
+                       (element->steps[1].op == XSLT_OP_END)) {
+                        element->priority = -0.5;
+            } else {
+                element->priority = 0.5;
+            }
+        }
+#ifdef WITH_XSLT_DEBUG_PATTERN
+        xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltCompilePattern : parsed %s, default priority %f\n",
+                         element->pattern, element->priority);
+#endif
+        if (pattern[end] == '|')
+            end++;
+        current = end;
     }
     if (end == 0) {
-    xsltTransformError(NULL, style, node,
-             "xsltCompilePattern : NULL pattern\n");
-    if (style != NULL) style->errors++;
-    goto error;
+        xsltTransformError(NULL, style, node,
+                         "xsltCompilePattern : NULL pattern\n");
+        if (style != NULL) style->errors++;
+        goto error;
     }
 
     xsltFreeParserContext(ctxt);
@@ -2073,9 +1985,9 @@ xsltCompilePatternInternal(const xmlChar *pattern, xmlDocPtr doc,
 
 error:
     if (ctxt != NULL)
-    xsltFreeParserContext(ctxt);
+        xsltFreeParserContext(ctxt);
     if (first != NULL)
-    xsltFreeCompMatchList(first);
+        xsltFreeCompMatchList(first);
     return(NULL);
 }
 
@@ -2097,15 +2009,15 @@ error:
 
 xsltCompMatchPtr
 xsltCompilePattern(const xmlChar *pattern, xmlDocPtr doc,
-               xmlNodePtr node, xsltStylesheetPtr style,
-           xsltTransformContextPtr runtime) {
+                   xmlNodePtr node, xsltStylesheetPtr style,
+                   xsltTransformContextPtr runtime) {
     return (xsltCompilePatternInternal(pattern, doc, node, style, runtime, 0));
 }
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -2121,18 +2033,21 @@ xsltCompilePattern(const xmlChar *pattern, xmlDocPtr doc,
  */
 int
 xsltAddTemplate(xsltStylesheetPtr style, xsltTemplatePtr cur,
-            const xmlChar *mode, const xmlChar *modeURI) {
+                const xmlChar *mode, const xmlChar *modeURI) {
     xsltCompMatchPtr pat, list, next;
     /*
      * 'top' will point to style->xxxMatch ptr - declaring as 'void'
      *  avoids gcc 'type-punned pointer' warning.
      */
-    void **top = NULL;
+    xsltCompMatchPtr *top = NULL;
     const xmlChar *name = NULL;
     float priority;              /* the priority */
 
     if ((style == NULL) || (cur == NULL))
-    return(-1);
+        return(-1);
+
+    if (cur->next != NULL)
+        cur->position = cur->next->position + 1;
 
     /* Register named template */
     if (cur->name != NULL) {
@@ -2163,153 +2078,153 @@ xsltAddTemplate(xsltStylesheetPtr style, xsltTemplatePtr cur,
                 style->errors++;
                 return(-1);
             }
-    return(0);
+        return(0);
     }
 
     priority = cur->priority;
     pat = xsltCompilePatternInternal(cur->match, style->doc, cur->elem,
-            style, NULL, 1);
+                    style, NULL, 1);
     if (pat == NULL)
-    return(-1);
+        return(-1);
     while (pat) {
-    next = pat->next;
-    pat->next = NULL;
-    name = NULL;
+        next = pat->next;
+        pat->next = NULL;
+        name = NULL;
 
-    pat->template = cur;
-    if (mode != NULL)
-        pat->mode = xmlDictLookup(style->dict, mode, -1);
-    if (modeURI != NULL)
-        pat->modeURI = xmlDictLookup(style->dict, modeURI, -1);
-    if (priority != XSLT_PAT_NO_PRIORITY)
-        pat->priority = priority;
+        pat->template = cur;
+        if (mode != NULL)
+            pat->mode = xmlDictLookup(style->dict, mode, -1);
+        if (modeURI != NULL)
+            pat->modeURI = xmlDictLookup(style->dict, modeURI, -1);
+        if (priority != XSLT_PAT_NO_PRIORITY)
+            pat->priority = priority;
 
-    /*
-     * insert it in the hash table list corresponding to its lookup name
-     */
-    switch (pat->steps[0].op) {
+        /*
+         * insert it in the hash table list corresponding to its lookup name
+         */
+        switch (pat->steps[0].op) {
         case XSLT_OP_ATTR:
-        if (pat->steps[0].value != NULL)
-        name = pat->steps[0].value;
-        else
-        top = &(style->attrMatch);
-        break;
+            if (pat->steps[0].value != NULL)
+                name = pat->steps[0].value;
+            else
+                top = &(style->attrMatch);
+            break;
         case XSLT_OP_PARENT:
         case XSLT_OP_ANCESTOR:
-        top = &(style->elemMatch);
-        break;
+            top = &(style->elemMatch);
+            break;
         case XSLT_OP_ROOT:
-        top = &(style->rootMatch);
-        break;
+            top = &(style->rootMatch);
+            break;
         case XSLT_OP_KEY:
-        top = &(style->keyMatch);
-        break;
+            top = &(style->keyMatch);
+            break;
         case XSLT_OP_ID:
-        /* TODO optimize ID !!! */
+            /* TODO optimize ID !!! */
         case XSLT_OP_NS:
         case XSLT_OP_ALL:
-        top = &(style->elemMatch);
-        break;
+            top = &(style->elemMatch);
+            break;
         case XSLT_OP_END:
-    case XSLT_OP_PREDICATE:
-        xsltTransformError(NULL, style, NULL,
-                 "xsltAddTemplate: invalid compiled pattern\n");
-        xsltFreeCompMatch(pat);
-        return(-1);
-        /*
-         * TODO: some flags at the top level about type based patterns
-         *       would be faster than inclusion in the hash table.
-         */
-    case XSLT_OP_PI:
-        if (pat->steps[0].value != NULL)
-        name = pat->steps[0].value;
-        else
-        top = &(style->piMatch);
-        break;
-    case XSLT_OP_COMMENT:
-        top = &(style->commentMatch);
-        break;
-    case XSLT_OP_TEXT:
-        top = &(style->textMatch);
-        break;
+        case XSLT_OP_PREDICATE:
+            xsltTransformError(NULL, style, NULL,
+                             "xsltAddTemplate: invalid compiled pattern\n");
+            xsltFreeCompMatch(pat);
+            return(-1);
+            /*
+             * TODO: some flags at the top level about type based patterns
+             *       would be faster than inclusion in the hash table.
+             */
+        case XSLT_OP_PI:
+            if (pat->steps[0].value != NULL)
+                name = pat->steps[0].value;
+            else
+                top = &(style->piMatch);
+            break;
+        case XSLT_OP_COMMENT:
+            top = &(style->commentMatch);
+            break;
+        case XSLT_OP_TEXT:
+            top = &(style->textMatch);
+            break;
         case XSLT_OP_ELEM:
-    case XSLT_OP_NODE:
-        if (pat->steps[0].value != NULL)
-        name = pat->steps[0].value;
-        else
-        top = &(style->elemMatch);
-        break;
-    }
-    if (name != NULL) {
-        if (style->templatesHash == NULL) {
-        style->templatesHash = xmlHashCreate(1024);
-        if (style->templatesHash == NULL) {
+        case XSLT_OP_NODE:
+            if (pat->steps[0].value != NULL)
+                name = pat->steps[0].value;
+            else
+                top = &(style->elemMatch);
+            break;
+        }
+        if (name != NULL) {
+            if (style->templatesHash == NULL) {
+                style->templatesHash = xmlHashCreate(1024);
+                if (style->templatesHash == NULL) {
+                    xsltFreeCompMatch(pat);
+                    return(-1);
+                }
+                xmlHashAddEntry3(style->templatesHash, name, mode, modeURI, pat);
+            } else {
+                list = (xsltCompMatchPtr) xmlHashLookup3(style->templatesHash,
+                                                         name, mode, modeURI);
+                if (list == NULL) {
+                    xmlHashAddEntry3(style->templatesHash, name,
+                                     mode, modeURI, pat);
+                } else {
+                    /*
+                     * Note '<=' since one must choose among the matching
+                     * template rules that are left, the one that occurs
+                     * last in the stylesheet
+                     */
+                    if (list->priority <= pat->priority) {
+                        pat->next = list;
+                        xmlHashUpdateEntry3(style->templatesHash, name,
+                                            mode, modeURI, pat, NULL);
+                    } else {
+                        while (list->next != NULL) {
+                            if (list->next->priority <= pat->priority)
+                                break;
+                            list = list->next;
+                        }
+                        pat->next = list->next;
+                        list->next = pat;
+                    }
+                }
+            }
+        } else if (top != NULL) {
+            list = *top;
+            if (list == NULL) {
+                *top = pat;
+                pat->next = NULL;
+            } else if (list->priority <= pat->priority) {
+                pat->next = list;
+                *top = pat;
+            } else {
+                while (list->next != NULL) {
+                    if (list->next->priority <= pat->priority)
+                        break;
+                    list = list->next;
+                }
+                pat->next = list->next;
+                list->next = pat;
+            }
+        } else {
+            xsltTransformError(NULL, style, NULL,
+                             "xsltAddTemplate: invalid compiled pattern\n");
             xsltFreeCompMatch(pat);
             return(-1);
         }
-        xmlHashAddEntry3(style->templatesHash, name, mode, modeURI, pat);
-        } else {
-        list = (xsltCompMatchPtr) xmlHashLookup3(style->templatesHash,
-                             name, mode, modeURI);
-        if (list == NULL) {
-            xmlHashAddEntry3(style->templatesHash, name,
-                     mode, modeURI, pat);
-        } else {
-            /*
-             * Note '<=' since one must choose among the matching
-             * template rules that are left, the one that occurs
-             * last in the stylesheet
-             */
-            if (list->priority <= pat->priority) {
-            pat->next = list;
-            xmlHashUpdateEntry3(style->templatesHash, name,
-                        mode, modeURI, pat, NULL);
-            } else {
-            while (list->next != NULL) {
-                if (list->next->priority <= pat->priority)
-                break;
-                list = list->next;
-            }
-            pat->next = list->next;
-            list->next = pat;
-            }
-        }
-        }
-    } else if (top != NULL) {
-        list = *top;
-        if (list == NULL) {
-        *top = pat;
-        pat->next = NULL;
-        } else if (list->priority <= pat->priority) {
-        pat->next = list;
-        *top = pat;
-        } else {
-        while (list->next != NULL) {
-            if (list->next->priority <= pat->priority)
-            break;
-            list = list->next;
-        }
-        pat->next = list->next;
-        list->next = pat;
-        }
-    } else {
-        xsltTransformError(NULL, style, NULL,
-                 "xsltAddTemplate: invalid compiled pattern\n");
-        xsltFreeCompMatch(pat);
-        return(-1);
-    }
 #ifdef WITH_XSLT_DEBUG_PATTERN
-    if (mode)
-        xsltGenericDebug(xsltGenericDebugContext,
-             "added pattern : '%s' mode '%s' priority %f\n",
-                 pat->pattern, pat->mode, pat->priority);
-    else
-        xsltGenericDebug(xsltGenericDebugContext,
-             "added pattern : '%s' priority %f\n",
-                 pat->pattern, pat->priority);
+        if (mode)
+            xsltGenericDebug(xsltGenericDebugContext,
+                         "added pattern : '%s' mode '%s' priority %f\n",
+                             pat->pattern, pat->mode, pat->priority);
+        else
+            xsltGenericDebug(xsltGenericDebugContext,
+                         "added pattern : '%s' priority %f\n",
+                             pat->pattern, pat->priority);
 #endif
 
-    pat = next;
+        pat = next;
     }
     return(0);
 }
@@ -2318,32 +2233,32 @@ static int
 xsltComputeAllKeys(xsltTransformContextPtr ctxt, xmlNodePtr contextNode)
 {
     if ((ctxt == NULL) || (contextNode == NULL)) {
-    xsltTransformError(ctxt, NULL, ctxt->inst,
-        "Internal error in xsltComputeAllKeys(): "
-        "Bad arguments.\n");
-    return(-1);
+        xsltTransformError(ctxt, NULL, ctxt->inst,
+            "Internal error in xsltComputeAllKeys(): "
+            "Bad arguments.\n");
+        return(-1);
     }
 
     if (ctxt->document == NULL) {
-    /*
-    * The document info will only be NULL if we have a RTF.
-    */
-    if (contextNode->doc->_private != NULL)
-        goto doc_info_mismatch;
-    /*
-    * On-demand creation of the document info (needed for keys).
-    */
-    ctxt->document = xsltNewDocument(ctxt, contextNode->doc);
-    if (ctxt->document == NULL)
-        return(-1);
+        /*
+        * The document info will only be NULL if we have a RTF.
+        */
+        if (contextNode->doc->_private != NULL)
+            goto doc_info_mismatch;
+        /*
+        * On-demand creation of the document info (needed for keys).
+        */
+        ctxt->document = xsltNewDocument(ctxt, contextNode->doc);
+        if (ctxt->document == NULL)
+            return(-1);
     }
     return xsltInitAllDocKeys(ctxt);
 
 doc_info_mismatch:
     xsltTransformError(ctxt, NULL, ctxt->inst,
-    "Internal error in xsltComputeAllKeys(): "
-    "The context's document info doesn't match the "
-    "document info of the current result tree.\n");
+        "Internal error in xsltComputeAllKeys(): "
+        "The context's document info doesn't match the "
+        "document info of the current result tree.\n");
     ctxt->state = XSLT_STATE_STOPPED;
     return(-1);
 }
@@ -2361,7 +2276,7 @@ doc_info_mismatch:
  */
 xsltTemplatePtr
 xsltGetTemplate(xsltTransformContextPtr ctxt, xmlNodePtr node,
-            xsltStylesheetPtr style)
+                xsltStylesheetPtr style)
 {
     xsltStylesheetPtr curstyle;
     xsltTemplatePtr ret = NULL;
@@ -2371,227 +2286,239 @@ xsltGetTemplate(xsltTransformContextPtr ctxt, xmlNodePtr node,
     int keyed = 0;
 
     if ((ctxt == NULL) || (node == NULL))
-    return(NULL);
+        return(NULL);
 
     if (style == NULL) {
-    curstyle = ctxt->style;
+        curstyle = ctxt->style;
     } else {
-    curstyle = xsltNextImport(style);
+        curstyle = xsltNextImport(style);
     }
 
     while ((curstyle != NULL) && (curstyle != style)) {
-    priority = XSLT_PAT_NO_PRIORITY;
-    /* TODO : handle IDs/keys here ! */
-    if (curstyle->templatesHash != NULL) {
+        priority = XSLT_PAT_NO_PRIORITY;
+        /* TODO : handle IDs/keys here ! */
+        if (curstyle->templatesHash != NULL) {
+            /*
+             * Use the top name as selector
+             */
+            switch (node->type) {
+                case XML_ELEMENT_NODE:
+                    if (node->name[0] == ' ')
+                        break;
+                    /* Intentional fall-through */
+                case XML_ATTRIBUTE_NODE:
+                case XML_PI_NODE:
+                    name = node->name;
+                    break;
+                case XML_DOCUMENT_NODE:
+                case XML_HTML_DOCUMENT_NODE:
+                case XML_TEXT_NODE:
+                case XML_CDATA_SECTION_NODE:
+                case XML_COMMENT_NODE:
+                case XML_ENTITY_REF_NODE:
+                case XML_ENTITY_NODE:
+                case XML_DOCUMENT_TYPE_NODE:
+                case XML_DOCUMENT_FRAG_NODE:
+                case XML_NOTATION_NODE:
+                case XML_DTD_NODE:
+                case XML_ELEMENT_DECL:
+                case XML_ATTRIBUTE_DECL:
+                case XML_ENTITY_DECL:
+                case XML_NAMESPACE_DECL:
+                case XML_XINCLUDE_START:
+                case XML_XINCLUDE_END:
+                    break;
+                default:
+                    return(NULL);
+
+            }
+        }
+        if (name != NULL) {
+            /*
+             * find the list of applicable expressions based on the name
+             */
+            list = (xsltCompMatchPtr) xmlHashLookup3(curstyle->templatesHash,
+                                             name, ctxt->mode, ctxt->modeURI);
+        } else
+            list = NULL;
+        while (list != NULL) {
+            if (xsltTestCompMatch(ctxt, list, node,
+                                  ctxt->mode, ctxt->modeURI) == 1) {
+                ret = list->template;
+                priority = list->priority;
+                break;
+            }
+            list = list->next;
+        }
+        list = NULL;
+
         /*
-         * Use the top name as selector
+         * find alternate generic matches
          */
         switch (node->type) {
-        case XML_ELEMENT_NODE:
-            if (node->name[0] == ' ')
-            break;
-                    /* Intentional fall-through */
-        case XML_ATTRIBUTE_NODE:
-        case XML_PI_NODE:
-            name = node->name;
-            break;
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        case XML_COMMENT_NODE:
-        case XML_ENTITY_REF_NODE:
-        case XML_ENTITY_NODE:
-        case XML_DOCUMENT_TYPE_NODE:
-        case XML_DOCUMENT_FRAG_NODE:
-        case XML_NOTATION_NODE:
-        case XML_DTD_NODE:
-        case XML_ELEMENT_DECL:
-        case XML_ATTRIBUTE_DECL:
-        case XML_ENTITY_DECL:
-        case XML_NAMESPACE_DECL:
-        case XML_XINCLUDE_START:
-        case XML_XINCLUDE_END:
-            break;
-        default:
-            return(NULL);
+            case XML_ELEMENT_NODE:
+                if (node->name[0] == ' ')
+                    list = curstyle->rootMatch;
+                else
+                    list = curstyle->elemMatch;
+                if (node->psvi != NULL) keyed = 1;
+                break;
+            case XML_ATTRIBUTE_NODE: {
+                xmlAttrPtr attr;
 
+                list = curstyle->attrMatch;
+                attr = (xmlAttrPtr) node;
+                if (attr->psvi != NULL) keyed = 1;
+                break;
+            }
+            case XML_PI_NODE:
+                list = curstyle->piMatch;
+                if (node->psvi != NULL) keyed = 1;
+                break;
+            case XML_DOCUMENT_NODE:
+            case XML_HTML_DOCUMENT_NODE: {
+                xmlDocPtr doc;
+
+                list = curstyle->rootMatch;
+                doc = (xmlDocPtr) node;
+                if (doc->psvi != NULL) keyed = 1;
+                break;
+            }
+            case XML_TEXT_NODE:
+            case XML_CDATA_SECTION_NODE:
+                list = curstyle->textMatch;
+                if (node->psvi != NULL) keyed = 1;
+                break;
+            case XML_COMMENT_NODE:
+                list = curstyle->commentMatch;
+                if (node->psvi != NULL) keyed = 1;
+                break;
+            case XML_ENTITY_REF_NODE:
+            case XML_ENTITY_NODE:
+            case XML_DOCUMENT_TYPE_NODE:
+            case XML_DOCUMENT_FRAG_NODE:
+            case XML_NOTATION_NODE:
+            case XML_DTD_NODE:
+            case XML_ELEMENT_DECL:
+            case XML_ATTRIBUTE_DECL:
+            case XML_ENTITY_DECL:
+            case XML_NAMESPACE_DECL:
+            case XML_XINCLUDE_START:
+            case XML_XINCLUDE_END:
+                break;
+            default:
+                break;
         }
-    }
-    if (name != NULL) {
+        while ((list != NULL) &&
+               ((ret == NULL) ||
+                (list->priority > priority) ||
+                ((list->priority == priority) &&
+                 (list->template->position > ret->position)))) {
+            if (xsltTestCompMatch(ctxt, list, node,
+                                  ctxt->mode, ctxt->modeURI) == 1) {
+                ret = list->template;
+                priority = list->priority;
+                break;
+            }
+            list = list->next;
+        }
         /*
-         * find the list of applicable expressions based on the name
+         * Some of the tests for elements can also apply to documents
          */
-        list = (xsltCompMatchPtr) xmlHashLookup3(curstyle->templatesHash,
-                         name, ctxt->mode, ctxt->modeURI);
-    } else
-        list = NULL;
-    while (list != NULL) {
-        if (xsltTestCompMatch(ctxt, list, node,
-                      ctxt->mode, ctxt->modeURI) == 1) {
-        ret = list->template;
-        priority = list->priority;
-        break;
-        }
-        list = list->next;
-    }
-    list = NULL;
-
-    /*
-     * find alternate generic matches
-     */
-    switch (node->type) {
-        case XML_ELEMENT_NODE:
-        if (node->name[0] == ' ')
-            list = curstyle->rootMatch;
-        else
+        if ((node->type == XML_DOCUMENT_NODE) ||
+            (node->type == XML_HTML_DOCUMENT_NODE) ||
+            (node->type == XML_TEXT_NODE)) {
             list = curstyle->elemMatch;
-        if (node->psvi != NULL) keyed = 1;
-        break;
-        case XML_ATTRIBUTE_NODE: {
-            xmlAttrPtr attr;
-
-        list = curstyle->attrMatch;
-        attr = (xmlAttrPtr) node;
-        if (attr->psvi != NULL) keyed = 1;
-        break;
+            while ((list != NULL) &&
+                   ((ret == NULL) ||
+                    (list->priority > priority) ||
+                    ((list->priority == priority) &&
+                     (list->template->position > ret->position)))) {
+                if (xsltTestCompMatch(ctxt, list, node,
+                                      ctxt->mode, ctxt->modeURI) == 1) {
+                    ret = list->template;
+                    priority = list->priority;
+                    break;
+                }
+                list = list->next;
+            }
+        } else if ((node->type == XML_PI_NODE) ||
+                   (node->type == XML_COMMENT_NODE)) {
+            list = curstyle->elemMatch;
+            while ((list != NULL) &&
+                   ((ret == NULL) ||
+                    (list->priority > priority) ||
+                    ((list->priority == priority) &&
+                     (list->template->position > ret->position)))) {
+                if (xsltTestCompMatch(ctxt, list, node,
+                                      ctxt->mode, ctxt->modeURI) == 1) {
+                    ret = list->template;
+                    priority = list->priority;
+                    break;
+                }
+                list = list->next;
+            }
         }
-        case XML_PI_NODE:
-        list = curstyle->piMatch;
-        if (node->psvi != NULL) keyed = 1;
-        break;
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE: {
-            xmlDocPtr doc;
-
-        list = curstyle->rootMatch;
-        doc = (xmlDocPtr) node;
-        if (doc->psvi != NULL) keyed = 1;
-        break;
-        }
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        list = curstyle->textMatch;
-        if (node->psvi != NULL) keyed = 1;
-        break;
-        case XML_COMMENT_NODE:
-        list = curstyle->commentMatch;
-        if (node->psvi != NULL) keyed = 1;
-        break;
-        case XML_ENTITY_REF_NODE:
-        case XML_ENTITY_NODE:
-        case XML_DOCUMENT_TYPE_NODE:
-        case XML_DOCUMENT_FRAG_NODE:
-        case XML_NOTATION_NODE:
-        case XML_DTD_NODE:
-        case XML_ELEMENT_DECL:
-        case XML_ATTRIBUTE_DECL:
-        case XML_ENTITY_DECL:
-        case XML_NAMESPACE_DECL:
-        case XML_XINCLUDE_START:
-        case XML_XINCLUDE_END:
-        break;
-        default:
-        break;
-    }
-    while ((list != NULL) &&
-           ((ret == NULL)  || (list->priority > priority))) {
-        if (xsltTestCompMatch(ctxt, list, node,
-                      ctxt->mode, ctxt->modeURI) == 1) {
-        ret = list->template;
-        priority = list->priority;
-        break;
-        }
-        list = list->next;
-    }
-    /*
-     * Some of the tests for elements can also apply to documents
-     */
-    if ((node->type == XML_DOCUMENT_NODE) ||
-        (node->type == XML_HTML_DOCUMENT_NODE) ||
-        (node->type == XML_TEXT_NODE)) {
-        list = curstyle->elemMatch;
-        while ((list != NULL) &&
-           ((ret == NULL)  || (list->priority > priority))) {
-        if (xsltTestCompMatch(ctxt, list, node,
-                      ctxt->mode, ctxt->modeURI) == 1) {
-            ret = list->template;
-            priority = list->priority;
-            break;
-        }
-        list = list->next;
-        }
-    } else if ((node->type == XML_PI_NODE) ||
-           (node->type == XML_COMMENT_NODE)) {
-        list = curstyle->elemMatch;
-        while ((list != NULL) &&
-           ((ret == NULL)  || (list->priority > priority))) {
-        if (xsltTestCompMatch(ctxt, list, node,
-                      ctxt->mode, ctxt->modeURI) == 1) {
-            ret = list->template;
-            priority = list->priority;
-            break;
-        }
-        list = list->next;
-        }
-    }
 
 keyed_match:
-    if (keyed) {
-        list = curstyle->keyMatch;
-        while ((list != NULL) &&
-           ((ret == NULL)  || (list->priority > priority))) {
-        if (xsltTestCompMatch(ctxt, list, node,
-                      ctxt->mode, ctxt->modeURI) == 1) {
-            ret = list->template;
-            priority = list->priority;
-            break;
+        if (keyed) {
+            list = curstyle->keyMatch;
+            while ((list != NULL) &&
+                   ((ret == NULL) ||
+                    (list->priority > priority) ||
+                    ((list->priority == priority) &&
+                     (list->template->position > ret->position)))) {
+                if (xsltTestCompMatch(ctxt, list, node,
+                                      ctxt->mode, ctxt->modeURI) == 1) {
+                    ret = list->template;
+                    priority = list->priority;
+                    break;
+                }
+                list = list->next;
+            }
         }
-        list = list->next;
+        else if (ctxt->hasTemplKeyPatterns &&
+            ((ctxt->document == NULL) ||
+             (ctxt->document->nbKeysComputed < ctxt->nbKeys)))
+        {
+            /*
+            * Compute all remaining keys for this document.
+            *
+            * REVISIT TODO: I think this could be further optimized.
+            */
+            if (xsltComputeAllKeys(ctxt, node) == -1)
+                goto error;
+
+            switch (node->type) {
+                case XML_ELEMENT_NODE:
+                    if (node->psvi != NULL) keyed = 1;
+                    break;
+                case XML_ATTRIBUTE_NODE:
+                    if (((xmlAttrPtr) node)->psvi != NULL) keyed = 1;
+                    break;
+                case XML_TEXT_NODE:
+                case XML_CDATA_SECTION_NODE:
+                case XML_COMMENT_NODE:
+                case XML_PI_NODE:
+                    if (node->psvi != NULL) keyed = 1;
+                    break;
+                case XML_DOCUMENT_NODE:
+                case XML_HTML_DOCUMENT_NODE:
+                    if (((xmlDocPtr) node)->psvi != NULL) keyed = 1;
+                    break;
+                default:
+                    break;
+            }
+            if (keyed)
+                goto keyed_match;
         }
-    }
-    else if (ctxt->hasTemplKeyPatterns &&
-        ((ctxt->document == NULL) ||
-         (ctxt->document->nbKeysComputed < ctxt->nbKeys)))
-    {
+        if (ret != NULL)
+            return(ret);
+
         /*
-        * Compute all remaining keys for this document.
-        *
-        * REVISIT TODO: I think this could be further optimized.
-        */
-        if (xsltComputeAllKeys(ctxt, node) == -1)
-        goto error;
-
-        switch (node->type) {
-        case XML_ELEMENT_NODE:
-            if (node->psvi != NULL) keyed = 1;
-            break;
-        case XML_ATTRIBUTE_NODE:
-            if (((xmlAttrPtr) node)->psvi != NULL) keyed = 1;
-            break;
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        case XML_COMMENT_NODE:
-        case XML_PI_NODE:
-            if (node->psvi != NULL) keyed = 1;
-            break;
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-            if (((xmlDocPtr) node)->psvi != NULL) keyed = 1;
-            break;
-        default:
-            break;
-        }
-        if (keyed)
-        goto keyed_match;
-    }
-    if (ret != NULL)
-        return(ret);
-
-    /*
-     * Cycle on next curstylesheet import.
-     */
-    curstyle = xsltNextImport(curstyle);
+         * Cycle on next curstylesheet import.
+         */
+        curstyle = xsltNextImport(curstyle);
     }
 
 error:
@@ -2618,8 +2545,7 @@ xsltCleanupTemplates(xsltStylesheetPtr style ATTRIBUTE_UNUSED) {
 void
 xsltFreeTemplateHashes(xsltStylesheetPtr style) {
     if (style->templatesHash != NULL)
-    xmlHashFree((xmlHashTablePtr) style->templatesHash,
-            xsltFreeCompMatchListEntry);
+        xmlHashFree(style->templatesHash, xsltFreeCompMatchListEntry);
     if (style->rootMatch != NULL)
         xsltFreeCompMatchList(style->rootMatch);
     if (style->keyMatch != NULL)

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/pattern.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/pattern.h
@@ -33,48 +33,48 @@ typedef xsltCompMatch *xsltCompMatchPtr;
  */
 
 XSLTPUBFUN xsltCompMatchPtr XSLTCALL
-        xsltCompilePattern  (const xmlChar *pattern,
-                     xmlDocPtr doc,
-                     xmlNodePtr node,
-                     xsltStylesheetPtr style,
-                     xsltTransformContextPtr runtime);
+                xsltCompilePattern      (const xmlChar *pattern,
+                                         xmlDocPtr doc,
+                                         xmlNodePtr node,
+                                         xsltStylesheetPtr style,
+                                         xsltTransformContextPtr runtime);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeCompMatchList   (xsltCompMatchPtr comp);
+                xsltFreeCompMatchList   (xsltCompMatchPtr comp);
 XSLTPUBFUN int XSLTCALL
-        xsltTestCompMatchList   (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xsltCompMatchPtr comp);
+                xsltTestCompMatchList   (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xsltCompMatchPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltCompMatchClearCache (xsltTransformContextPtr ctxt,
-                     xsltCompMatchPtr comp);
+                xsltCompMatchClearCache (xsltTransformContextPtr ctxt,
+                                         xsltCompMatchPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltNormalizeCompSteps  (void *payload,
-                     void *data,
-                     const xmlChar *name);
+                xsltNormalizeCompSteps  (void *payload,
+                                         void *data,
+                                         const xmlChar *name);
 
 /*
  * Template related interfaces.
  */
 XSLTPUBFUN int XSLTCALL
-        xsltAddTemplate     (xsltStylesheetPtr style,
-                     xsltTemplatePtr cur,
-                     const xmlChar *mode,
-                     const xmlChar *modeURI);
+                xsltAddTemplate         (xsltStylesheetPtr style,
+                                         xsltTemplatePtr cur,
+                                         const xmlChar *mode,
+                                         const xmlChar *modeURI);
 XSLTPUBFUN xsltTemplatePtr XSLTCALL
-        xsltGetTemplate     (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xsltStylesheetPtr style);
+                xsltGetTemplate         (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xsltStylesheetPtr style);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeTemplateHashes  (xsltStylesheetPtr style);
+                xsltFreeTemplateHashes  (xsltStylesheetPtr style);
 XSLTPUBFUN void XSLTCALL
-        xsltCleanupTemplates    (xsltStylesheetPtr style);
+                xsltCleanupTemplates    (xsltStylesheetPtr style);
 
 #if 0
-int     xsltMatchPattern    (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     const xmlChar *pattern,
-                     xmlDocPtr ctxtdoc,
-                     xmlNodePtr ctxtnode);
+int             xsltMatchPattern        (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         const xmlChar *pattern,
+                                         xmlDocPtr ctxtdoc,
+                                         xmlNodePtr ctxtnode);
 #endif
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/preproc.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/preproc.c
@@ -48,9 +48,9 @@
 const xmlChar *xsltExtMarker = (const xmlChar *) "Extension Element";
 
 /************************************************************************
- *                                  *
- *          Grammar checks                  *
- *                                  *
+ *                                                                      *
+ *                      Grammar checks                                  *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef XSLT_REFACTORED
@@ -77,24 +77,24 @@ xsltCheckTopLevelElement(xsltStylesheetPtr style, xmlNodePtr inst, int err) {
     parent = inst->parent;
     if (parent == NULL) {
         if (err) {
-        xsltTransformError(NULL, style, inst,
-            "internal problem: element has no parent\n");
-        style->errors++;
-    }
-    return(0);
+            xsltTransformError(NULL, style, inst,
+                    "internal problem: element has no parent\n");
+            style->errors++;
+        }
+        return(0);
     }
     if ((parent->ns == NULL) || (parent->type != XML_ELEMENT_NODE) ||
         ((parent->ns != inst->ns) &&
-     (!xmlStrEqual(parent->ns->href, inst->ns->href))) ||
-    ((!xmlStrEqual(parent->name, BAD_CAST "stylesheet")) &&
-     (!xmlStrEqual(parent->name, BAD_CAST "transform")))) {
-    if (err) {
-        xsltTransformError(NULL, style, inst,
-            "element %s only allowed as child of stylesheet\n",
-                   inst->name);
-        style->errors++;
-    }
-    return(0);
+         (!xmlStrEqual(parent->ns->href, inst->ns->href))) ||
+        ((!xmlStrEqual(parent->name, BAD_CAST "stylesheet")) &&
+         (!xmlStrEqual(parent->name, BAD_CAST "transform")))) {
+        if (err) {
+            xsltTransformError(NULL, style, inst,
+                    "element %s only allowed as child of stylesheet\n",
+                               inst->name);
+            style->errors++;
+        }
+        return(0);
     }
     return(1);
 }
@@ -119,35 +119,35 @@ xsltCheckInstructionElement(xsltStylesheetPtr style, xmlNodePtr inst) {
 
     parent = inst->parent;
     if (parent == NULL) {
-    xsltTransformError(NULL, style, inst,
-        "internal problem: element has no parent\n");
-    style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+                "internal problem: element has no parent\n");
+        style->errors++;
+        return;
     }
     while ((parent != NULL) && (parent->type != XML_DOCUMENT_NODE)) {
         if (((parent->ns == inst->ns) ||
-         ((parent->ns != NULL) &&
-          (xmlStrEqual(parent->ns->href, inst->ns->href)))) &&
-        ((xmlStrEqual(parent->name, BAD_CAST "template")) ||
-         (xmlStrEqual(parent->name, BAD_CAST "param")) ||
-         (xmlStrEqual(parent->name, BAD_CAST "attribute")) ||
-         (xmlStrEqual(parent->name, BAD_CAST "variable")))) {
-        return;
-    }
+             ((parent->ns != NULL) &&
+              (xmlStrEqual(parent->ns->href, inst->ns->href)))) &&
+            ((xmlStrEqual(parent->name, BAD_CAST "template")) ||
+             (xmlStrEqual(parent->name, BAD_CAST "param")) ||
+             (xmlStrEqual(parent->name, BAD_CAST "attribute")) ||
+             (xmlStrEqual(parent->name, BAD_CAST "variable")))) {
+            return;
+        }
 
-    /*
-     * if we are within an extension element all bets are off
-     * about the semantic there e.g. xsl:param within func:function
-     */
-    if ((has_ext) && (parent->ns != NULL) &&
-        (xmlHashLookup(style->extInfos, parent->ns->href) != NULL))
-        return;
+        /*
+         * if we are within an extension element all bets are off
+         * about the semantic there e.g. xsl:param within func:function
+         */
+        if ((has_ext) && (parent->ns != NULL) &&
+            (xmlHashLookup(style->extInfos, parent->ns->href) != NULL))
+            return;
 
         parent = parent->parent;
     }
     xsltTransformError(NULL, style, inst,
-        "element %s only allowed within a template, variable or param\n",
-                   inst->name);
+            "element %s only allowed within a template, variable or param\n",
+                           inst->name);
     style->errors++;
 }
 
@@ -172,43 +172,43 @@ xsltCheckParentElement(xsltStylesheetPtr style, xmlNodePtr inst,
 
     parent = inst->parent;
     if (parent == NULL) {
-    xsltTransformError(NULL, style, inst,
-        "internal problem: element has no parent\n");
-    style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+                "internal problem: element has no parent\n");
+        style->errors++;
+        return;
     }
     if (((parent->ns == inst->ns) ||
-     ((parent->ns != NULL) &&
-      (xmlStrEqual(parent->ns->href, inst->ns->href)))) &&
-    ((xmlStrEqual(parent->name, allow1)) ||
-     (xmlStrEqual(parent->name, allow2)))) {
-    return;
+         ((parent->ns != NULL) &&
+          (xmlStrEqual(parent->ns->href, inst->ns->href)))) &&
+        ((xmlStrEqual(parent->name, allow1)) ||
+         (xmlStrEqual(parent->name, allow2)))) {
+        return;
     }
 
     if (style->extInfos != NULL) {
-    while ((parent != NULL) && (parent->type != XML_DOCUMENT_NODE)) {
-        /*
-         * if we are within an extension element all bets are off
-         * about the semantic there e.g. xsl:param within func:function
-         */
-        if ((parent->ns != NULL) &&
-        (xmlHashLookup(style->extInfos, parent->ns->href) != NULL))
-        return;
+        while ((parent != NULL) && (parent->type != XML_DOCUMENT_NODE)) {
+            /*
+             * if we are within an extension element all bets are off
+             * about the semantic there e.g. xsl:param within func:function
+             */
+            if ((parent->ns != NULL) &&
+                (xmlHashLookup(style->extInfos, parent->ns->href) != NULL))
+                return;
 
-        parent = parent->parent;
-    }
+            parent = parent->parent;
+        }
     }
     xsltTransformError(NULL, style, inst,
-               "element %s is not allowed within that context\n",
-               inst->name);
+                       "element %s is not allowed within that context\n",
+                       inst->name);
     style->errors++;
 }
 #endif
 
 /************************************************************************
- *                                  *
- *          handling of precomputed data            *
- *                                  *
+ *                                                                      *
+ *                      handling of precomputed data                    *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -271,31 +271,31 @@ xsltNewStylePreComp(xsltStylesheetPtr style, xsltStyleType type) {
             size = sizeof(xsltStyleItemForEach); break;
         case XSLT_FUNC_DOCUMENT:
             size = sizeof(xsltStyleItemDocument); break;
-    case XSLT_FUNC_WITHPARAM:
-        size = sizeof(xsltStyleItemWithParam); break;
-    case XSLT_FUNC_PARAM:
-        size = sizeof(xsltStyleItemParam); break;
-    case XSLT_FUNC_VARIABLE:
-        size = sizeof(xsltStyleItemVariable); break;
-    case XSLT_FUNC_WHEN:
-        size = sizeof(xsltStyleItemWhen); break;
-    case XSLT_FUNC_OTHERWISE:
-        size = sizeof(xsltStyleItemOtherwise); break;
-    default:
-        xsltTransformError(NULL, style, NULL,
-            "xsltNewStylePreComp : invalid type %d\n", type);
-        style->errors++;
-        return(NULL);
+        case XSLT_FUNC_WITHPARAM:
+            size = sizeof(xsltStyleItemWithParam); break;
+        case XSLT_FUNC_PARAM:
+            size = sizeof(xsltStyleItemParam); break;
+        case XSLT_FUNC_VARIABLE:
+            size = sizeof(xsltStyleItemVariable); break;
+        case XSLT_FUNC_WHEN:
+            size = sizeof(xsltStyleItemWhen); break;
+        case XSLT_FUNC_OTHERWISE:
+            size = sizeof(xsltStyleItemOtherwise); break;
+        default:
+            xsltTransformError(NULL, style, NULL,
+                    "xsltNewStylePreComp : invalid type %d\n", type);
+            style->errors++;
+            return(NULL);
     }
     /*
     * Create the structure.
     */
     cur = (xsltStylePreCompPtr) xmlMalloc(size);
     if (cur == NULL) {
-    xsltTransformError(NULL, style, NULL,
-        "xsltNewStylePreComp : malloc failed\n");
-    style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, style, NULL,
+                "xsltNewStylePreComp : malloc failed\n");
+        style->errors++;
+        return(NULL);
     }
     memset(cur, 0, size);
 
@@ -305,10 +305,10 @@ xsltNewStylePreComp(xsltStylesheetPtr style, xsltStyleType type) {
     */
     cur = (xsltStylePreCompPtr) xmlMalloc(sizeof(xsltStylePreComp));
     if (cur == NULL) {
-    xsltTransformError(NULL, style, NULL,
-        "xsltNewStylePreComp : malloc failed\n");
-    style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, style, NULL,
+                "xsltNewStylePreComp : malloc failed\n");
+        style->errors++;
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltStylePreComp));
 #endif /* XSLT_REFACTORED */
@@ -332,7 +332,7 @@ xsltNewStylePreComp(xsltStylesheetPtr style, xsltStyleType type) {
             cur->func = xsltComment;break;
         case XSLT_FUNC_PI:
             cur->func = xsltProcessingInstruction;
-        break;
+            break;
         case XSLT_FUNC_COPYOF:
             cur->func = xsltCopyOf;break;
         case XSLT_FUNC_VALUEOF:
@@ -353,17 +353,17 @@ xsltNewStylePreComp(xsltStylesheetPtr style, xsltStyleType type) {
             cur->func = xsltForEach;break;
         case XSLT_FUNC_DOCUMENT:
             cur->func = xsltDocumentElem;break;
-    case XSLT_FUNC_WITHPARAM:
-    case XSLT_FUNC_PARAM:
-    case XSLT_FUNC_VARIABLE:
-    case XSLT_FUNC_WHEN:
-        break;
-    default:
-    if (cur->func == NULL) {
-        xsltTransformError(NULL, style, NULL,
-            "xsltNewStylePreComp : no function for type %d\n", type);
-        style->errors++;
-    }
+        case XSLT_FUNC_WITHPARAM:
+        case XSLT_FUNC_PARAM:
+        case XSLT_FUNC_VARIABLE:
+        case XSLT_FUNC_WHEN:
+            break;
+        default:
+        if (cur->func == NULL) {
+            xsltTransformError(NULL, style, NULL,
+                    "xsltNewStylePreComp : no function for type %d\n", type);
+            style->errors++;
+        }
     }
     cur->next = style->preComps;
     style->preComps = (xsltElemPreCompPtr) cur;
@@ -380,23 +380,23 @@ xsltNewStylePreComp(xsltStylesheetPtr style, xsltStyleType type) {
 static void
 xsltFreeStylePreComp(xsltStylePreCompPtr comp) {
     if (comp == NULL)
-    return;
+        return;
 #ifdef XSLT_REFACTORED
     /*
     * URGENT TODO: Implement destructors.
     */
     switch (comp->type) {
-    case XSLT_FUNC_LITERAL_RESULT_ELEMENT:
-        break;
-    case XSLT_FUNC_COPY:
+        case XSLT_FUNC_LITERAL_RESULT_ELEMENT:
+            break;
+        case XSLT_FUNC_COPY:
             break;
         case XSLT_FUNC_SORT: {
-        xsltStyleItemSortPtr item = (xsltStyleItemSortPtr) comp;
-        if (item->locale != (xsltLocale)0)
-            xsltFreeLocale(item->locale);
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemSortPtr item = (xsltStyleItemSortPtr) comp;
+                if (item->locale != (xsltLocale)0)
+                    xsltFreeLocale(item->locale);
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_TEXT:
             break;
@@ -407,18 +407,18 @@ xsltFreeStylePreComp(xsltStylePreCompPtr comp) {
         case XSLT_FUNC_COMMENT:
             break;
         case XSLT_FUNC_PI:
-        break;
+            break;
         case XSLT_FUNC_COPYOF: {
-        xsltStyleItemCopyOfPtr item = (xsltStyleItemCopyOfPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemCopyOfPtr item = (xsltStyleItemCopyOfPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_VALUEOF: {
-        xsltStyleItemValueOfPtr item = (xsltStyleItemValueOfPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemValueOfPtr item = (xsltStyleItemValueOfPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_NUMBER: {
                 xsltStyleItemNumberPtr item = (xsltStyleItemNumberPtr) comp;
@@ -433,79 +433,79 @@ xsltFreeStylePreComp(xsltStylePreCompPtr comp) {
         case XSLT_FUNC_CALLTEMPLATE:
             break;
         case XSLT_FUNC_APPLYTEMPLATES: {
-        xsltStyleItemApplyTemplatesPtr item =
-            (xsltStyleItemApplyTemplatesPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemApplyTemplatesPtr item =
+                    (xsltStyleItemApplyTemplatesPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_CHOOSE:
             break;
         case XSLT_FUNC_IF: {
-        xsltStyleItemIfPtr item = (xsltStyleItemIfPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemIfPtr item = (xsltStyleItemIfPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_FOREACH: {
-        xsltStyleItemForEachPtr item =
-            (xsltStyleItemForEachPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
+                xsltStyleItemForEachPtr item =
+                    (xsltStyleItemForEachPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
             break;
         case XSLT_FUNC_DOCUMENT:
             break;
-    case XSLT_FUNC_WITHPARAM: {
-        xsltStyleItemWithParamPtr item =
-            (xsltStyleItemWithParamPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
-        break;
-    case XSLT_FUNC_PARAM: {
-        xsltStyleItemParamPtr item =
-            (xsltStyleItemParamPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
-        break;
-    case XSLT_FUNC_VARIABLE: {
-        xsltStyleItemVariablePtr item =
-            (xsltStyleItemVariablePtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
-        break;
-    case XSLT_FUNC_WHEN: {
-        xsltStyleItemWhenPtr item =
-            (xsltStyleItemWhenPtr) comp;
-        if (item->comp != NULL)
-            xmlXPathFreeCompExpr(item->comp);
-        }
-        break;
-    case XSLT_FUNC_OTHERWISE:
-    case XSLT_FUNC_FALLBACK:
-    case XSLT_FUNC_MESSAGE:
-    case XSLT_FUNC_INCLUDE:
-    case XSLT_FUNC_ATTRSET:
+        case XSLT_FUNC_WITHPARAM: {
+                xsltStyleItemWithParamPtr item =
+                    (xsltStyleItemWithParamPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
+            break;
+        case XSLT_FUNC_PARAM: {
+                xsltStyleItemParamPtr item =
+                    (xsltStyleItemParamPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
+            break;
+        case XSLT_FUNC_VARIABLE: {
+                xsltStyleItemVariablePtr item =
+                    (xsltStyleItemVariablePtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
+            break;
+        case XSLT_FUNC_WHEN: {
+                xsltStyleItemWhenPtr item =
+                    (xsltStyleItemWhenPtr) comp;
+                if (item->comp != NULL)
+                    xmlXPathFreeCompExpr(item->comp);
+            }
+            break;
+        case XSLT_FUNC_OTHERWISE:
+        case XSLT_FUNC_FALLBACK:
+        case XSLT_FUNC_MESSAGE:
+        case XSLT_FUNC_INCLUDE:
+        case XSLT_FUNC_ATTRSET:
 
-        break;
-    default:
-        /* TODO: Raise error. */
-        break;
+            break;
+        default:
+            /* TODO: Raise error. */
+            break;
     }
 #else
     if (comp->locale != (xsltLocale)0)
-    xsltFreeLocale(comp->locale);
+        xsltFreeLocale(comp->locale);
     if (comp->comp != NULL)
-    xmlXPathFreeCompExpr(comp->comp);
+        xmlXPathFreeCompExpr(comp->comp);
     if (comp->numdata.countPat != NULL)
         xsltFreeCompMatchList(comp->numdata.countPat);
     if (comp->numdata.fromPat != NULL)
         xsltFreeCompMatchList(comp->numdata.fromPat);
     if (comp->nsList != NULL)
-    xmlFree(comp->nsList);
+        xmlFree(comp->nsList);
 #endif
 
     xmlFree(comp);
@@ -513,9 +513,9 @@ xsltFreeStylePreComp(xsltStylePreCompPtr comp) {
 
 
 /************************************************************************
- *                                  *
- *          XSLT-1.1 extensions                 *
- *                                  *
+ *                                                                      *
+ *                  XSLT-1.1 extensions                                 *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -530,7 +530,7 @@ xsltFreeStylePreComp(xsltStylePreCompPtr comp) {
  */
 xsltElemPreCompPtr
 xsltDocumentComp(xsltStylesheetPtr style, xmlNodePtr inst,
-         xsltTransformFunction function ATTRIBUTE_UNUSED) {
+                 xsltTransformFunction function ATTRIBUTE_UNUSED) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemDocumentPtr comp;
 #else
@@ -552,107 +552,107 @@ xsltDocumentComp(xsltStylesheetPtr style, xmlNodePtr inst,
     */
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemDocumentPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_DOCUMENT);
+        xsltNewStylePreComp(style, XSLT_FUNC_DOCUMENT);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_DOCUMENT);
 #endif
 
     if (comp == NULL)
-    return (NULL);
+        return (NULL);
     comp->inst = inst;
     comp->ver11 = 0;
 
     if (xmlStrEqual(inst->name, (const xmlChar *) "output")) {
 #ifdef WITH_XSLT_DEBUG_EXTRA
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Found saxon:output extension\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+            "Found saxon:output extension\n");
 #endif
-    /*
-    * The element "output" is in the namespace XSLT_SAXON_NAMESPACE
-    *   (http://icl.com/saxon)
-    * The @file is in no namespace; it is an AVT.
-    *   (http://www.computerwizards.com/saxon/doc/extensions.html#saxon:output)
-    *
-    * TODO: Do we need not to check the namespace here?
-    */
-    filename = xsltEvalStaticAttrValueTemplate(style, inst,
-             (const xmlChar *)"file",
-             NULL, &comp->has_filename);
+        /*
+        * The element "output" is in the namespace XSLT_SAXON_NAMESPACE
+        *   (http://icl.com/saxon)
+        * The @file is in no namespace; it is an AVT.
+        *   (http://www.computerwizards.com/saxon/doc/extensions.html#saxon:output)
+        *
+        * TODO: Do we need not to check the namespace here?
+        */
+        filename = xsltEvalStaticAttrValueTemplate(style, inst,
+                         (const xmlChar *)"file",
+                         NULL, &comp->has_filename);
     } else if (xmlStrEqual(inst->name, (const xmlChar *) "write")) {
 #ifdef WITH_XSLT_DEBUG_EXTRA
-    xsltGenericDebug(xsltGenericDebugContext,
-        "Found xalan:write extension\n");
-#endif
-    /* the filename need to be interpreted */
-    /*
-    * TODO: Is "filename need to be interpreted" meant to be a todo?
-    *   Where will be the filename of xalan:write be processed?
-    *
-    * TODO: Do we need not to check the namespace here?
-    *   The extension ns is "http://xml.apache.org/xalan/redirect".
-    *   See http://xml.apache.org/xalan-j/extensionslib.html.
-    */
-    } else if (xmlStrEqual(inst->name, (const xmlChar *) "document")) {
-    if (inst->ns != NULL) {
-        if (xmlStrEqual(inst->ns->href, XSLT_NAMESPACE)) {
-        /*
-        * Mark the instruction as being of
-        * XSLT version 1.1 (abandoned).
-        */
-        comp->ver11 = 1;
-#ifdef WITH_XSLT_DEBUG_EXTRA
         xsltGenericDebug(xsltGenericDebugContext,
-            "Found xslt11:document construct\n");
+            "Found xalan:write extension\n");
 #endif
-        } else {
-        if (xmlStrEqual(inst->ns->href,
-            (const xmlChar *)"http://exslt.org/common")) {
-            /* EXSLT. */
+        /* the filename need to be interpreted */
+        /*
+        * TODO: Is "filename need to be interpreted" meant to be a todo?
+        *   Where will be the filename of xalan:write be processed?
+        *
+        * TODO: Do we need not to check the namespace here?
+        *   The extension ns is "http://xml.apache.org/xalan/redirect".
+        *   See http://xml.apache.org/xalan-j/extensionslib.html.
+        */
+    } else if (xmlStrEqual(inst->name, (const xmlChar *) "document")) {
+        if (inst->ns != NULL) {
+            if (xmlStrEqual(inst->ns->href, XSLT_NAMESPACE)) {
+                /*
+                * Mark the instruction as being of
+                * XSLT version 1.1 (abandoned).
+                */
+                comp->ver11 = 1;
 #ifdef WITH_XSLT_DEBUG_EXTRA
-            xsltGenericDebug(xsltGenericDebugContext,
-            "Found exslt:document extension\n");
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "Found xslt11:document construct\n");
 #endif
-        } else if (xmlStrEqual(inst->ns->href, XSLT_XT_NAMESPACE)) {
-            /* James Clark's XT. */
+            } else {
+                if (xmlStrEqual(inst->ns->href,
+                    (const xmlChar *)"http://exslt.org/common")) {
+                    /* EXSLT. */
 #ifdef WITH_XSLT_DEBUG_EXTRA
-            xsltGenericDebug(xsltGenericDebugContext,
-            "Found xt:document extension\n");
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "Found exslt:document extension\n");
 #endif
+                } else if (xmlStrEqual(inst->ns->href, XSLT_XT_NAMESPACE)) {
+                    /* James Clark's XT. */
+#ifdef WITH_XSLT_DEBUG_EXTRA
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "Found xt:document extension\n");
+#endif
+                }
+            }
         }
-        }
-    }
-    /*
-    * The element "document" is used in conjunction with the
-    * following namespaces:
-    *
-    * 1) XSLT_NAMESPACE (http://www.w3.org/1999/XSL/Transform version 1.1)
-    *    <!ELEMENT xsl:document %template;>
-    *    <!ATTLIST xsl:document
-    *       href %avt; #REQUIRED
-    *    @href is an AVT
-    *    IMPORTANT: xsl:document was in the abandoned XSLT 1.1 draft,
-    *    it was removed and isn't available in XSLT 1.1 anymore.
-    *    In XSLT 2.0 it was renamed to xsl:result-document.
-    *
-    *   All other attributes are identical to the attributes
-    *   on xsl:output
-    *
-    * 2) EXSLT_COMMON_NAMESPACE (http://exslt.org/common)
-    *    <exsl:document
-    *       href = { uri-reference }
-    *    TODO: is @href is an AVT?
-    *
-    * 3) XSLT_XT_NAMESPACE (http://www.jclark.com/xt)
-    *     Example: <xt:document method="xml" href="myFile.xml">
-    *    TODO: is @href is an AVT?
-    *
-    * In all cases @href is in no namespace.
-    */
-    filename = xsltEvalStaticAttrValueTemplate(style, inst,
-        (const xmlChar *)"href", NULL, &comp->has_filename);
+        /*
+        * The element "document" is used in conjunction with the
+        * following namespaces:
+        *
+        * 1) XSLT_NAMESPACE (http://www.w3.org/1999/XSL/Transform version 1.1)
+        *    <!ELEMENT xsl:document %template;>
+        *    <!ATTLIST xsl:document
+        *       href %avt; #REQUIRED
+        *    @href is an AVT
+        *    IMPORTANT: xsl:document was in the abandoned XSLT 1.1 draft,
+        *    it was removed and isn't available in XSLT 1.1 anymore.
+        *    In XSLT 2.0 it was renamed to xsl:result-document.
+        *
+        *   All other attributes are identical to the attributes
+        *   on xsl:output
+        *
+        * 2) EXSLT_COMMON_NAMESPACE (http://exslt.org/common)
+        *    <exsl:document
+        *       href = { uri-reference }
+        *    TODO: is @href is an AVT?
+        *
+        * 3) XSLT_XT_NAMESPACE (http://www.jclark.com/xt)
+        *     Example: <xt:document method="xml" href="myFile.xml">
+        *    TODO: is @href is an AVT?
+        *
+        * In all cases @href is in no namespace.
+        */
+        filename = xsltEvalStaticAttrValueTemplate(style, inst,
+            (const xmlChar *)"href", NULL, &comp->has_filename);
     }
     if (!comp->has_filename) {
-    goto error;
+        goto error;
     }
     comp->filename = filename;
 
@@ -661,9 +661,9 @@ error:
 }
 
 /************************************************************************
- *                                  *
- *      Most of the XSLT-1.0 transformations            *
- *                                  *
+ *                                                                      *
+ *              Most of the XSLT-1.0 transformations                    *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -681,7 +681,7 @@ xsltSortComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     xsltStylePreCompPtr comp;
 #endif
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemSortPtr) xsltNewStylePreComp(style, XSLT_FUNC_SORT);
@@ -690,61 +690,61 @@ xsltSortComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->stype = xsltEvalStaticAttrValueTemplate(style, inst,
-             (const xmlChar *)"data-type",
-             NULL, &comp->has_stype);
+                         (const xmlChar *)"data-type",
+                         NULL, &comp->has_stype);
     if (comp->stype != NULL) {
-    if (xmlStrEqual(comp->stype, (const xmlChar *) "text"))
-        comp->number = 0;
-    else if (xmlStrEqual(comp->stype, (const xmlChar *) "number"))
-        comp->number = 1;
-    else {
-        xsltTransformError(NULL, style, inst,
-         "xsltSortComp: no support for data-type = %s\n", comp->stype);
-        comp->number = 0; /* use default */
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(comp->stype, (const xmlChar *) "text"))
+            comp->number = 0;
+        else if (xmlStrEqual(comp->stype, (const xmlChar *) "number"))
+            comp->number = 1;
+        else {
+            xsltTransformError(NULL, style, inst,
+                 "xsltSortComp: no support for data-type = %s\n", comp->stype);
+            comp->number = 0; /* use default */
+            if (style != NULL) style->warnings++;
+        }
     }
     comp->order = xsltEvalStaticAttrValueTemplate(style, inst,
-                  (const xmlChar *)"order",
-                  NULL, &comp->has_order);
+                              (const xmlChar *)"order",
+                              NULL, &comp->has_order);
     if (comp->order != NULL) {
-    if (xmlStrEqual(comp->order, (const xmlChar *) "ascending"))
-        comp->descending = 0;
-    else if (xmlStrEqual(comp->order, (const xmlChar *) "descending"))
-        comp->descending = 1;
-    else {
-        xsltTransformError(NULL, style, inst,
-         "xsltSortComp: invalid value %s for order\n", comp->order);
-        comp->descending = 0; /* use default */
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(comp->order, (const xmlChar *) "ascending"))
+            comp->descending = 0;
+        else if (xmlStrEqual(comp->order, (const xmlChar *) "descending"))
+            comp->descending = 1;
+        else {
+            xsltTransformError(NULL, style, inst,
+                 "xsltSortComp: invalid value %s for order\n", comp->order);
+            comp->descending = 0; /* use default */
+            if (style != NULL) style->warnings++;
+        }
     }
     comp->case_order = xsltEvalStaticAttrValueTemplate(style, inst,
-                  (const xmlChar *)"case-order",
-                  NULL, &comp->has_use);
+                              (const xmlChar *)"case-order",
+                              NULL, &comp->has_use);
     if (comp->case_order != NULL) {
-    if (xmlStrEqual(comp->case_order, (const xmlChar *) "upper-first"))
-        comp->lower_first = 0;
-    else if (xmlStrEqual(comp->case_order, (const xmlChar *) "lower-first"))
-        comp->lower_first = 1;
-    else {
-        xsltTransformError(NULL, style, inst,
-         "xsltSortComp: invalid value %s for order\n", comp->order);
-        comp->lower_first = 0; /* use default */
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(comp->case_order, (const xmlChar *) "upper-first"))
+            comp->lower_first = 0;
+        else if (xmlStrEqual(comp->case_order, (const xmlChar *) "lower-first"))
+            comp->lower_first = 1;
+        else {
+            xsltTransformError(NULL, style, inst,
+                 "xsltSortComp: invalid value %s for order\n", comp->order);
+            comp->lower_first = 0; /* use default */
+            if (style != NULL) style->warnings++;
+        }
     }
 
     comp->lang = xsltEvalStaticAttrValueTemplate(style, inst,
-                 (const xmlChar *)"lang",
-                 NULL, &comp->has_lang);
+                                 (const xmlChar *)"lang",
+                                 NULL, &comp->has_lang);
     if (comp->lang != NULL) {
-    comp->locale = xsltNewLocale(comp->lang);
+        comp->locale = xsltNewLocale(comp->lang);
     }
     else {
         comp->locale = (xsltLocale)0;
@@ -752,24 +752,24 @@ xsltSortComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 
     comp->select = xsltGetCNsProp(style, inst,(const xmlChar *)"select", XSLT_NAMESPACE);
     if (comp->select == NULL) {
-    /*
-     * The default value of the select attribute is ., which will
-     * cause the string-value of the current node to be used as
-     * the sort key.
-     */
-    comp->select = xmlDictLookup(style->dict, BAD_CAST ".", 1);
+        /*
+         * The default value of the select attribute is ., which will
+         * cause the string-value of the current node to be used as
+         * the sort key.
+         */
+        comp->select = xmlDictLookup(style->dict, BAD_CAST ".", 1);
     }
     comp->comp = xsltXPathCompile(style, comp->select);
     if (comp->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsltSortComp: could not compile select expression '%s'\n",
-                     comp->select);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+             "xsltSortComp: could not compile select expression '%s'\n",
+                         comp->select);
+        if (style != NULL) style->errors++;
     }
     if (inst->children != NULL) {
-    xsltTransformError(NULL, style, inst,
-    "xsl:sort : is not empty\n");
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+        "xsl:sort : is not empty\n");
+        if (style != NULL) style->errors++;
     }
 }
 
@@ -789,7 +789,7 @@ xsltCopyComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemCopyPtr) xsltNewStylePreComp(style, XSLT_FUNC_COPY);
 #else
@@ -797,17 +797,17 @@ xsltCopyComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
 
     comp->use = xsltGetCNsProp(style, inst, (const xmlChar *)"use-attribute-sets",
-                    XSLT_NAMESPACE);
+                                    XSLT_NAMESPACE);
     if (comp->use == NULL)
-    comp->has_use = 0;
+        comp->has_use = 0;
     else
-    comp->has_use = 1;
+        comp->has_use = 1;
 }
 
 #ifdef XSLT_REFACTORED
@@ -833,7 +833,7 @@ xsltTextComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     const xmlChar *prop;
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemTextPtr) xsltNewStylePreComp(style, XSLT_FUNC_TEXT);
@@ -841,23 +841,23 @@ xsltTextComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     comp = xsltNewStylePreComp(style, XSLT_FUNC_TEXT);
 #endif
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
     comp->noescape = 0;
 
     prop = xsltGetCNsProp(style, inst,
-        (const xmlChar *)"disable-output-escaping",
-            XSLT_NAMESPACE);
+            (const xmlChar *)"disable-output-escaping",
+                        XSLT_NAMESPACE);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
-        comp->noescape = 1;
-    } else if (!xmlStrEqual(prop,
-        (const xmlChar *)"no")){
-        xsltTransformError(NULL, style, inst,
-        "xsl:text: disable-output-escaping allows only yes or no\n");
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
+            comp->noescape = 1;
+        } else if (!xmlStrEqual(prop,
+            (const xmlChar *)"no")){
+            xsltTransformError(NULL, style, inst,
+                "xsl:text: disable-output-escaping allows only yes or no\n");
+            if (style != NULL) style->warnings++;
+        }
     }
 }
 #endif /* else of XSLT_REFACTORED */
@@ -886,7 +886,7 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * </xsl:element>
     */
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemElementPtr) xsltNewStylePreComp(style, XSLT_FUNC_ELEMENT);
@@ -895,7 +895,7 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -906,12 +906,12 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * TODO: Precompile the AVT. See bug #344894.
     */
     comp->name = xsltEvalStaticAttrValueTemplate(style, inst,
-    (const xmlChar *)"name", NULL, &comp->has_name);
+        (const xmlChar *)"name", NULL, &comp->has_name);
     if (! comp->has_name) {
-    xsltTransformError(NULL, style, inst,
-        "xsl:element: The attribute 'name' is missing.\n");
-    style->errors++;
-    goto error;
+        xsltTransformError(NULL, style, inst,
+            "xsl:element: The attribute 'name' is missing.\n");
+        style->errors++;
+        goto error;
     }
     /*
     * Attribute "namespace".
@@ -920,63 +920,63 @@ xsltElementComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * TODO: Precompile the AVT. See bug #344894.
     */
     comp->ns = xsltEvalStaticAttrValueTemplate(style, inst,
-    (const xmlChar *)"namespace", NULL, &comp->has_ns);
+        (const xmlChar *)"namespace", NULL, &comp->has_ns);
 
     if (comp->name != NULL) {
-    if (xmlValidateQName(comp->name, 0)) {
-        xsltTransformError(NULL, style, inst,
-        "xsl:element: The value '%s' of the attribute 'name' is "
-        "not a valid QName.\n", comp->name);
-        style->errors++;
-    } else {
-        const xmlChar *prefix = NULL, *name;
+        if (xmlValidateQName(comp->name, 0)) {
+            xsltTransformError(NULL, style, inst,
+                "xsl:element: The value '%s' of the attribute 'name' is "
+                "not a valid QName.\n", comp->name);
+            style->errors++;
+        } else {
+            const xmlChar *prefix = NULL, *name;
 
-        name = xsltSplitQName(style->dict, comp->name, &prefix);
-        if (comp->has_ns == 0) {
-        xmlNsPtr ns;
+            name = xsltSplitQName(style->dict, comp->name, &prefix);
+            if (comp->has_ns == 0) {
+                xmlNsPtr ns;
 
-        /*
-        * SPEC XSLT 1.0:
-        *  "If the namespace attribute is not present, then the QName is
-        *  expanded into an expanded-name using the namespace declarations
-        *  in effect for the xsl:element element, including any default
-        *  namespace declaration.
-        */
-        ns = xmlSearchNs(inst->doc, inst, prefix);
-        if (ns != NULL) {
-            comp->ns = xmlDictLookup(style->dict, ns->href, -1);
-            comp->has_ns = 1;
+                /*
+                * SPEC XSLT 1.0:
+                *  "If the namespace attribute is not present, then the QName is
+                *  expanded into an expanded-name using the namespace declarations
+                *  in effect for the xsl:element element, including any default
+                *  namespace declaration.
+                */
+                ns = xmlSearchNs(inst->doc, inst, prefix);
+                if (ns != NULL) {
+                    comp->ns = xmlDictLookup(style->dict, ns->href, -1);
+                    comp->has_ns = 1;
 #ifdef XSLT_REFACTORED
-            comp->nsPrefix = prefix;
-            comp->name = name;
+                    comp->nsPrefix = prefix;
+                    comp->name = name;
 #else
                     (void)name; /* Suppress unused variable warning. */
 #endif
-        } else if (prefix != NULL) {
-            xsltTransformError(NULL, style, inst,
-            "xsl:element: The prefixed QName '%s' "
-            "has no namespace binding in scope in the "
-            "stylesheet; this is an error, since the namespace was "
-            "not specified by the instruction itself.\n", comp->name);
-            style->errors++;
+                } else if (prefix != NULL) {
+                    xsltTransformError(NULL, style, inst,
+                        "xsl:element: The prefixed QName '%s' "
+                        "has no namespace binding in scope in the "
+                        "stylesheet; this is an error, since the namespace was "
+                        "not specified by the instruction itself.\n", comp->name);
+                    style->errors++;
+                }
+            }
+            if ((prefix != NULL) &&
+                (!xmlStrncasecmp(prefix, (xmlChar *)"xml", 3)))
+            {
+                /*
+                * Mark is to be skipped.
+                */
+                comp->has_name = 0;
+            }
         }
-        }
-        if ((prefix != NULL) &&
-        (!xmlStrncasecmp(prefix, (xmlChar *)"xml", 3)))
-        {
-        /*
-        * Mark is to be skipped.
-        */
-        comp->has_name = 0;
-        }
-    }
     }
     /*
     * Attribute "use-attribute-sets",
     */
     comp->use = xsltEvalStaticAttrValueTemplate(style, inst,
-               (const xmlChar *)"use-attribute-sets",
-               NULL, &comp->has_use);
+                       (const xmlChar *)"use-attribute-sets",
+                       NULL, &comp->has_use);
 
 error:
     return;
@@ -1005,17 +1005,17 @@ xsltAttributeComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * </xsl:attribute>
     */
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemAttributePtr) xsltNewStylePreComp(style,
-    XSLT_FUNC_ATTRIBUTE);
+        XSLT_FUNC_ATTRIBUTE);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_ATTRIBUTE);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -1026,13 +1026,13 @@ xsltAttributeComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * TODO: Precompile the AVT. See bug #344894.
     */
     comp->name = xsltEvalStaticAttrValueTemplate(style, inst,
-                 (const xmlChar *)"name",
-                 NULL, &comp->has_name);
+                                 (const xmlChar *)"name",
+                                 NULL, &comp->has_name);
     if (! comp->has_name) {
-    xsltTransformError(NULL, style, inst,
-        "XSLT-attribute: The attribute 'name' is missing.\n");
-    style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+            "XSLT-attribute: The attribute 'name' is missing.\n");
+        style->errors++;
+        return;
     }
     /*
     * Attribute "namespace".
@@ -1041,56 +1041,56 @@ xsltAttributeComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * TODO: Precompile the AVT. See bug #344894.
     */
     comp->ns = xsltEvalStaticAttrValueTemplate(style, inst,
-    (const xmlChar *)"namespace",
-    NULL, &comp->has_ns);
+        (const xmlChar *)"namespace",
+        NULL, &comp->has_ns);
 
     if (comp->name != NULL) {
-    if (xmlValidateQName(comp->name, 0)) {
-        xsltTransformError(NULL, style, inst,
-        "xsl:attribute: The value '%s' of the attribute 'name' is "
-        "not a valid QName.\n", comp->name);
-        style->errors++;
+        if (xmlValidateQName(comp->name, 0)) {
+            xsltTransformError(NULL, style, inst,
+                "xsl:attribute: The value '%s' of the attribute 'name' is "
+                "not a valid QName.\n", comp->name);
+            style->errors++;
         } else if (xmlStrEqual(comp->name, BAD_CAST "xmlns")) {
-        xsltTransformError(NULL, style, inst,
+            xsltTransformError(NULL, style, inst,
                 "xsl:attribute: The attribute name 'xmlns' is not allowed.\n");
-        style->errors++;
-    } else {
-        const xmlChar *prefix = NULL, *name;
+            style->errors++;
+        } else {
+            const xmlChar *prefix = NULL, *name;
 
-        name = xsltSplitQName(style->dict, comp->name, &prefix);
-        if (prefix != NULL) {
-        if (comp->has_ns == 0) {
-            xmlNsPtr ns;
+            name = xsltSplitQName(style->dict, comp->name, &prefix);
+            if (prefix != NULL) {
+                if (comp->has_ns == 0) {
+                    xmlNsPtr ns;
 
-            /*
-            * SPEC XSLT 1.0:
-            *  "If the namespace attribute is not present, then the
-            *  QName is expanded into an expanded-name using the
-            *  namespace declarations in effect for the xsl:element
-            *  element, including any default namespace declaration.
-            */
-            ns = xmlSearchNs(inst->doc, inst, prefix);
-            if (ns != NULL) {
-            comp->ns = xmlDictLookup(style->dict, ns->href, -1);
-            comp->has_ns = 1;
+                    /*
+                    * SPEC XSLT 1.0:
+                    *  "If the namespace attribute is not present, then the
+                    *  QName is expanded into an expanded-name using the
+                    *  namespace declarations in effect for the xsl:element
+                    *  element, including any default namespace declaration.
+                    */
+                    ns = xmlSearchNs(inst->doc, inst, prefix);
+                    if (ns != NULL) {
+                        comp->ns = xmlDictLookup(style->dict, ns->href, -1);
+                        comp->has_ns = 1;
 #ifdef XSLT_REFACTORED
-            comp->nsPrefix = prefix;
-            comp->name = name;
+                        comp->nsPrefix = prefix;
+                        comp->name = name;
 #else
                         (void)name; /* Suppress unused variable warning. */
 #endif
-            } else {
-            xsltTransformError(NULL, style, inst,
-                "xsl:attribute: The prefixed QName '%s' "
-                "has no namespace binding in scope in the "
-                "stylesheet; this is an error, since the "
-                "namespace was not specified by the instruction "
-                "itself.\n", comp->name);
-            style->errors++;
+                    } else {
+                        xsltTransformError(NULL, style, inst,
+                            "xsl:attribute: The prefixed QName '%s' "
+                            "has no namespace binding in scope in the "
+                            "stylesheet; this is an error, since the "
+                            "namespace was not specified by the instruction "
+                            "itself.\n", comp->name);
+                        style->errors++;
+                    }
+                }
             }
         }
-        }
-    }
     }
 }
 
@@ -1110,7 +1110,7 @@ xsltCommentComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemCommentPtr) xsltNewStylePreComp(style, XSLT_FUNC_COMMENT);
@@ -1119,7 +1119,7 @@ xsltCommentComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 }
@@ -1140,7 +1140,7 @@ xsltProcessingInstructionComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemPIPtr) xsltNewStylePreComp(style, XSLT_FUNC_PI);
@@ -1149,13 +1149,13 @@ xsltProcessingInstructionComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->name = xsltEvalStaticAttrValueTemplate(style, inst,
-                 (const xmlChar *)"name",
-                 XSLT_NAMESPACE, &comp->has_name);
+                                 (const xmlChar *)"name",
+                                 XSLT_NAMESPACE, &comp->has_name);
 }
 
 /**
@@ -1174,7 +1174,7 @@ xsltCopyOfComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemCopyOfPtr) xsltNewStylePreComp(style, XSLT_FUNC_COPYOF);
@@ -1183,24 +1183,24 @@ xsltCopyOfComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:copy-of : select is missing\n");
-    if (style != NULL) style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+             "xsl:copy-of : select is missing\n");
+        if (style != NULL) style->errors++;
+        return;
     }
     comp->comp = xsltXPathCompile(style, comp->select);
     if (comp->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:copy-of : could not compile select expression '%s'\n",
-                     comp->select);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+             "xsl:copy-of : could not compile select expression '%s'\n",
+                         comp->select);
+        if (style != NULL) style->errors++;
     }
 }
 
@@ -1221,7 +1221,7 @@ xsltValueOfComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     const xmlChar *prop;
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemValueOfPtr) xsltNewStylePreComp(style, XSLT_FUNC_VALUEOF);
@@ -1230,97 +1230,97 @@ xsltValueOfComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     prop = xsltGetCNsProp(style, inst,
-        (const xmlChar *)"disable-output-escaping",
-            XSLT_NAMESPACE);
+            (const xmlChar *)"disable-output-escaping",
+                        XSLT_NAMESPACE);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
-        comp->noescape = 1;
-    } else if (!xmlStrEqual(prop,
-                (const xmlChar *)"no")){
-        xsltTransformError(NULL, style, inst,
+        if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
+            comp->noescape = 1;
+        } else if (!xmlStrEqual(prop,
+                                (const xmlChar *)"no")){
+            xsltTransformError(NULL, style, inst,
 "xsl:value-of : disable-output-escaping allows only yes or no\n");
-        if (style != NULL) style->warnings++;
-    }
+            if (style != NULL) style->warnings++;
+        }
     }
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:value-of : select is missing\n");
-    if (style != NULL) style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+             "xsl:value-of : select is missing\n");
+        if (style != NULL) style->errors++;
+        return;
     }
     comp->comp = xsltXPathCompile(style, comp->select);
     if (comp->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:value-of : could not compile select expression '%s'\n",
-                     comp->select);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+             "xsl:value-of : could not compile select expression '%s'\n",
+                         comp->select);
+        if (style != NULL) style->errors++;
     }
 }
 
 static void
 xsltGetQNameProperty(xsltStylesheetPtr style, xmlNodePtr inst,
-             const xmlChar *propName,
-             int mandatory,
-             int *hasProp, const xmlChar **nsName,
-             const xmlChar** localName)
+                     const xmlChar *propName,
+                     int mandatory,
+                     int *hasProp, const xmlChar **nsName,
+                     const xmlChar** localName)
 {
     const xmlChar *prop;
 
     if (nsName)
-    *nsName = NULL;
+        *nsName = NULL;
     if (localName)
-    *localName = NULL;
+        *localName = NULL;
     if (hasProp)
-    *hasProp = 0;
+        *hasProp = 0;
 
     prop = xsltGetCNsProp(style, inst, propName, XSLT_NAMESPACE);
     if (prop == NULL) {
-    if (mandatory) {
-        xsltTransformError(NULL, style, inst,
-        "The attribute '%s' is missing.\n", propName);
-        style->errors++;
-        return;
-    }
+        if (mandatory) {
+            xsltTransformError(NULL, style, inst,
+                "The attribute '%s' is missing.\n", propName);
+            style->errors++;
+            return;
+        }
     } else {
         const xmlChar *URI;
 
-    if (xmlValidateQName(prop, 0)) {
-        xsltTransformError(NULL, style, inst,
-        "The value '%s' of the attribute "
-        "'%s' is not a valid QName.\n", prop, propName);
-        style->errors++;
-        return;
-    } else {
-        /*
-        * @prop will be in the string dict afterwards, @URI not.
-        */
-        URI = xsltGetQNameURI2(style, inst, &prop);
-        if (prop == NULL) {
-        style->errors++;
+        if (xmlValidateQName(prop, 0)) {
+            xsltTransformError(NULL, style, inst,
+                "The value '%s' of the attribute "
+                "'%s' is not a valid QName.\n", prop, propName);
+            style->errors++;
+            return;
         } else {
-        if (localName)
-            *localName = prop;
-        if (hasProp)
-            *hasProp = 1;
-        if (URI != NULL) {
             /*
-            * Fixes bug #308441: Put the ns-name in the dict
-            * in order to pointer compare names during XPath's
-            * variable lookup.
+            * @prop will be in the string dict afterwards, @URI not.
             */
-            if (nsName)
-            *nsName = xmlDictLookup(style->dict, URI, -1);
-            /* comp->has_ns = 1; */
+            URI = xsltGetQNameURI2(style, inst, &prop);
+            if (prop == NULL) {
+                style->errors++;
+            } else {
+                if (localName)
+                    *localName = prop;
+                if (hasProp)
+                    *hasProp = 1;
+                if (URI != NULL) {
+                    /*
+                    * Fixes bug #308441: Put the ns-name in the dict
+                    * in order to pointer compare names during XPath's
+                    * variable lookup.
+                    */
+                    if (nsName)
+                        *nsName = xmlDictLookup(style->dict, URI, -1);
+                    /* comp->has_ns = 1; */
+                }
+            }
         }
-        }
-    }
     }
     return;
 }
@@ -1347,7 +1347,7 @@ xsltWithParamComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemWithParamPtr) xsltNewStylePreComp(style, XSLT_FUNC_WITHPARAM);
@@ -1356,7 +1356,7 @@ xsltWithParamComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -1364,28 +1364,28 @@ xsltWithParamComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * Attribute "name".
     */
     xsltGetQNameProperty(style, inst, BAD_CAST "name",
-    1, &(comp->has_name), &(comp->ns), &(comp->name));
+        1, &(comp->has_name), &(comp->ns), &(comp->name));
     if (comp->ns)
-    comp->has_ns = 1;
+        comp->has_ns = 1;
     /*
     * Attribute "select".
     */
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select != NULL) {
-    comp->comp = xsltXPathCompile(style, comp->select);
-    if (comp->comp == NULL) {
-        xsltTransformError(NULL, style, inst,
-         "XSLT-with-param: Failed to compile select "
-         "expression '%s'\n", comp->select);
-        style->errors++;
-    }
-    if (inst->children != NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-with-param: The content should be empty since "
-        "the attribute select is present.\n");
-        style->warnings++;
-    }
+        comp->comp = xsltXPathCompile(style, comp->select);
+        if (comp->comp == NULL) {
+            xsltTransformError(NULL, style, inst,
+                 "XSLT-with-param: Failed to compile select "
+                 "expression '%s'\n", comp->select);
+            style->errors++;
+        }
+        if (inst->children != NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-with-param: The content should be empty since "
+                "the attribute select is present.\n");
+            style->warnings++;
+        }
     }
 }
 
@@ -1406,7 +1406,7 @@ xsltNumberComp(xsltStylesheetPtr style, xmlNodePtr cur) {
     const xmlChar *prop;
 
     if ((style == NULL) || (cur == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemNumberPtr) xsltNewStylePreComp(style, XSLT_FUNC_NUMBER);
@@ -1415,21 +1415,21 @@ xsltNumberComp(xsltStylesheetPtr style, xmlNodePtr cur) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     cur->psvi = comp;
 
     comp->numdata.doc = cur->doc;
     comp->numdata.node = cur;
     comp->numdata.value = xsltGetCNsProp(style, cur, (const xmlChar *)"value",
-                                    XSLT_NAMESPACE);
+                                        XSLT_NAMESPACE);
 
     prop = xsltEvalStaticAttrValueTemplate(style, cur,
-             (const xmlChar *)"format",
-             XSLT_NAMESPACE, &comp->numdata.has_format);
+                         (const xmlChar *)"format",
+                         XSLT_NAMESPACE, &comp->numdata.has_format);
     if (comp->numdata.has_format == 0) {
-    comp->numdata.format = xmlDictLookup(style->dict, BAD_CAST "" , 0);
+        comp->numdata.format = xmlDictLookup(style->dict, BAD_CAST "" , 0);
     } else {
-    comp->numdata.format = prop;
+        comp->numdata.format = prop;
     }
 
     comp->numdata.count = xsltGetCNsProp(style, cur, (const xmlChar *)"count",
@@ -1439,76 +1439,78 @@ xsltNumberComp(xsltStylesheetPtr style, xmlNodePtr cur) {
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"count", XSLT_NAMESPACE);
     if (prop != NULL) {
-    comp->numdata.countPat = xsltCompilePattern(prop, cur->doc, cur, style,
+        comp->numdata.countPat = xsltCompilePattern(prop, cur->doc, cur, style,
                                                     NULL);
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"from", XSLT_NAMESPACE);
     if (prop != NULL) {
-    comp->numdata.fromPat = xsltCompilePattern(prop, cur->doc, cur, style,
+        comp->numdata.fromPat = xsltCompilePattern(prop, cur->doc, cur, style,
                                                    NULL);
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"level", XSLT_NAMESPACE);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, BAD_CAST("single")) ||
-        xmlStrEqual(prop, BAD_CAST("multiple")) ||
-        xmlStrEqual(prop, BAD_CAST("any"))) {
-        comp->numdata.level = prop;
-    } else {
-        xsltTransformError(NULL, style, cur,
-             "xsl:number : invalid value %s for level\n", prop);
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(prop, BAD_CAST("single")) ||
+            xmlStrEqual(prop, BAD_CAST("multiple")) ||
+            xmlStrEqual(prop, BAD_CAST("any"))) {
+            comp->numdata.level = prop;
+        } else {
+            xsltTransformError(NULL, style, cur,
+                         "xsl:number : invalid value %s for level\n", prop);
+            if (style != NULL) style->warnings++;
+        }
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"lang", XSLT_NAMESPACE);
     if (prop != NULL) {
-        xsltTransformError(NULL, style, cur,
-         "xsl:number : lang attribute not implemented\n");
-    XSLT_TODO; /* xsl:number lang attribute */
+            xsltTransformError(NULL, style, cur,
+                 "xsl:number : lang attribute not implemented\n");
+        XSLT_TODO; /* xsl:number lang attribute */
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"letter-value", XSLT_NAMESPACE);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, BAD_CAST("alphabetic"))) {
-        xsltTransformError(NULL, style, cur,
-         "xsl:number : letter-value 'alphabetic' not implemented\n");
-        if (style != NULL) style->warnings++;
-        XSLT_TODO; /* xsl:number letter-value attribute alphabetic */
-    } else if (xmlStrEqual(prop, BAD_CAST("traditional"))) {
-        xsltTransformError(NULL, style, cur,
-         "xsl:number : letter-value 'traditional' not implemented\n");
-        if (style != NULL) style->warnings++;
-        XSLT_TODO; /* xsl:number letter-value attribute traditional */
-    } else {
-        xsltTransformError(NULL, style, cur,
-             "xsl:number : invalid value %s for letter-value\n", prop);
-        if (style != NULL) style->warnings++;
-    }
+        if (xmlStrEqual(prop, BAD_CAST("alphabetic"))) {
+            xsltTransformError(NULL, style, cur,
+                 "xsl:number : letter-value 'alphabetic' not implemented\n");
+            if (style != NULL) style->warnings++;
+            XSLT_TODO; /* xsl:number letter-value attribute alphabetic */
+        } else if (xmlStrEqual(prop, BAD_CAST("traditional"))) {
+            xsltTransformError(NULL, style, cur,
+                 "xsl:number : letter-value 'traditional' not implemented\n");
+            if (style != NULL) style->warnings++;
+            XSLT_TODO; /* xsl:number letter-value attribute traditional */
+        } else {
+            xsltTransformError(NULL, style, cur,
+                     "xsl:number : invalid value %s for letter-value\n", prop);
+            if (style != NULL) style->warnings++;
+        }
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"grouping-separator",
-                    XSLT_NAMESPACE);
+                        XSLT_NAMESPACE);
     if (prop != NULL) {
         comp->numdata.groupingCharacterLen = xmlStrlen(prop);
-    comp->numdata.groupingCharacter =
-        xsltGetUTF8Char(prop, &(comp->numdata.groupingCharacterLen));
+        comp->numdata.groupingCharacter =
+            xsltGetUTF8Char(prop, &(comp->numdata.groupingCharacterLen));
+        if (comp->numdata.groupingCharacter < 0)
+            comp->numdata.groupingCharacter = 0;
     }
 
     prop = xsltGetCNsProp(style, cur, (const xmlChar *)"grouping-size", XSLT_NAMESPACE);
     if (prop != NULL) {
-    sscanf((char *)prop, "%d", &comp->numdata.digitsPerGroup);
+        sscanf((char *)prop, "%d", &comp->numdata.digitsPerGroup);
     } else {
-    comp->numdata.groupingCharacter = 0;
+        comp->numdata.groupingCharacter = 0;
     }
 
     /* Set default values */
     if (comp->numdata.value == NULL) {
-    if (comp->numdata.level == NULL) {
-        comp->numdata.level = xmlDictLookup(style->dict,
-                                            BAD_CAST"single", 6);
-    }
+        if (comp->numdata.level == NULL) {
+            comp->numdata.level = xmlDictLookup(style->dict,
+                                                BAD_CAST"single", 6);
+        }
     }
 
 }
@@ -1529,7 +1531,7 @@ xsltApplyImportsComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemApplyImportsPtr) xsltNewStylePreComp(style, XSLT_FUNC_APPLYIMPORTS);
@@ -1538,7 +1540,7 @@ xsltApplyImportsComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 }
@@ -1559,17 +1561,17 @@ xsltCallTemplateComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemCallTemplatePtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_CALLTEMPLATE);
+        xsltNewStylePreComp(style, XSLT_FUNC_CALLTEMPLATE);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_CALLTEMPLATE);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -1577,9 +1579,9 @@ xsltCallTemplateComp(xsltStylesheetPtr style, xmlNodePtr inst) {
      * Attribute "name".
      */
     xsltGetQNameProperty(style, inst, BAD_CAST "name",
-    1, &(comp->has_name), &(comp->ns), &(comp->name));
+        1, &(comp->has_name), &(comp->ns), &(comp->name));
     if (comp->ns)
-    comp->has_ns = 1;
+        comp->has_ns = 1;
 }
 
 /**
@@ -1598,17 +1600,17 @@ xsltApplyTemplatesComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemApplyTemplatesPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_APPLYTEMPLATES);
+        xsltNewStylePreComp(style, XSLT_FUNC_APPLYTEMPLATES);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_APPLYTEMPLATES);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -1616,20 +1618,20 @@ xsltApplyTemplatesComp(xsltStylesheetPtr style, xmlNodePtr inst) {
      * Attribute "mode".
      */
     xsltGetQNameProperty(style, inst, BAD_CAST "mode",
-    0, NULL, &(comp->modeURI), &(comp->mode));
+        0, NULL, &(comp->modeURI), &(comp->mode));
     /*
     * Attribute "select".
     */
     comp->select = xsltGetCNsProp(style, inst, BAD_CAST "select",
-    XSLT_NAMESPACE);
+        XSLT_NAMESPACE);
     if (comp->select != NULL) {
-    comp->comp = xsltXPathCompile(style, comp->select);
-    if (comp->comp == NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-apply-templates: could not compile select "
-        "expression '%s'\n", comp->select);
-         style->errors++;
-    }
+        comp->comp = xsltXPathCompile(style, comp->select);
+        if (comp->comp == NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-apply-templates: could not compile select "
+                "expression '%s'\n", comp->select);
+             style->errors++;
+        }
     }
     /* TODO: handle (or skip) the xsl:sort and xsl:with-param */
 }
@@ -1650,17 +1652,17 @@ xsltChooseComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemChoosePtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_CHOOSE);
+        xsltNewStylePreComp(style, XSLT_FUNC_CHOOSE);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_CHOOSE);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 }
@@ -1681,33 +1683,33 @@ xsltIfComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemIfPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_IF);
+        xsltNewStylePreComp(style, XSLT_FUNC_IF);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_IF);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->test = xsltGetCNsProp(style, inst, (const xmlChar *)"test", XSLT_NAMESPACE);
     if (comp->test == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:if : test is not defined\n");
-    if (style != NULL) style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+             "xsl:if : test is not defined\n");
+        if (style != NULL) style->errors++;
+        return;
     }
     comp->comp = xsltXPathCompile(style, comp->test);
     if (comp->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:if : could not compile test expression '%s'\n",
-                     comp->test);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+             "xsl:if : could not compile test expression '%s'\n",
+                         comp->test);
+        if (style != NULL) style->errors++;
     }
 }
 
@@ -1727,33 +1729,33 @@ xsltWhenComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemWhenPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_WHEN);
+        xsltNewStylePreComp(style, XSLT_FUNC_WHEN);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_WHEN);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->test = xsltGetCNsProp(style, inst, (const xmlChar *)"test", XSLT_NAMESPACE);
     if (comp->test == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:when : test is not defined\n");
-    if (style != NULL) style->errors++;
-    return;
+        xsltTransformError(NULL, style, inst,
+             "xsl:when : test is not defined\n");
+        if (style != NULL) style->errors++;
+        return;
     }
     comp->comp = xsltXPathCompile(style, comp->test);
     if (comp->comp == NULL) {
-    xsltTransformError(NULL, style, inst,
-         "xsl:when : could not compile test expression '%s'\n",
-                     comp->test);
-    if (style != NULL) style->errors++;
+        xsltTransformError(NULL, style, inst,
+             "xsl:when : could not compile test expression '%s'\n",
+                         comp->test);
+        if (style != NULL) style->errors++;
     }
 }
 
@@ -1773,34 +1775,34 @@ xsltForEachComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemForEachPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_FOREACH);
+        xsltNewStylePreComp(style, XSLT_FUNC_FOREACH);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_FOREACH);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select == NULL) {
-    xsltTransformError(NULL, style, inst,
-        "xsl:for-each : select is missing\n");
-    if (style != NULL) style->errors++;
-    } else {
-    comp->comp = xsltXPathCompile(style, comp->select);
-    if (comp->comp == NULL) {
         xsltTransformError(NULL, style, inst,
-     "xsl:for-each : could not compile select expression '%s'\n",
-                 comp->select);
+                "xsl:for-each : select is missing\n");
         if (style != NULL) style->errors++;
-    }
+    } else {
+        comp->comp = xsltXPathCompile(style, comp->select);
+        if (comp->comp == NULL) {
+            xsltTransformError(NULL, style, inst,
+     "xsl:for-each : could not compile select expression '%s'\n",
+                             comp->select);
+            if (style != NULL) style->errors++;
+        }
     }
     /* TODO: handle and skip the xsl:sort */
 }
@@ -1821,17 +1823,17 @@ xsltVariableComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemVariablePtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_VARIABLE);
+        xsltNewStylePreComp(style, XSLT_FUNC_VARIABLE);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_VARIABLE);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
 
     inst->psvi = comp;
     comp->inst = inst;
@@ -1843,32 +1845,32 @@ xsltVariableComp(xsltStylesheetPtr style, xmlNodePtr inst) {
     * Attribute "name".
     */
     xsltGetQNameProperty(style, inst, BAD_CAST "name",
-    1, &(comp->has_name), &(comp->ns), &(comp->name));
+        1, &(comp->has_name), &(comp->ns), &(comp->name));
     if (comp->ns)
-    comp->has_ns = 1;
+        comp->has_ns = 1;
     /*
     * Attribute "select".
     */
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select != NULL) {
 #ifndef XSLT_REFACTORED
         xmlNodePtr cur;
 #endif
-    comp->comp = xsltXPathCompile(style, comp->select);
-    if (comp->comp == NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-variable: Failed to compile the XPath expression '%s'.\n",
-        comp->select);
-        style->errors++;
-    }
+        comp->comp = xsltXPathCompile(style, comp->select);
+        if (comp->comp == NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-variable: Failed to compile the XPath expression '%s'.\n",
+                comp->select);
+            style->errors++;
+        }
 #ifdef XSLT_REFACTORED
-    if (inst->children != NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-variable: There must be no child nodes, since the "
-        "attribute 'select' was specified.\n");
-        style->errors++;
-    }
+        if (inst->children != NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-variable: There must be no child nodes, since the "
+                "attribute 'select' was specified.\n");
+            style->errors++;
+        }
 #else
         for (cur = inst->children; cur != NULL; cur = cur->next) {
             if (cur->type != XML_COMMENT_NODE &&
@@ -1900,17 +1902,17 @@ xsltParamComp(xsltStylesheetPtr style, xmlNodePtr inst) {
 #endif
 
     if ((style == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleItemParamPtr)
-    xsltNewStylePreComp(style, XSLT_FUNC_PARAM);
+        xsltNewStylePreComp(style, XSLT_FUNC_PARAM);
 #else
     comp = xsltNewStylePreComp(style, XSLT_FUNC_PARAM);
 #endif
 
     if (comp == NULL)
-    return;
+        return;
     inst->psvi = comp;
     comp->inst = inst;
 
@@ -1918,35 +1920,35 @@ xsltParamComp(xsltStylesheetPtr style, xmlNodePtr inst) {
      * Attribute "name".
      */
     xsltGetQNameProperty(style, inst, BAD_CAST "name",
-    1, &(comp->has_name), &(comp->ns), &(comp->name));
+        1, &(comp->has_name), &(comp->ns), &(comp->name));
     if (comp->ns)
-    comp->has_ns = 1;
+        comp->has_ns = 1;
     /*
     * Attribute "select".
     */
     comp->select = xsltGetCNsProp(style, inst, (const xmlChar *)"select",
-                            XSLT_NAMESPACE);
+                                XSLT_NAMESPACE);
     if (comp->select != NULL) {
-    comp->comp = xsltXPathCompile(style, comp->select);
-    if (comp->comp == NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-param: could not compile select expression '%s'.\n",
-        comp->select);
-        style->errors++;
-    }
-    if (inst->children != NULL) {
-        xsltTransformError(NULL, style, inst,
-        "XSLT-param: The content should be empty since the "
-        "attribute 'select' is present.\n");
-        style->warnings++;
-    }
+        comp->comp = xsltXPathCompile(style, comp->select);
+        if (comp->comp == NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-param: could not compile select expression '%s'.\n",
+                comp->select);
+            style->errors++;
+        }
+        if (inst->children != NULL) {
+            xsltTransformError(NULL, style, inst,
+                "XSLT-param: The content should be empty since the "
+                "attribute 'select' is present.\n");
+            style->warnings++;
+        }
     }
 }
 
 /************************************************************************
- *                                  *
- *          Generic interface                   *
- *                                  *
+ *                                                                      *
+ *                  Generic interface                                   *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1960,16 +1962,16 @@ xsltFreeStylePreComps(xsltStylesheetPtr style) {
     xsltElemPreCompPtr cur, next;
 
     if (style == NULL)
-    return;
+        return;
 
     cur = style->preComps;
     while (cur != NULL) {
-    next = cur->next;
-    if (cur->type == XSLT_FUNC_EXTENSION)
-        cur->free(cur);
-    else
-        xsltFreeStylePreComp((xsltStylePreCompPtr) cur);
-    cur = next;
+        next = cur->next;
+        if (cur->type == XSLT_FUNC_EXTENSION)
+            cur->free(cur);
+        else
+            xsltFreeStylePreComp((xsltStylePreCompPtr) cur);
+        cur = next;
     }
 }
 
@@ -1991,198 +1993,198 @@ xsltStylePreCompute(xsltStylesheetPtr style, xmlNodePtr node) {
     *  the parsing mechanism for all elements in the XSLT namespace.
     */
     if (style == NULL) {
-    if ((node != NULL) && (node->type == XML_ELEMENT_NODE))
-        node->psvi = NULL;
-    return;
+        if ((node != NULL) && (node->type == XML_ELEMENT_NODE))
+            node->psvi = NULL;
+        return;
     }
     if (node == NULL)
-    return;
+        return;
     if (! IS_XSLT_ELEM_FAST(node))
-    return;
+        return;
 
     node->psvi = NULL;
     if (XSLT_CCTXT(style)->inode->type != 0) {
-    switch (XSLT_CCTXT(style)->inode->type) {
-        case XSLT_FUNC_APPLYTEMPLATES:
-        xsltApplyTemplatesComp(style, node);
-        break;
-        case XSLT_FUNC_WITHPARAM:
-        xsltWithParamComp(style, node);
-        break;
-        case XSLT_FUNC_VALUEOF:
-        xsltValueOfComp(style, node);
-        break;
-        case XSLT_FUNC_COPY:
-        xsltCopyComp(style, node);
-        break;
-        case XSLT_FUNC_COPYOF:
-        xsltCopyOfComp(style, node);
-        break;
-        case XSLT_FUNC_IF:
-        xsltIfComp(style, node);
-        break;
-        case XSLT_FUNC_CHOOSE:
-        xsltChooseComp(style, node);
-        break;
-        case XSLT_FUNC_WHEN:
-        xsltWhenComp(style, node);
-        break;
-        case XSLT_FUNC_OTHERWISE:
-        /* NOP yet */
-        return;
-        case XSLT_FUNC_FOREACH:
-        xsltForEachComp(style, node);
-        break;
-        case XSLT_FUNC_APPLYIMPORTS:
-        xsltApplyImportsComp(style, node);
-        break;
-        case XSLT_FUNC_ATTRIBUTE:
-        xsltAttributeComp(style, node);
-        break;
-        case XSLT_FUNC_ELEMENT:
-        xsltElementComp(style, node);
-        break;
-        case XSLT_FUNC_SORT:
-        xsltSortComp(style, node);
-        break;
-        case XSLT_FUNC_COMMENT:
-        xsltCommentComp(style, node);
-        break;
-        case XSLT_FUNC_NUMBER:
-        xsltNumberComp(style, node);
-        break;
-        case XSLT_FUNC_PI:
-        xsltProcessingInstructionComp(style, node);
-        break;
-        case XSLT_FUNC_CALLTEMPLATE:
-        xsltCallTemplateComp(style, node);
-        break;
-        case XSLT_FUNC_PARAM:
-        xsltParamComp(style, node);
-        break;
-        case XSLT_FUNC_VARIABLE:
-        xsltVariableComp(style, node);
-        break;
-        case XSLT_FUNC_FALLBACK:
-        /* NOP yet */
-        return;
-        case XSLT_FUNC_DOCUMENT:
-        /* The extra one */
-        node->psvi = (void *) xsltDocumentComp(style, node,
-            xsltDocumentElem);
-        break;
-        case XSLT_FUNC_MESSAGE:
-        /* NOP yet */
-        return;
-        default:
-        /*
-        * NOTE that xsl:text, xsl:template, xsl:stylesheet,
-        *  xsl:transform, xsl:import, xsl:include are not expected
-        *  to be handed over to this function.
-        */
-        xsltTransformError(NULL, style, node,
-            "Internal error: (xsltStylePreCompute) cannot handle "
-            "the XSLT element '%s'.\n", node->name);
-        style->errors++;
-        return;
-    }
-    } else {
-    /*
-    * Fallback to string comparison.
-    */
-    if (IS_XSLT_NAME(node, "apply-templates")) {
-        xsltApplyTemplatesComp(style, node);
-    } else if (IS_XSLT_NAME(node, "with-param")) {
-        xsltWithParamComp(style, node);
-    } else if (IS_XSLT_NAME(node, "value-of")) {
-        xsltValueOfComp(style, node);
-    } else if (IS_XSLT_NAME(node, "copy")) {
-        xsltCopyComp(style, node);
-    } else if (IS_XSLT_NAME(node, "copy-of")) {
-        xsltCopyOfComp(style, node);
-    } else if (IS_XSLT_NAME(node, "if")) {
-        xsltIfComp(style, node);
-    } else if (IS_XSLT_NAME(node, "choose")) {
-        xsltChooseComp(style, node);
-    } else if (IS_XSLT_NAME(node, "when")) {
-        xsltWhenComp(style, node);
-    } else if (IS_XSLT_NAME(node, "otherwise")) {
-        /* NOP yet */
-        return;
-    } else if (IS_XSLT_NAME(node, "for-each")) {
-        xsltForEachComp(style, node);
-    } else if (IS_XSLT_NAME(node, "apply-imports")) {
-        xsltApplyImportsComp(style, node);
-    } else if (IS_XSLT_NAME(node, "attribute")) {
-        xsltAttributeComp(style, node);
-    } else if (IS_XSLT_NAME(node, "element")) {
-        xsltElementComp(style, node);
-    } else if (IS_XSLT_NAME(node, "sort")) {
-        xsltSortComp(style, node);
-    } else if (IS_XSLT_NAME(node, "comment")) {
-        xsltCommentComp(style, node);
-    } else if (IS_XSLT_NAME(node, "number")) {
-        xsltNumberComp(style, node);
-    } else if (IS_XSLT_NAME(node, "processing-instruction")) {
-        xsltProcessingInstructionComp(style, node);
-    } else if (IS_XSLT_NAME(node, "call-template")) {
-        xsltCallTemplateComp(style, node);
-    } else if (IS_XSLT_NAME(node, "param")) {
-        xsltParamComp(style, node);
-    } else if (IS_XSLT_NAME(node, "variable")) {
-        xsltVariableComp(style, node);
-    } else if (IS_XSLT_NAME(node, "fallback")) {
-        /* NOP yet */
-        return;
-    } else if (IS_XSLT_NAME(node, "document")) {
-        /* The extra one */
-        node->psvi = (void *) xsltDocumentComp(style, node,
-        xsltDocumentElem);
-    } else if (IS_XSLT_NAME(node, "output")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "preserve-space")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "strip-space")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "key")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "message")) {
-        return;
-    } else if (IS_XSLT_NAME(node, "attribute-set")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "namespace-alias")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "decimal-format")) {
-        /* Top-level */
-        return;
-    } else if (IS_XSLT_NAME(node, "include")) {
-        /* Top-level */
+        switch (XSLT_CCTXT(style)->inode->type) {
+            case XSLT_FUNC_APPLYTEMPLATES:
+                xsltApplyTemplatesComp(style, node);
+                break;
+            case XSLT_FUNC_WITHPARAM:
+                xsltWithParamComp(style, node);
+                break;
+            case XSLT_FUNC_VALUEOF:
+                xsltValueOfComp(style, node);
+                break;
+            case XSLT_FUNC_COPY:
+                xsltCopyComp(style, node);
+                break;
+            case XSLT_FUNC_COPYOF:
+                xsltCopyOfComp(style, node);
+                break;
+            case XSLT_FUNC_IF:
+                xsltIfComp(style, node);
+                break;
+            case XSLT_FUNC_CHOOSE:
+                xsltChooseComp(style, node);
+                break;
+            case XSLT_FUNC_WHEN:
+                xsltWhenComp(style, node);
+                break;
+            case XSLT_FUNC_OTHERWISE:
+                /* NOP yet */
+                return;
+            case XSLT_FUNC_FOREACH:
+                xsltForEachComp(style, node);
+                break;
+            case XSLT_FUNC_APPLYIMPORTS:
+                xsltApplyImportsComp(style, node);
+                break;
+            case XSLT_FUNC_ATTRIBUTE:
+                xsltAttributeComp(style, node);
+                break;
+            case XSLT_FUNC_ELEMENT:
+                xsltElementComp(style, node);
+                break;
+            case XSLT_FUNC_SORT:
+                xsltSortComp(style, node);
+                break;
+            case XSLT_FUNC_COMMENT:
+                xsltCommentComp(style, node);
+                break;
+            case XSLT_FUNC_NUMBER:
+                xsltNumberComp(style, node);
+                break;
+            case XSLT_FUNC_PI:
+                xsltProcessingInstructionComp(style, node);
+                break;
+            case XSLT_FUNC_CALLTEMPLATE:
+                xsltCallTemplateComp(style, node);
+                break;
+            case XSLT_FUNC_PARAM:
+                xsltParamComp(style, node);
+                break;
+            case XSLT_FUNC_VARIABLE:
+                xsltVariableComp(style, node);
+                break;
+            case XSLT_FUNC_FALLBACK:
+                /* NOP yet */
+                return;
+            case XSLT_FUNC_DOCUMENT:
+                /* The extra one */
+                node->psvi = (void *) xsltDocumentComp(style, node,
+                    xsltDocumentElem);
+                break;
+            case XSLT_FUNC_MESSAGE:
+                /* NOP yet */
+                return;
+            default:
+                /*
+                * NOTE that xsl:text, xsl:template, xsl:stylesheet,
+                *  xsl:transform, xsl:import, xsl:include are not expected
+                *  to be handed over to this function.
+                */
+                xsltTransformError(NULL, style, node,
+                    "Internal error: (xsltStylePreCompute) cannot handle "
+                    "the XSLT element '%s'.\n", node->name);
+                style->errors++;
+                return;
+        }
     } else {
         /*
-        * NOTE that xsl:text, xsl:template, xsl:stylesheet,
-        *  xsl:transform, xsl:import, xsl:include are not expected
-        *  to be handed over to this function.
+        * Fallback to string comparison.
         */
-        xsltTransformError(NULL, style, node,
-        "Internal error: (xsltStylePreCompute) cannot handle "
-        "the XSLT element '%s'.\n", node->name);
-        style->errors++;
-        return;
-    }
+        if (IS_XSLT_NAME(node, "apply-templates")) {
+            xsltApplyTemplatesComp(style, node);
+        } else if (IS_XSLT_NAME(node, "with-param")) {
+            xsltWithParamComp(style, node);
+        } else if (IS_XSLT_NAME(node, "value-of")) {
+            xsltValueOfComp(style, node);
+        } else if (IS_XSLT_NAME(node, "copy")) {
+            xsltCopyComp(style, node);
+        } else if (IS_XSLT_NAME(node, "copy-of")) {
+            xsltCopyOfComp(style, node);
+        } else if (IS_XSLT_NAME(node, "if")) {
+            xsltIfComp(style, node);
+        } else if (IS_XSLT_NAME(node, "choose")) {
+            xsltChooseComp(style, node);
+        } else if (IS_XSLT_NAME(node, "when")) {
+            xsltWhenComp(style, node);
+        } else if (IS_XSLT_NAME(node, "otherwise")) {
+            /* NOP yet */
+            return;
+        } else if (IS_XSLT_NAME(node, "for-each")) {
+            xsltForEachComp(style, node);
+        } else if (IS_XSLT_NAME(node, "apply-imports")) {
+            xsltApplyImportsComp(style, node);
+        } else if (IS_XSLT_NAME(node, "attribute")) {
+            xsltAttributeComp(style, node);
+        } else if (IS_XSLT_NAME(node, "element")) {
+            xsltElementComp(style, node);
+        } else if (IS_XSLT_NAME(node, "sort")) {
+            xsltSortComp(style, node);
+        } else if (IS_XSLT_NAME(node, "comment")) {
+            xsltCommentComp(style, node);
+        } else if (IS_XSLT_NAME(node, "number")) {
+            xsltNumberComp(style, node);
+        } else if (IS_XSLT_NAME(node, "processing-instruction")) {
+            xsltProcessingInstructionComp(style, node);
+        } else if (IS_XSLT_NAME(node, "call-template")) {
+            xsltCallTemplateComp(style, node);
+        } else if (IS_XSLT_NAME(node, "param")) {
+            xsltParamComp(style, node);
+        } else if (IS_XSLT_NAME(node, "variable")) {
+            xsltVariableComp(style, node);
+        } else if (IS_XSLT_NAME(node, "fallback")) {
+            /* NOP yet */
+            return;
+        } else if (IS_XSLT_NAME(node, "document")) {
+            /* The extra one */
+            node->psvi = (void *) xsltDocumentComp(style, node,
+                xsltDocumentElem);
+        } else if (IS_XSLT_NAME(node, "output")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "preserve-space")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "strip-space")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "key")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "message")) {
+            return;
+        } else if (IS_XSLT_NAME(node, "attribute-set")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "namespace-alias")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "decimal-format")) {
+            /* Top-level */
+            return;
+        } else if (IS_XSLT_NAME(node, "include")) {
+            /* Top-level */
+        } else {
+            /*
+            * NOTE that xsl:text, xsl:template, xsl:stylesheet,
+            *  xsl:transform, xsl:import, xsl:include are not expected
+            *  to be handed over to this function.
+            */
+            xsltTransformError(NULL, style, node,
+                "Internal error: (xsltStylePreCompute) cannot handle "
+                "the XSLT element '%s'.\n", node->name);
+                style->errors++;
+            return;
+        }
     }
     /*
     * Assign the current list of in-scope namespaces to the
     * item. This is needed for XPath expressions.
     */
     if (node->psvi != NULL) {
-    ((xsltStylePreCompPtr) node->psvi)->inScopeNs =
-        XSLT_CCTXT(style)->inode->inScopeNs;
+        ((xsltStylePreCompPtr) node->psvi)->inScopeNs =
+            XSLT_CCTXT(style)->inode->inScopeNs;
     }
 }
 
@@ -2208,169 +2210,169 @@ xsltStylePreCompute(xsltStylesheetPtr style, xmlNodePtr inst) {
     */
     if ((inst == NULL) || (inst->type != XML_ELEMENT_NODE) ||
         (inst->psvi != NULL))
-    return;
+        return;
 
     if (IS_XSLT_ELEM(inst)) {
-    xsltStylePreCompPtr cur;
+        xsltStylePreCompPtr cur;
 
-    if (IS_XSLT_NAME(inst, "apply-templates")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltApplyTemplatesComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "with-param")) {
-        xsltCheckParentElement(style, inst, BAD_CAST "apply-templates",
-                               BAD_CAST "call-template");
-        xsltWithParamComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "value-of")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltValueOfComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "copy")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltCopyComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "copy-of")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltCopyOfComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "if")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltIfComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "when")) {
-        xsltCheckParentElement(style, inst, BAD_CAST "choose", NULL);
-        xsltWhenComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "choose")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltChooseComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "for-each")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltForEachComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "apply-imports")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltApplyImportsComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "attribute")) {
-        xmlNodePtr parent = inst->parent;
-
-        if ((parent == NULL) ||
-            (parent->type != XML_ELEMENT_NODE) || (parent->ns == NULL) ||
-        ((parent->ns != inst->ns) &&
-         (!xmlStrEqual(parent->ns->href, inst->ns->href))) ||
-        (!xmlStrEqual(parent->name, BAD_CAST "attribute-set"))) {
-        xsltCheckInstructionElement(style, inst);
-        }
-        xsltAttributeComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "element")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltElementComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "text")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltTextComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "sort")) {
-        xsltCheckParentElement(style, inst, BAD_CAST "apply-templates",
-                               BAD_CAST "for-each");
-        xsltSortComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "comment")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltCommentComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "number")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltNumberComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "processing-instruction")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltProcessingInstructionComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "call-template")) {
-        xsltCheckInstructionElement(style, inst);
-        xsltCallTemplateComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "param")) {
-        if (xsltCheckTopLevelElement(style, inst, 0) == 0)
+        if (IS_XSLT_NAME(inst, "apply-templates")) {
             xsltCheckInstructionElement(style, inst);
-        xsltParamComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "variable")) {
-        if (xsltCheckTopLevelElement(style, inst, 0) == 0)
+            xsltApplyTemplatesComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "with-param")) {
+            xsltCheckParentElement(style, inst, BAD_CAST "apply-templates",
+                                   BAD_CAST "call-template");
+            xsltWithParamComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "value-of")) {
             xsltCheckInstructionElement(style, inst);
-        xsltVariableComp(style, inst);
-    } else if (IS_XSLT_NAME(inst, "otherwise")) {
-        xsltCheckParentElement(style, inst, BAD_CAST "choose", NULL);
-        xsltCheckInstructionElement(style, inst);
-        return;
-    } else if (IS_XSLT_NAME(inst, "template")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "output")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "preserve-space")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "strip-space")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if ((IS_XSLT_NAME(inst, "stylesheet")) ||
-               (IS_XSLT_NAME(inst, "transform"))) {
-        xmlNodePtr parent = inst->parent;
+            xsltValueOfComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "copy")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltCopyComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "copy-of")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltCopyOfComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "if")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltIfComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "when")) {
+            xsltCheckParentElement(style, inst, BAD_CAST "choose", NULL);
+            xsltWhenComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "choose")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltChooseComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "for-each")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltForEachComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "apply-imports")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltApplyImportsComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "attribute")) {
+            xmlNodePtr parent = inst->parent;
 
-        if ((parent == NULL) || (parent->type != XML_DOCUMENT_NODE)) {
-        xsltTransformError(NULL, style, inst,
-            "element %s only allowed only as root element\n",
-                   inst->name);
-        style->errors++;
+            if ((parent == NULL) ||
+                (parent->type != XML_ELEMENT_NODE) || (parent->ns == NULL) ||
+                ((parent->ns != inst->ns) &&
+                 (!xmlStrEqual(parent->ns->href, inst->ns->href))) ||
+                (!xmlStrEqual(parent->name, BAD_CAST "attribute-set"))) {
+                xsltCheckInstructionElement(style, inst);
+            }
+            xsltAttributeComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "element")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltElementComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "text")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltTextComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "sort")) {
+            xsltCheckParentElement(style, inst, BAD_CAST "apply-templates",
+                                   BAD_CAST "for-each");
+            xsltSortComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "comment")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltCommentComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "number")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltNumberComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "processing-instruction")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltProcessingInstructionComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "call-template")) {
+            xsltCheckInstructionElement(style, inst);
+            xsltCallTemplateComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "param")) {
+            if (xsltCheckTopLevelElement(style, inst, 0) == 0)
+                xsltCheckInstructionElement(style, inst);
+            xsltParamComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "variable")) {
+            if (xsltCheckTopLevelElement(style, inst, 0) == 0)
+                xsltCheckInstructionElement(style, inst);
+            xsltVariableComp(style, inst);
+        } else if (IS_XSLT_NAME(inst, "otherwise")) {
+            xsltCheckParentElement(style, inst, BAD_CAST "choose", NULL);
+            xsltCheckInstructionElement(style, inst);
+            return;
+        } else if (IS_XSLT_NAME(inst, "template")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "output")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "preserve-space")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "strip-space")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if ((IS_XSLT_NAME(inst, "stylesheet")) ||
+                   (IS_XSLT_NAME(inst, "transform"))) {
+            xmlNodePtr parent = inst->parent;
+
+            if ((parent == NULL) || (parent->type != XML_DOCUMENT_NODE)) {
+                xsltTransformError(NULL, style, inst,
+                    "element %s only allowed only as root element\n",
+                                   inst->name);
+                style->errors++;
+            }
+            return;
+        } else if (IS_XSLT_NAME(inst, "key")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "message")) {
+            xsltCheckInstructionElement(style, inst);
+            return;
+        } else if (IS_XSLT_NAME(inst, "attribute-set")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "namespace-alias")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "include")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "import")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "decimal-format")) {
+            xsltCheckTopLevelElement(style, inst, 1);
+            return;
+        } else if (IS_XSLT_NAME(inst, "fallback")) {
+            xsltCheckInstructionElement(style, inst);
+            return;
+        } else if (IS_XSLT_NAME(inst, "document")) {
+            xsltCheckInstructionElement(style, inst);
+            inst->psvi = (void *) xsltDocumentComp(style, inst,
+                                xsltDocumentElem);
+        } else if ((style == NULL) || (style->forwards_compatible == 0)) {
+            xsltTransformError(NULL, style, inst,
+                 "xsltStylePreCompute: unknown xsl:%s\n", inst->name);
+            if (style != NULL) style->warnings++;
         }
-        return;
-    } else if (IS_XSLT_NAME(inst, "key")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "message")) {
-        xsltCheckInstructionElement(style, inst);
-        return;
-    } else if (IS_XSLT_NAME(inst, "attribute-set")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "namespace-alias")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "include")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "import")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "decimal-format")) {
-        xsltCheckTopLevelElement(style, inst, 1);
-        return;
-    } else if (IS_XSLT_NAME(inst, "fallback")) {
-        xsltCheckInstructionElement(style, inst);
-        return;
-    } else if (IS_XSLT_NAME(inst, "document")) {
-        xsltCheckInstructionElement(style, inst);
-        inst->psvi = (void *) xsltDocumentComp(style, inst,
-                xsltDocumentElem);
-    } else if ((style == NULL) || (style->forwards_compatible == 0)) {
-        xsltTransformError(NULL, style, inst,
-         "xsltStylePreCompute: unknown xsl:%s\n", inst->name);
-        if (style != NULL) style->warnings++;
-    }
 
-    cur = (xsltStylePreCompPtr) inst->psvi;
-    /*
-    * A ns-list is build for every XSLT item in the
-    * node-tree. This is needed for XPath expressions.
-    */
-    if (cur != NULL) {
-        int i = 0;
+        cur = (xsltStylePreCompPtr) inst->psvi;
+        /*
+        * A ns-list is build for every XSLT item in the
+        * node-tree. This is needed for XPath expressions.
+        */
+        if (cur != NULL) {
+            int i = 0;
 
-        cur->nsList = xmlGetNsList(inst->doc, inst);
+            cur->nsList = xmlGetNsList(inst->doc, inst);
             if (cur->nsList != NULL) {
-        while (cur->nsList[i] != NULL)
-            i++;
+                while (cur->nsList[i] != NULL)
+                    i++;
+            }
+            cur->nsNr = i;
         }
-        cur->nsNr = i;
-    }
     } else {
-    inst->psvi =
-        (void *) xsltPreComputeExtModuleElement(style, inst);
+        inst->psvi =
+            (void *) xsltPreComputeExtModuleElement(style, inst);
 
-    /*
-     * Unknown element, maybe registered at the context
-     * level. Mark it for later recognition.
-     */
-    if (inst->psvi == NULL)
-        inst->psvi = (void *) xsltExtMarker;
+        /*
+         * Unknown element, maybe registered at the context
+         * level. Mark it for later recognition.
+         */
+        if (inst->psvi == NULL)
+            inst->psvi = (void *) xsltExtMarker;
     }
 }
 #endif /* XSLT_REFACTORED */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/preproc.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/preproc.h
@@ -22,18 +22,18 @@ extern "C" {
 /*
  * Interfaces
  */
-extern const xmlChar *xsltExtMarker;
+XSLTPUBVAR const xmlChar *xsltExtMarker;
 
 XSLTPUBFUN xsltElemPreCompPtr XSLTCALL
-        xsltDocumentComp    (xsltStylesheetPtr style,
-                     xmlNodePtr inst,
-                     xsltTransformFunction function);
+                xsltDocumentComp        (xsltStylesheetPtr style,
+                                         xmlNodePtr inst,
+                                         xsltTransformFunction function);
 
 XSLTPUBFUN void XSLTCALL
-        xsltStylePreCompute (xsltStylesheetPtr style,
-                     xmlNodePtr inst);
+                xsltStylePreCompute     (xsltStylesheetPtr style,
+                                         xmlNodePtr inst);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeStylePreComps   (xsltStylesheetPtr style);
+                xsltFreeStylePreComps   (xsltStylesheetPtr style);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/security.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/security.c
@@ -73,9 +73,9 @@ struct _xsltSecurityPrefs {
 static xsltSecurityPrefsPtr xsltDefaultSecurityPrefs = NULL;
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -93,9 +93,9 @@ xsltNewSecurityPrefs(void) {
 
     ret = (xsltSecurityPrefsPtr) xmlMalloc(sizeof(xsltSecurityPrefs));
     if (ret == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewSecurityPrefs : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewSecurityPrefs : malloc failed\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltSecurityPrefs));
     return(ret);
@@ -110,7 +110,7 @@ xsltNewSecurityPrefs(void) {
 void
 xsltFreeSecurityPrefs(xsltSecurityPrefsPtr sec) {
     if (sec == NULL)
-    return;
+        return;
     xmlFree(sec);
 }
 
@@ -129,7 +129,7 @@ xsltSetSecurityPrefs(xsltSecurityPrefsPtr sec, xsltSecurityOption option,
                      xsltSecurityCheck func) {
     xsltInitGlobals();
     if (sec == NULL)
-    return(-1);
+        return(-1);
     switch (option) {
         case XSLT_SECPREF_READ_FILE:
             sec->readFile = func; return(0);
@@ -157,7 +157,7 @@ xsltSetSecurityPrefs(xsltSecurityPrefsPtr sec, xsltSecurityOption option,
 xsltSecurityCheck
 xsltGetSecurityPrefs(xsltSecurityPrefsPtr sec, xsltSecurityOption option) {
     if (sec == NULL)
-    return(NULL);
+        return(NULL);
     switch (option) {
         case XSLT_SECPREF_READ_FILE:
             return(sec->readFile);
@@ -208,9 +208,9 @@ xsltGetDefaultSecurityPrefs(void) {
  */
 int
 xsltSetCtxtSecurityPrefs(xsltSecurityPrefsPtr sec,
-                     xsltTransformContextPtr ctxt) {
+                         xsltTransformContextPtr ctxt) {
     if (ctxt == NULL)
-    return(-1);
+        return(-1);
     ctxt->sec = (void *) sec;
     return(0);
 }
@@ -228,8 +228,8 @@ xsltSetCtxtSecurityPrefs(xsltSecurityPrefsPtr sec,
  */
 int
 xsltSecurityAllow(xsltSecurityPrefsPtr sec ATTRIBUTE_UNUSED,
-              xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
-          const char *value ATTRIBUTE_UNUSED) {
+                  xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
+                  const char *value ATTRIBUTE_UNUSED) {
     return(1);
 }
 
@@ -245,15 +245,15 @@ xsltSecurityAllow(xsltSecurityPrefsPtr sec ATTRIBUTE_UNUSED,
  */
 int
 xsltSecurityForbid(xsltSecurityPrefsPtr sec ATTRIBUTE_UNUSED,
-              xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
-          const char *value ATTRIBUTE_UNUSED) {
+                  xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
+                  const char *value ATTRIBUTE_UNUSED) {
     return(0);
 }
 
 /************************************************************************
- *                                  *
- *          Internal interfaces             *
- *                                  *
+ *                                                                      *
+ *                      Internal interfaces                             *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -282,11 +282,11 @@ xsltCheckFilename (const char *path)
 #if defined(_WIN32) && !defined(__CYGWIN__)
     DWORD dwAttrs;
 
-    dwAttrs = GetFileAttributes(path);
+    dwAttrs = GetFileAttributesA(path);
     if (dwAttrs != INVALID_FILE_ATTRIBUTES) {
         if (dwAttrs & FILE_ATTRIBUTE_DIRECTORY) {
             return 2;
-        }
+                }
     }
 #endif
 
@@ -304,8 +304,8 @@ xsltCheckFilename (const char *path)
 
 static int
 xsltCheckWritePath(xsltSecurityPrefsPtr sec,
-           xsltTransformContextPtr ctxt,
-           const char *path)
+                   xsltTransformContextPtr ctxt,
+                   const char *path)
 {
     int ret;
     xsltSecurityCheck check;
@@ -313,41 +313,41 @@ xsltCheckWritePath(xsltSecurityPrefsPtr sec,
 
     check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_WRITE_FILE);
     if (check != NULL) {
-    ret = check(sec, ctxt, path);
-    if (ret == 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-                   "File write for %s refused\n", path);
-        return(0);
-    }
+        ret = check(sec, ctxt, path);
+        if (ret == 0) {
+            xsltTransformError(ctxt, NULL, NULL,
+                               "File write for %s refused\n", path);
+            return(0);
+        }
     }
 
     directory = xmlParserGetDirectory (path);
 
     if (directory != NULL) {
-    ret = xsltCheckFilename(directory);
-    if (ret == 0) {
-        /*
-         * The directory doesn't exist check for creation
-         */
-        check = xsltGetSecurityPrefs(sec,
-                     XSLT_SECPREF_CREATE_DIRECTORY);
-        if (check != NULL) {
-        ret = check(sec, ctxt, directory);
+        ret = xsltCheckFilename(directory);
         if (ret == 0) {
-            xsltTransformError(ctxt, NULL, NULL,
-                       "Directory creation for %s refused\n",
-                       path);
-            xmlFree(directory);
-            return(0);
+            /*
+             * The directory doesn't exist check for creation
+             */
+            check = xsltGetSecurityPrefs(sec,
+                                         XSLT_SECPREF_CREATE_DIRECTORY);
+            if (check != NULL) {
+                ret = check(sec, ctxt, directory);
+                if (ret == 0) {
+                    xsltTransformError(ctxt, NULL, NULL,
+                                       "Directory creation for %s refused\n",
+                                       path);
+                    xmlFree(directory);
+                    return(0);
+                }
+            }
+            ret = xsltCheckWritePath(sec, ctxt, directory);
+            if (ret == 1)
+                ret = mkdir(directory, 0755);
         }
-        }
-        ret = xsltCheckWritePath(sec, ctxt, directory);
-        if (ret == 1)
-        ret = mkdir(directory, 0755);
-    }
-    xmlFree(directory);
-    if (ret < 0)
-        return(ret);
+        xmlFree(directory);
+        if (ret < 0)
+            return(ret);
     }
 
     return(1);
@@ -366,7 +366,7 @@ xsltCheckWritePath(xsltSecurityPrefsPtr sec,
  */
 int
 xsltCheckWrite(xsltSecurityPrefsPtr sec,
-           xsltTransformContextPtr ctxt, const xmlChar *URL) {
+               xsltTransformContextPtr ctxt, const xmlChar *URL) {
     int ret;
     xmlURIPtr uri;
     xsltSecurityCheck check;
@@ -374,15 +374,15 @@ xsltCheckWrite(xsltSecurityPrefsPtr sec,
     uri = xmlParseURI((const char *)URL);
     if (uri == NULL) {
         uri = xmlCreateURI();
-    if (uri == NULL) {
-        xsltTransformError(ctxt, NULL, NULL,
-         "xsltCheckWrite: out of memory for %s\n", URL);
-        return(-1);
-    }
-    uri->path = (char *)xmlStrdup(URL);
+        if (uri == NULL) {
+            xsltTransformError(ctxt, NULL, NULL,
+             "xsltCheckWrite: out of memory for %s\n", URL);
+            return(-1);
+        }
+        uri->path = (char *)xmlStrdup(URL);
     }
     if ((uri->scheme == NULL) ||
-    (xmlStrEqual(BAD_CAST uri->scheme, BAD_CAST "file"))) {
+        (xmlStrEqual(BAD_CAST uri->scheme, BAD_CAST "file"))) {
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
         if ((uri->path)&&(uri->path[0]=='/')&&
@@ -394,27 +394,27 @@ xsltCheckWrite(xsltSecurityPrefsPtr sec,
             /*
              * Check if we are allowed to write this file
              */
-        ret = xsltCheckWritePath(sec, ctxt, uri->path);
+            ret = xsltCheckWritePath(sec, ctxt, uri->path);
         }
 
-    if (ret <= 0) {
-        xmlFreeURI(uri);
-        return(ret);
-    }
-    } else {
-    /*
-     * Check if we are allowed to write this network resource
-     */
-    check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_WRITE_NETWORK);
-    if (check != NULL) {
-        ret = check(sec, ctxt, (const char *)URL);
-        if (ret == 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-                 "File write for %s refused\n", URL);
-        xmlFreeURI(uri);
-        return(0);
+        if (ret <= 0) {
+            xmlFreeURI(uri);
+            return(ret);
         }
-    }
+    } else {
+        /*
+         * Check if we are allowed to write this network resource
+         */
+        check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_WRITE_NETWORK);
+        if (check != NULL) {
+            ret = check(sec, ctxt, (const char *)URL);
+            if (ret == 0) {
+                xsltTransformError(ctxt, NULL, NULL,
+                             "File write for %s refused\n", URL);
+                xmlFreeURI(uri);
+                return(0);
+            }
+        }
     }
     xmlFreeURI(uri);
     return(1);
@@ -433,48 +433,48 @@ xsltCheckWrite(xsltSecurityPrefsPtr sec,
  */
 int
 xsltCheckRead(xsltSecurityPrefsPtr sec,
-          xsltTransformContextPtr ctxt, const xmlChar *URL) {
+              xsltTransformContextPtr ctxt, const xmlChar *URL) {
     int ret;
     xmlURIPtr uri;
     xsltSecurityCheck check;
 
     uri = xmlParseURI((const char *)URL);
     if (uri == NULL) {
-    xsltTransformError(ctxt, NULL, NULL,
-     "xsltCheckRead: URL parsing failed for %s\n",
-             URL);
-    return(-1);
+        xsltTransformError(ctxt, NULL, NULL,
+         "xsltCheckRead: URL parsing failed for %s\n",
+                         URL);
+        return(-1);
     }
     if ((uri->scheme == NULL) ||
-    (xmlStrEqual(BAD_CAST uri->scheme, BAD_CAST "file"))) {
+        (xmlStrEqual(BAD_CAST uri->scheme, BAD_CAST "file"))) {
 
-    /*
-     * Check if we are allowed to read this file
-     */
-    check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_READ_FILE);
-    if (check != NULL) {
-        ret = check(sec, ctxt, uri->path);
-        if (ret == 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-                 "Local file read for %s refused\n", URL);
-        xmlFreeURI(uri);
-        return(0);
+        /*
+         * Check if we are allowed to read this file
+         */
+        check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_READ_FILE);
+        if (check != NULL) {
+            ret = check(sec, ctxt, uri->path);
+            if (ret == 0) {
+                xsltTransformError(ctxt, NULL, NULL,
+                             "Local file read for %s refused\n", URL);
+                xmlFreeURI(uri);
+                return(0);
+            }
         }
-    }
     } else {
-    /*
-     * Check if we are allowed to write this network resource
-     */
-    check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_READ_NETWORK);
-    if (check != NULL) {
-        ret = check(sec, ctxt, (const char *)URL);
-        if (ret == 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-                 "Network file read for %s refused\n", URL);
-        xmlFreeURI(uri);
-        return(0);
+        /*
+         * Check if we are allowed to write this network resource
+         */
+        check = xsltGetSecurityPrefs(sec, XSLT_SECPREF_READ_NETWORK);
+        if (check != NULL) {
+            ret = check(sec, ctxt, (const char *)URL);
+            if (ret == 0) {
+                xsltTransformError(ctxt, NULL, NULL,
+                             "Network file read for %s refused\n", URL);
+                xmlFreeURI(uri);
+                return(0);
+            }
         }
-    }
     }
     xmlFreeURI(uri);
     return(1);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/security.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/security.h
@@ -48,53 +48,53 @@ typedef enum {
  * User provided function to check the value of a string like a file
  * path or an URL ...
  */
-typedef int (*xsltSecurityCheck)    (xsltSecurityPrefsPtr sec,
-                     xsltTransformContextPtr ctxt,
-                     const char *value);
+typedef int (*xsltSecurityCheck)        (xsltSecurityPrefsPtr sec,
+                                         xsltTransformContextPtr ctxt,
+                                         const char *value);
 
 /*
  * Module interfaces
  */
 XSLTPUBFUN xsltSecurityPrefsPtr XSLTCALL
-            xsltNewSecurityPrefs    (void);
+                    xsltNewSecurityPrefs        (void);
 XSLTPUBFUN void XSLTCALL
-            xsltFreeSecurityPrefs   (xsltSecurityPrefsPtr sec);
+                    xsltFreeSecurityPrefs       (xsltSecurityPrefsPtr sec);
 XSLTPUBFUN int XSLTCALL
-            xsltSetSecurityPrefs    (xsltSecurityPrefsPtr sec,
-                         xsltSecurityOption option,
-                         xsltSecurityCheck func);
+                    xsltSetSecurityPrefs        (xsltSecurityPrefsPtr sec,
+                                                 xsltSecurityOption option,
+                                                 xsltSecurityCheck func);
 XSLTPUBFUN xsltSecurityCheck XSLTCALL
-            xsltGetSecurityPrefs    (xsltSecurityPrefsPtr sec,
-                         xsltSecurityOption option);
+                    xsltGetSecurityPrefs        (xsltSecurityPrefsPtr sec,
+                                                 xsltSecurityOption option);
 
 XSLTPUBFUN void XSLTCALL
-            xsltSetDefaultSecurityPrefs (xsltSecurityPrefsPtr sec);
+                    xsltSetDefaultSecurityPrefs (xsltSecurityPrefsPtr sec);
 XSLTPUBFUN xsltSecurityPrefsPtr XSLTCALL
-            xsltGetDefaultSecurityPrefs (void);
+                    xsltGetDefaultSecurityPrefs (void);
 
 XSLTPUBFUN int XSLTCALL
-            xsltSetCtxtSecurityPrefs    (xsltSecurityPrefsPtr sec,
-                         xsltTransformContextPtr ctxt);
+                    xsltSetCtxtSecurityPrefs    (xsltSecurityPrefsPtr sec,
+                                                 xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN int XSLTCALL
-            xsltSecurityAllow       (xsltSecurityPrefsPtr sec,
-                         xsltTransformContextPtr ctxt,
-                         const char *value);
+                    xsltSecurityAllow           (xsltSecurityPrefsPtr sec,
+                                                 xsltTransformContextPtr ctxt,
+                                                 const char *value);
 XSLTPUBFUN int XSLTCALL
-            xsltSecurityForbid      (xsltSecurityPrefsPtr sec,
-                         xsltTransformContextPtr ctxt,
-                         const char *value);
+                    xsltSecurityForbid          (xsltSecurityPrefsPtr sec,
+                                                 xsltTransformContextPtr ctxt,
+                                                 const char *value);
 /*
  * internal interfaces
  */
 XSLTPUBFUN int XSLTCALL
-            xsltCheckWrite      (xsltSecurityPrefsPtr sec,
-                         xsltTransformContextPtr ctxt,
-                         const xmlChar *URL);
+                    xsltCheckWrite              (xsltSecurityPrefsPtr sec,
+                                                 xsltTransformContextPtr ctxt,
+                                                 const xmlChar *URL);
 XSLTPUBFUN int XSLTCALL
-            xsltCheckRead       (xsltSecurityPrefsPtr sec,
-                         xsltTransformContextPtr ctxt,
-                         const xmlChar *URL);
+                    xsltCheckRead               (xsltSecurityPrefsPtr sec,
+                                                 xsltTransformContextPtr ctxt,
+                                                 const xmlChar *URL);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/templates.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/templates.c
@@ -36,9 +36,9 @@
 #endif
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -55,7 +55,7 @@
  */
 int
 xsltEvalXPathPredicate(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
-               xmlNsPtr *nsList, int nsNr) {
+                       xmlNsPtr *nsList, int nsNr) {
     int ret;
     xmlXPathObjectPtr res;
     int oldNsNr;
@@ -82,19 +82,19 @@ xsltEvalXPathPredicate(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
     res = xmlXPathCompiledEval(comp, ctxt->xpathCtxt);
 
     if (res != NULL) {
-    ret = xmlXPathEvalPredicate(ctxt->xpathCtxt, res);
-    xmlXPathFreeObject(res);
+        ret = xmlXPathEvalPredicate(ctxt->xpathCtxt, res);
+        xmlXPathFreeObject(res);
 #ifdef WITH_XSLT_DEBUG_TEMPLATES
-    XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltEvalXPathPredicate: returns %d\n", ret));
+        XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltEvalXPathPredicate: returns %d\n", ret));
 #endif
     } else {
 #ifdef WITH_XSLT_DEBUG_TEMPLATES
-    XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltEvalXPathPredicate: failed\n"));
+        XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltEvalXPathPredicate: failed\n"));
 #endif
-    ctxt->state = XSLT_STATE_STOPPED;
-    ret = 0;
+        ctxt->state = XSLT_STATE_STOPPED;
+        ret = 0;
     }
     ctxt->xpathCtxt->nsNr = oldNsNr;
 
@@ -121,7 +121,7 @@ xsltEvalXPathPredicate(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
  */
 xmlChar *
 xsltEvalXPathStringNs(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
-                  int nsNr, xmlNsPtr *nsList) {
+                      int nsNr, xmlNsPtr *nsList) {
     xmlChar *ret = NULL;
     xmlXPathObjectPtr res;
     xmlNodePtr oldInst;
@@ -149,22 +149,22 @@ xsltEvalXPathStringNs(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp,
     ctxt->xpathCtxt->nsNr = nsNr;
     res = xmlXPathCompiledEval(comp, ctxt->xpathCtxt);
     if (res != NULL) {
-    if (res->type != XPATH_STRING)
-        res = xmlXPathConvertString(res);
-    if (res->type == XPATH_STRING) {
+        if (res->type != XPATH_STRING)
+            res = xmlXPathConvertString(res);
+        if (res->type == XPATH_STRING) {
             ret = res->stringval;
-        res->stringval = NULL;
+            res->stringval = NULL;
+        } else {
+            xsltTransformError(ctxt, NULL, NULL,
+                 "xpath : string() function didn't return a String\n");
+        }
+        xmlXPathFreeObject(res);
     } else {
-        xsltTransformError(ctxt, NULL, NULL,
-         "xpath : string() function didn't return a String\n");
-    }
-    xmlXPathFreeObject(res);
-    } else {
-    ctxt->state = XSLT_STATE_STOPPED;
+        ctxt->state = XSLT_STATE_STOPPED;
     }
 #ifdef WITH_XSLT_DEBUG_TEMPLATES
     XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltEvalXPathString: returns %s\n", ret));
+         "xsltEvalXPathString: returns %s\n", ret));
 #endif
     ctxt->inst = oldInst;
     ctxt->node = oldNode;
@@ -205,18 +205,20 @@ xsltEvalXPathString(xsltTransformContextPtr ctxt, xmlXPathCompExprPtr comp) {
  */
 xmlChar *
 xsltEvalTemplateString(xsltTransformContextPtr ctxt,
-               xmlNodePtr contextNode,
-                   xmlNodePtr inst)
+                       xmlNodePtr contextNode,
+                       xmlNodePtr inst)
 {
     xmlNodePtr oldInsert, insert = NULL;
     xmlChar *ret;
+    const xmlChar *oldLastText;
+    int oldLastTextSize, oldLastTextUse;
 
     if ((ctxt == NULL) || (contextNode == NULL) || (inst == NULL) ||
         (inst->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     if (inst->children == NULL)
-    return(NULL);
+        return(NULL);
 
     /*
     * This creates a temporary element-node to add the resulting
@@ -225,24 +227,30 @@ xsltEvalTemplateString(xsltTransformContextPtr ctxt,
     *  context to avoid creating it every time.
     */
     insert = xmlNewDocNode(ctxt->output, NULL,
-                       (const xmlChar *)"fake", NULL);
+                           (const xmlChar *)"fake", NULL);
     if (insert == NULL) {
-    xsltTransformError(ctxt, NULL, contextNode,
-        "Failed to create temporary node\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, contextNode,
+                "Failed to create temporary node\n");
+        return(NULL);
     }
     oldInsert = ctxt->insert;
     ctxt->insert = insert;
+    oldLastText = ctxt->lasttext;
+    oldLastTextSize = ctxt->lasttsize;
+    oldLastTextUse = ctxt->lasttuse;
     /*
     * OPTIMIZE TODO: if inst->children consists only of text-nodes.
     */
     xsltApplyOneTemplate(ctxt, contextNode, inst->children, NULL, NULL);
 
     ctxt->insert = oldInsert;
+    ctxt->lasttext = oldLastText;
+    ctxt->lasttsize = oldLastTextSize;
+    ctxt->lasttuse = oldLastTextUse;
 
     ret = xmlNodeGetContent(insert);
     if (insert != NULL)
-    xmlFreeNode(insert);
+        xmlFreeNode(insert);
     return(ret);
 }
 
@@ -268,7 +276,7 @@ xsltEvalTemplateString(xsltTransformContextPtr ctxt,
  */
 xmlChar *
 xsltAttrTemplateValueProcessNode(xsltTransformContextPtr ctxt,
-      const xmlChar *str, xmlNodePtr inst)
+          const xmlChar *str, xmlNodePtr inst)
 {
     xmlChar *ret = NULL;
     const xmlChar *cur;
@@ -278,92 +286,92 @@ xsltAttrTemplateValueProcessNode(xsltTransformContextPtr ctxt,
 
     if (str == NULL) return(NULL);
     if (*str == 0)
-    return(xmlStrndup((xmlChar *)"", 0));
+        return(xmlStrndup((xmlChar *)"", 0));
 
     cur = str;
     while (*cur != 0) {
-    if (*cur == '{') {
-        if (*(cur+1) == '{') {  /* escaped '{' */
+        if (*cur == '{') {
+            if (*(cur+1) == '{') {      /* escaped '{' */
+                cur++;
+                ret = xmlStrncat(ret, str, cur - str);
+                cur++;
+                str = cur;
+                continue;
+            }
+            ret = xmlStrncat(ret, str, cur - str);
+            str = cur;
             cur++;
-        ret = xmlStrncat(ret, str, cur - str);
-        cur++;
-        str = cur;
-        continue;
-        }
-        ret = xmlStrncat(ret, str, cur - str);
-        str = cur;
-        cur++;
-        while ((*cur != 0) && (*cur != '}')) {
-        /* Need to check for literal (bug539741) */
-        if ((*cur == '\'') || (*cur == '"')) {
-            char delim = *(cur++);
-            while ((*cur != 0) && (*cur != delim))
+            while ((*cur != 0) && (*cur != '}')) {
+                /* Need to check for literal (bug539741) */
+                if ((*cur == '\'') || (*cur == '"')) {
+                    char delim = *(cur++);
+                    while ((*cur != 0) && (*cur != delim))
+                        cur++;
+                    if (*cur != 0)
+                        cur++;  /* skip the ending delimiter */
+                } else
+                    cur++;
+            }
+            if (*cur == 0) {
+                xsltTransformError(ctxt, NULL, inst,
+                        "xsltAttrTemplateValueProcessNode: unmatched '{'\n");
+                ret = xmlStrncat(ret, str, cur - str);
+                goto exit;
+            }
+            str++;
+            expr = xmlStrndup(str, cur - str);
+            if (expr == NULL)
+                goto exit;
+            else if (*expr == '{') {
+                ret = xmlStrcat(ret, expr);
+                xmlFree(expr);
+            } else {
+                xmlXPathCompExprPtr comp;
+                /*
+                 * TODO: keep precompiled form around
+                 */
+                if ((nsList == NULL) && (inst != NULL)) {
+                    int i = 0;
+
+                    nsList = xmlGetNsList(inst->doc, inst);
+                    if (nsList != NULL) {
+                        while (nsList[i] != NULL)
+                            i++;
+                        nsNr = i;
+                    }
+                }
+                comp = xmlXPathCtxtCompile(ctxt->xpathCtxt, expr);
+                val = xsltEvalXPathStringNs(ctxt, comp, nsNr, nsList);
+                xmlXPathFreeCompExpr(comp);
+                xmlFree(expr);
+                if (val != NULL) {
+                    ret = xmlStrcat(ret, val);
+                    xmlFree(val);
+                }
+            }
             cur++;
-            if (*cur != 0)
-            cur++;  /* skip the ending delimiter */
+            str = cur;
+        } else if (*cur == '}') {
+            cur++;
+            if (*cur == '}') {  /* escaped '}' */
+                ret = xmlStrncat(ret, str, cur - str);
+                cur++;
+                str = cur;
+                continue;
+            } else {
+                xsltTransformError(ctxt, NULL, inst,
+                     "xsltAttrTemplateValueProcessNode: unmatched '}'\n");
+            }
         } else
             cur++;
-            }
-        if (*cur == 0) {
-            xsltTransformError(ctxt, NULL, inst,
-            "xsltAttrTemplateValueProcessNode: unmatched '{'\n");
-        ret = xmlStrncat(ret, str, cur - str);
-        goto exit;
-        }
-        str++;
-        expr = xmlStrndup(str, cur - str);
-        if (expr == NULL)
-        goto exit;
-        else if (*expr == '{') {
-        ret = xmlStrcat(ret, expr);
-        xmlFree(expr);
-        } else {
-        xmlXPathCompExprPtr comp;
-        /*
-         * TODO: keep precompiled form around
-         */
-        if ((nsList == NULL) && (inst != NULL)) {
-            int i = 0;
-
-            nsList = xmlGetNsList(inst->doc, inst);
-            if (nsList != NULL) {
-            while (nsList[i] != NULL)
-                i++;
-            nsNr = i;
-            }
-        }
-        comp = xmlXPathCtxtCompile(ctxt->xpathCtxt, expr);
-                val = xsltEvalXPathStringNs(ctxt, comp, nsNr, nsList);
-        xmlXPathFreeCompExpr(comp);
-        xmlFree(expr);
-        if (val != NULL) {
-            ret = xmlStrcat(ret, val);
-            xmlFree(val);
-        }
-        }
-        cur++;
-        str = cur;
-    } else if (*cur == '}') {
-        cur++;
-        if (*cur == '}') {  /* escaped '}' */
-        ret = xmlStrncat(ret, str, cur - str);
-        cur++;
-        str = cur;
-        continue;
-        } else {
-            xsltTransformError(ctxt, NULL, inst,
-             "xsltAttrTemplateValueProcessNode: unmatched '}'\n");
-        }
-    } else
-        cur++;
     }
     if (cur != str) {
-    ret = xmlStrncat(ret, str, cur - str);
+        ret = xmlStrncat(ret, str, cur - str);
     }
 
 exit:
     if (nsList != NULL)
-    xmlFree(nsList);
+        xmlFree(nsList);
 
     return(ret);
 }
@@ -400,18 +408,18 @@ xsltAttrTemplateValueProcess(xsltTransformContextPtr ctxt, const xmlChar *str) {
  */
 xmlChar *
 xsltEvalAttrValueTemplate(xsltTransformContextPtr ctxt, xmlNodePtr inst,
-                      const xmlChar *name, const xmlChar *ns)
+                          const xmlChar *name, const xmlChar *ns)
 {
     xmlChar *ret;
     xmlChar *expr;
 
     if ((ctxt == NULL) || (inst == NULL) || (name == NULL) ||
         (inst->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     expr = xsltGetNsProp(inst, name, ns);
     if (expr == NULL)
-    return(NULL);
+        return(NULL);
 
     /*
      * TODO: though now {} is detected ahead, it would still be good to
@@ -422,10 +430,10 @@ xsltEvalAttrValueTemplate(xsltTransformContextPtr ctxt, xmlNodePtr inst,
     ret = xsltAttrTemplateValueProcessNode(ctxt, expr, inst);
 #ifdef WITH_XSLT_DEBUG_TEMPLATES
     XSLT_TRACE(ctxt,XSLT_TRACE_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltEvalAttrValueTemplate: %s returns %s\n", expr, ret));
+         "xsltEvalAttrValueTemplate: %s returns %s\n", expr, ret));
 #endif
     if (expr != NULL)
-    xmlFree(expr);
+        xmlFree(expr);
     return(ret);
 }
 
@@ -446,25 +454,25 @@ xsltEvalAttrValueTemplate(xsltTransformContextPtr ctxt, xmlNodePtr inst,
  */
 const xmlChar *
 xsltEvalStaticAttrValueTemplate(xsltStylesheetPtr style, xmlNodePtr inst,
-            const xmlChar *name, const xmlChar *ns, int *found) {
+                        const xmlChar *name, const xmlChar *ns, int *found) {
     const xmlChar *ret;
     xmlChar *expr;
 
     if ((style == NULL) || (inst == NULL) || (name == NULL) ||
         (inst->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     expr = xsltGetNsProp(inst, name, ns);
     if (expr == NULL) {
-    *found = 0;
-    return(NULL);
+        *found = 0;
+        return(NULL);
     }
     *found = 1;
 
     ret = xmlStrchr(expr, '{');
     if (ret != NULL) {
-    xmlFree(expr);
-    return(NULL);
+        xmlFree(expr);
+        return(NULL);
     }
     ret = xmlDictLookup(style->dict, expr, -1);
     xmlFree(expr);
@@ -487,78 +495,78 @@ xsltEvalStaticAttrValueTemplate(xsltStylesheetPtr style, xmlNodePtr inst,
  */
 xmlAttrPtr
 xsltAttrTemplateProcess(xsltTransformContextPtr ctxt, xmlNodePtr target,
-                    xmlAttrPtr attr)
+                        xmlAttrPtr attr)
 {
     const xmlChar *value;
     xmlAttrPtr ret;
 
     if ((ctxt == NULL) || (attr == NULL) || (target == NULL) ||
         (target->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     if (attr->type != XML_ATTRIBUTE_NODE)
-    return(NULL);
+        return(NULL);
 
     /*
     * Skip all XSLT attributes.
     */
 #ifdef XSLT_REFACTORED
     if (attr->psvi == xsltXSLTAttrMarker)
-    return(NULL);
+        return(NULL);
 #else
     if ((attr->ns != NULL) && xmlStrEqual(attr->ns->href, XSLT_NAMESPACE))
-    return(NULL);
+        return(NULL);
 #endif
     /*
     * Get the value.
     */
     if (attr->children != NULL) {
-    if ((attr->children->type != XML_TEXT_NODE) ||
-        (attr->children->next != NULL))
-    {
-        xsltTransformError(ctxt, NULL, attr->parent,
-        "Internal error: The children of an attribute node of a "
-        "literal result element are not in the expected form.\n");
-        return(NULL);
-    }
-    value = attr->children->content;
-    if (value == NULL)
-        value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
+        if ((attr->children->type != XML_TEXT_NODE) ||
+            (attr->children->next != NULL))
+        {
+            xsltTransformError(ctxt, NULL, attr->parent,
+                "Internal error: The children of an attribute node of a "
+                "literal result element are not in the expected form.\n");
+            return(NULL);
+        }
+        value = attr->children->content;
+        if (value == NULL)
+            value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
     } else
-    value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
+        value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
     /*
     * Overwrite duplicates.
     */
     ret = target->properties;
     while (ret != NULL) {
         if (((attr->ns != NULL) == (ret->ns != NULL)) &&
-        xmlStrEqual(ret->name, attr->name) &&
-        ((attr->ns == NULL) || xmlStrEqual(ret->ns->href, attr->ns->href)))
-    {
-        break;
-    }
+            xmlStrEqual(ret->name, attr->name) &&
+            ((attr->ns == NULL) || xmlStrEqual(ret->ns->href, attr->ns->href)))
+        {
+            break;
+        }
         ret = ret->next;
     }
     if (ret != NULL) {
         /* free the existing value */
-    xmlFreeNodeList(ret->children);
-    ret->children = ret->last = NULL;
-    /*
-    * Adjust ns-prefix if needed.
-    */
-    if ((ret->ns != NULL) &&
-        (! xmlStrEqual(ret->ns->prefix, attr->ns->prefix)))
-    {
-        ret->ns = xsltGetNamespace(ctxt, attr->parent, attr->ns, target);
-    }
+        xmlFreeNodeList(ret->children);
+        ret->children = ret->last = NULL;
+        /*
+        * Adjust ns-prefix if needed.
+        */
+        if ((ret->ns != NULL) &&
+            (! xmlStrEqual(ret->ns->prefix, attr->ns->prefix)))
+        {
+            ret->ns = xsltGetNamespace(ctxt, attr->parent, attr->ns, target);
+        }
     } else {
         /* create a new attribute */
-    if (attr->ns != NULL)
-        ret = xmlNewNsProp(target,
-        xsltGetNamespace(ctxt, attr->parent, attr->ns, target),
-            attr->name, NULL);
-    else
-        ret = xmlNewNsProp(target, NULL, attr->name, NULL);
+        if (attr->ns != NULL)
+            ret = xmlNewNsProp(target,
+                xsltGetNamespace(ctxt, attr->parent, attr->ns, target),
+                    attr->name, NULL);
+        else
+            ret = xmlNewNsProp(target, NULL, attr->name, NULL);
     }
     /*
     * Set the value.
@@ -567,56 +575,56 @@ xsltAttrTemplateProcess(xsltTransformContextPtr ctxt, xmlNodePtr target,
         xmlNodePtr text;
 
         text = xmlNewText(NULL);
-    if (text != NULL) {
-        ret->last = ret->children = text;
-        text->parent = (xmlNodePtr) ret;
-        text->doc = ret->doc;
+        if (text != NULL) {
+            ret->last = ret->children = text;
+            text->parent = (xmlNodePtr) ret;
+            text->doc = ret->doc;
 
-        if (attr->psvi != NULL) {
-        /*
-        * Evaluate the Attribute Value Template.
-        */
-        xmlChar *val;
-        val = xsltEvalAVT(ctxt, attr->psvi, attr->parent);
-        if (val == NULL) {
-            /*
-            * TODO: Damn, we need an easy mechanism to report
-            * qualified names!
-            */
-            if (attr->ns) {
-            xsltTransformError(ctxt, NULL, attr->parent,
-                "Internal error: Failed to evaluate the AVT "
-                "of attribute '{%s}%s'.\n",
-                attr->ns->href, attr->name);
+            if (attr->psvi != NULL) {
+                /*
+                * Evaluate the Attribute Value Template.
+                */
+                xmlChar *val;
+                val = xsltEvalAVT(ctxt, attr->psvi, attr->parent);
+                if (val == NULL) {
+                    /*
+                    * TODO: Damn, we need an easy mechanism to report
+                    * qualified names!
+                    */
+                    if (attr->ns) {
+                        xsltTransformError(ctxt, NULL, attr->parent,
+                            "Internal error: Failed to evaluate the AVT "
+                            "of attribute '{%s}%s'.\n",
+                            attr->ns->href, attr->name);
+                    } else {
+                        xsltTransformError(ctxt, NULL, attr->parent,
+                            "Internal error: Failed to evaluate the AVT "
+                            "of attribute '%s'.\n",
+                            attr->name);
+                    }
+                    text->content = xmlStrdup(BAD_CAST "");
+                } else {
+                    text->content = val;
+                }
+            } else if ((ctxt->internalized) && (target != NULL) &&
+                       (target->doc != NULL) &&
+                       (target->doc->dict == ctxt->dict) &&
+                       xmlDictOwns(ctxt->dict, value)) {
+                text->content = (xmlChar *) value;
             } else {
-            xsltTransformError(ctxt, NULL, attr->parent,
-                "Internal error: Failed to evaluate the AVT "
-                "of attribute '%s'.\n",
-                attr->name);
+                text->content = xmlStrdup(value);
             }
-            text->content = xmlStrdup(BAD_CAST "");
-        } else {
-            text->content = val;
         }
-        } else if ((ctxt->internalized) && (target != NULL) &&
-                   (target->doc != NULL) &&
-               (target->doc->dict == ctxt->dict) &&
-               xmlDictOwns(ctxt->dict, value)) {
-        text->content = (xmlChar *) value;
+    } else {
+        if (attr->ns) {
+            xsltTransformError(ctxt, NULL, attr->parent,
+                "Internal error: Failed to create attribute '{%s}%s'.\n",
+                attr->ns->href, attr->name);
         } else {
-        text->content = xmlStrdup(value);
+            xsltTransformError(ctxt, NULL, attr->parent,
+                "Internal error: Failed to create attribute '%s'.\n",
+                attr->name);
         }
-    }
-    } else {
-    if (attr->ns) {
-        xsltTransformError(ctxt, NULL, attr->parent,
-        "Internal error: Failed to create attribute '{%s}%s'.\n",
-        attr->ns->href, attr->name);
-    } else {
-        xsltTransformError(ctxt, NULL, attr->parent,
-        "Internal error: Failed to create attribute '%s'.\n",
-        attr->name);
-    }
     }
     return(ret);
 }
@@ -643,7 +651,7 @@ xsltAttrTemplateProcess(xsltTransformContextPtr ctxt, xmlNodePtr target,
  */
 xmlAttrPtr
 xsltAttrListTemplateProcess(xsltTransformContextPtr ctxt,
-                        xmlNodePtr target, xmlAttrPtr attrs)
+                            xmlNodePtr target, xmlAttrPtr attrs)
 {
     xmlAttrPtr attr, copy, last = NULL;
     xmlNodePtr oldInsert, text;
@@ -654,7 +662,7 @@ xsltAttrListTemplateProcess(xsltTransformContextPtr ctxt,
 
     if ((ctxt == NULL) || (target == NULL) || (attrs == NULL) ||
         (target->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     oldInsert = ctxt->insert;
     ctxt->insert = target;
@@ -665,20 +673,20 @@ xsltAttrListTemplateProcess(xsltTransformContextPtr ctxt,
     attr = attrs;
     do {
 #ifdef XSLT_REFACTORED
-    if ((attr->psvi == xsltXSLTAttrMarker) &&
-        xmlStrEqual(attr->name, (const xmlChar *)"use-attribute-sets"))
-    {
-        xsltApplyAttributeSet(ctxt, ctxt->node, (xmlNodePtr) attr, NULL);
-    }
+        if ((attr->psvi == xsltXSLTAttrMarker) &&
+            xmlStrEqual(attr->name, (const xmlChar *)"use-attribute-sets"))
+        {
+            xsltApplyAttributeSet(ctxt, ctxt->node, (xmlNodePtr) attr, NULL);
+        }
 #else
-    if ((attr->ns != NULL) &&
-        xmlStrEqual(attr->name, (const xmlChar *)"use-attribute-sets") &&
-        xmlStrEqual(attr->ns->href, XSLT_NAMESPACE))
-    {
-        xsltApplyAttributeSet(ctxt, ctxt->node, (xmlNodePtr) attr, NULL);
-    }
+        if ((attr->ns != NULL) &&
+            xmlStrEqual(attr->name, (const xmlChar *)"use-attribute-sets") &&
+            xmlStrEqual(attr->ns->href, XSLT_NAMESPACE))
+        {
+            xsltApplyAttributeSet(ctxt, ctxt->node, (xmlNodePtr) attr, NULL);
+        }
 #endif
-    attr = attr->next;
+        attr = attr->next;
     } while (attr != NULL);
 
     if (target->properties != NULL) {
@@ -690,69 +698,69 @@ xsltAttrListTemplateProcess(xsltTransformContextPtr ctxt,
     */
     attr = attrs;
     do {
-    /*
-    * Skip XSLT attributes.
-    */
+        /*
+        * Skip XSLT attributes.
+        */
 #ifdef XSLT_REFACTORED
-    if (attr->psvi == xsltXSLTAttrMarker) {
-        goto next_attribute;
-    }
-#else
-    if ((attr->ns != NULL) &&
-        xmlStrEqual(attr->ns->href, XSLT_NAMESPACE))
-    {
-        goto next_attribute;
-    }
-#endif
-    /*
-    * Get the value.
-    */
-    if (attr->children != NULL) {
-        if ((attr->children->type != XML_TEXT_NODE) ||
-        (attr->children->next != NULL))
-        {
-        xsltTransformError(ctxt, NULL, attr->parent,
-            "Internal error: The children of an attribute node of a "
-            "literal result element are not in the expected form.\n");
-        goto error;
+        if (attr->psvi == xsltXSLTAttrMarker) {
+            goto next_attribute;
         }
-        value = attr->children->content;
-        if (value == NULL)
-        value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
-    } else
-        value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
-
-    /*
-    * Get the namespace. Avoid lookups of same namespaces.
-    */
-    if (attr->ns != origNs) {
-        origNs = attr->ns;
-        if (attr->ns != NULL) {
-#ifdef XSLT_REFACTORED
-        copyNs = xsltGetSpecialNamespace(ctxt, attr->parent,
-            attr->ns->href, attr->ns->prefix, target);
 #else
-        copyNs = xsltGetNamespace(ctxt, attr->parent,
-            attr->ns, target);
+        if ((attr->ns != NULL) &&
+            xmlStrEqual(attr->ns->href, XSLT_NAMESPACE))
+        {
+            goto next_attribute;
+        }
 #endif
-        if (copyNs == NULL)
-            goto error;
+        /*
+        * Get the value.
+        */
+        if (attr->children != NULL) {
+            if ((attr->children->type != XML_TEXT_NODE) ||
+                (attr->children->next != NULL))
+            {
+                xsltTransformError(ctxt, NULL, attr->parent,
+                    "Internal error: The children of an attribute node of a "
+                    "literal result element are not in the expected form.\n");
+                goto error;
+            }
+            value = attr->children->content;
+            if (value == NULL)
+                value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
         } else
-        copyNs = NULL;
-    }
-    /*
-    * Create a new attribute.
-    */
+            value = xmlDictLookup(ctxt->dict, BAD_CAST "", 0);
+
+        /*
+        * Get the namespace. Avoid lookups of same namespaces.
+        */
+        if (attr->ns != origNs) {
+            origNs = attr->ns;
+            if (attr->ns != NULL) {
+#ifdef XSLT_REFACTORED
+                copyNs = xsltGetSpecialNamespace(ctxt, attr->parent,
+                    attr->ns->href, attr->ns->prefix, target);
+#else
+                copyNs = xsltGetNamespace(ctxt, attr->parent,
+                    attr->ns, target);
+#endif
+                if (copyNs == NULL)
+                    goto error;
+            } else
+                copyNs = NULL;
+        }
+        /*
+        * Create a new attribute.
+        */
         if (hasAttr) {
-        copy = xmlSetNsProp(target, copyNs, attr->name, NULL);
+            copy = xmlSetNsProp(target, copyNs, attr->name, NULL);
         } else {
             /*
             * Avoid checking for duplicate attributes if there aren't
             * any attribute sets.
             */
-        copy = xmlNewDocProp(target->doc, attr->name, NULL);
+            copy = xmlNewDocProp(target->doc, attr->name, NULL);
 
-        if (copy != NULL) {
+            if (copy != NULL) {
                 copy->ns = copyNs;
 
                 /*
@@ -769,70 +777,70 @@ xsltAttrListTemplateProcess(xsltTransformContextPtr ctxt,
                 }
             }
         }
-    if (copy == NULL) {
-        if (attr->ns) {
-        xsltTransformError(ctxt, NULL, attr->parent,
-            "Internal error: Failed to create attribute '{%s}%s'.\n",
-            attr->ns->href, attr->name);
-        } else {
-        xsltTransformError(ctxt, NULL, attr->parent,
-            "Internal error: Failed to create attribute '%s'.\n",
-            attr->name);
-        }
-        goto error;
-    }
-
-    /*
-    * Set the value.
-    */
-    text = xmlNewText(NULL);
-    if (text != NULL) {
-        copy->last = copy->children = text;
-        text->parent = (xmlNodePtr) copy;
-        text->doc = copy->doc;
-
-        if (attr->psvi != NULL) {
-        /*
-        * Evaluate the Attribute Value Template.
-        */
-        valueAVT = xsltEvalAVT(ctxt, attr->psvi, attr->parent);
-        if (valueAVT == NULL) {
-            /*
-            * TODO: Damn, we need an easy mechanism to report
-            * qualified names!
-            */
+        if (copy == NULL) {
             if (attr->ns) {
-            xsltTransformError(ctxt, NULL, attr->parent,
-                "Internal error: Failed to evaluate the AVT "
-                "of attribute '{%s}%s'.\n",
-                attr->ns->href, attr->name);
+                xsltTransformError(ctxt, NULL, attr->parent,
+                    "Internal error: Failed to create attribute '{%s}%s'.\n",
+                    attr->ns->href, attr->name);
             } else {
-            xsltTransformError(ctxt, NULL, attr->parent,
-                "Internal error: Failed to evaluate the AVT "
-                "of attribute '%s'.\n",
-                attr->name);
+                xsltTransformError(ctxt, NULL, attr->parent,
+                    "Internal error: Failed to create attribute '%s'.\n",
+                    attr->name);
             }
-            text->content = xmlStrdup(BAD_CAST "");
             goto error;
-        } else {
-            text->content = valueAVT;
         }
-        } else if ((ctxt->internalized) &&
-        (target->doc != NULL) &&
-        (target->doc->dict == ctxt->dict) &&
-        xmlDictOwns(ctxt->dict, value))
-        {
-        text->content = (xmlChar *) value;
-        } else {
-        text->content = xmlStrdup(value);
-        }
+
+        /*
+        * Set the value.
+        */
+        text = xmlNewText(NULL);
+        if (text != NULL) {
+            copy->last = copy->children = text;
+            text->parent = (xmlNodePtr) copy;
+            text->doc = copy->doc;
+
+            if (attr->psvi != NULL) {
+                /*
+                * Evaluate the Attribute Value Template.
+                */
+                valueAVT = xsltEvalAVT(ctxt, attr->psvi, attr->parent);
+                if (valueAVT == NULL) {
+                    /*
+                    * TODO: Damn, we need an easy mechanism to report
+                    * qualified names!
+                    */
+                    if (attr->ns) {
+                        xsltTransformError(ctxt, NULL, attr->parent,
+                            "Internal error: Failed to evaluate the AVT "
+                            "of attribute '{%s}%s'.\n",
+                            attr->ns->href, attr->name);
+                    } else {
+                        xsltTransformError(ctxt, NULL, attr->parent,
+                            "Internal error: Failed to evaluate the AVT "
+                            "of attribute '%s'.\n",
+                            attr->name);
+                    }
+                    text->content = xmlStrdup(BAD_CAST "");
+                    goto error;
+                } else {
+                    text->content = valueAVT;
+                }
+            } else if ((ctxt->internalized) &&
+                (target->doc != NULL) &&
+                (target->doc->dict == ctxt->dict) &&
+                xmlDictOwns(ctxt->dict, value))
+            {
+                text->content = (xmlChar *) value;
+            } else {
+                text->content = xmlStrdup(value);
+            }
             if ((copy != NULL) && (text != NULL) &&
                 (xmlIsID(copy->doc, copy->parent, copy)))
                 xmlAddID(NULL, copy->doc, text->content, copy);
-    }
+        }
 
 next_attribute:
-    attr = attr->next;
+        attr = attr->next;
     } while (attr != NULL);
 
     ctxt->insert = oldInsert;
@@ -856,7 +864,7 @@ error:
 xmlNodePtr *
 xsltTemplateProcess(xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED, xmlNodePtr node) {
     if (node == NULL)
-    return(NULL);
+        return(NULL);
 
     return(0);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/templates.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/templates.h
@@ -21,54 +21,54 @@ extern "C" {
 #endif
 
 XSLTPUBFUN int XSLTCALL
-        xsltEvalXPathPredicate      (xsltTransformContextPtr ctxt,
-                         xmlXPathCompExprPtr comp,
-                                         xmlNsPtr *nsList,
-                         int nsNr);
+                xsltEvalXPathPredicate          (xsltTransformContextPtr ctxt,
+                                                 xmlXPathCompExprPtr comp,
+                                                 xmlNsPtr *nsList,
+                                                 int nsNr);
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltEvalTemplateString      (xsltTransformContextPtr ctxt,
-                         xmlNodePtr contextNode,
-                         xmlNodePtr inst);
+                xsltEvalTemplateString          (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr contextNode,
+                                                 xmlNodePtr inst);
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltEvalAttrValueTemplate   (xsltTransformContextPtr ctxt,
-                         xmlNodePtr node,
-                         const xmlChar *name,
-                         const xmlChar *ns);
+                xsltEvalAttrValueTemplate       (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr node,
+                                                 const xmlChar *name,
+                                                 const xmlChar *ns);
 XSLTPUBFUN const xmlChar * XSLTCALL
-        xsltEvalStaticAttrValueTemplate (xsltStylesheetPtr style,
-                         xmlNodePtr node,
-                         const xmlChar *name,
-                         const xmlChar *ns,
-                         int *found);
+                xsltEvalStaticAttrValueTemplate (xsltStylesheetPtr style,
+                                                 xmlNodePtr node,
+                                                 const xmlChar *name,
+                                                 const xmlChar *ns,
+                                                 int *found);
 
 /* TODO: this is obviously broken ... the namespaces should be passed too ! */
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltEvalXPathString     (xsltTransformContextPtr ctxt,
-                         xmlXPathCompExprPtr comp);
+                xsltEvalXPathString             (xsltTransformContextPtr ctxt,
+                                                 xmlXPathCompExprPtr comp);
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltEvalXPathStringNs       (xsltTransformContextPtr ctxt,
-                         xmlXPathCompExprPtr comp,
-                         int nsNr,
-                         xmlNsPtr *nsList);
+                xsltEvalXPathStringNs           (xsltTransformContextPtr ctxt,
+                                                 xmlXPathCompExprPtr comp,
+                                                 int nsNr,
+                                                 xmlNsPtr *nsList);
 
 XSLTPUBFUN xmlNodePtr * XSLTCALL
-        xsltTemplateProcess     (xsltTransformContextPtr ctxt,
-                         xmlNodePtr node);
+                xsltTemplateProcess             (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr node);
 XSLTPUBFUN xmlAttrPtr XSLTCALL
-        xsltAttrListTemplateProcess (xsltTransformContextPtr ctxt,
-                         xmlNodePtr target,
-                         xmlAttrPtr cur);
+                xsltAttrListTemplateProcess     (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr target,
+                                                 xmlAttrPtr cur);
 XSLTPUBFUN xmlAttrPtr XSLTCALL
-        xsltAttrTemplateProcess     (xsltTransformContextPtr ctxt,
-                         xmlNodePtr target,
-                         xmlAttrPtr attr);
+                xsltAttrTemplateProcess         (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr target,
+                                                 xmlAttrPtr attr);
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltAttrTemplateValueProcess    (xsltTransformContextPtr ctxt,
-                         const xmlChar* attr);
+                xsltAttrTemplateValueProcess    (xsltTransformContextPtr ctxt,
+                                                 const xmlChar* attr);
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltAttrTemplateValueProcessNode(xsltTransformContextPtr ctxt,
-                         const xmlChar* str,
-                         xmlNodePtr node);
+                xsltAttrTemplateValueProcessNode(xsltTransformContextPtr ctxt,
+                                                 const xmlChar* str,
+                                                 xmlNodePtr node);
 #ifdef __cplusplus
 }
 #endif

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/transform.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/transform.c
@@ -64,7 +64,7 @@
 #define XSLT_GENERATE_HTML_DOCTYPE
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
 static int xsltGetHTMLIDs(const xmlChar *version, const xmlChar **publicID,
-              const xmlChar **systemID);
+                          const xmlChar **systemID);
 #endif
 
 int xsltMaxDepth = 3000;
@@ -79,7 +79,7 @@ int xsltMaxVars = 15000;
 # define TRUE (!FALSE)
 #endif
 
-#define IS_BLANK_NODE(n)                        \
+#define IS_BLANK_NODE(n)                                                \
     (((n)->type == XML_TEXT_NODE) && (xsltIsBlank((n)->content)))
 
 
@@ -92,20 +92,20 @@ xsltCopyNamespaceListInternal(xmlNodePtr node, xmlNsPtr cur);
 
 static xmlNodePtr
 xsltCopyTree(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
-         xmlNodePtr node, xmlNodePtr insert, int isLRE,
-         int topElemVisited);
+             xmlNodePtr node, xmlNodePtr insert, int isLRE,
+             int topElemVisited);
 
 static void
 xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
-                 xmlNodePtr contextNode, xmlNodePtr list,
-                 xsltTemplatePtr templ);
+                             xmlNodePtr contextNode, xmlNodePtr list,
+                             xsltTemplatePtr templ);
 
 static void
 xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
-              xmlNodePtr contextNode,
-              xmlNodePtr list,
-              xsltTemplatePtr templ,
-              xsltStackElemPtr withParams);
+                      xmlNodePtr contextNode,
+                      xmlNodePtr list,
+                      xsltTemplatePtr templ,
+                      xsltStackElemPtr withParams);
 
 /**
  * templPush:
@@ -190,14 +190,14 @@ xsltLocalVariablePop(xsltTransformContextPtr ctxt, int limitNr, int level)
         return;
 
     do {
-    if (ctxt->varsNr <= limitNr)
-        break;
-    variable = ctxt->varsTab[ctxt->varsNr - 1];
-    if (variable->level <= level)
-        break;
-    if (variable->level >= 0)
-        xsltFreeStackElemList(variable);
-    ctxt->varsNr--;
+        if (ctxt->varsNr <= limitNr)
+            break;
+        variable = ctxt->varsTab[ctxt->varsNr - 1];
+        if (variable->level <= level)
+            break;
+        if (variable->level >= 0)
+            xsltFreeStackElemList(variable);
+        ctxt->varsNr--;
     } while (ctxt->varsNr != 0);
     if (ctxt->varsNr > 0)
         ctxt->vars = ctxt->varsTab[ctxt->varsNr - 1];
@@ -217,14 +217,14 @@ xsltTemplateParamsCleanup(xsltTransformContextPtr ctxt)
     xsltStackElemPtr param;
 
     for (; ctxt->varsNr > ctxt->varsBase; ctxt->varsNr--) {
-    param = ctxt->varsTab[ctxt->varsNr -1];
-    /*
-    * Free xsl:param items.
-    * xsl:with-param items will have a level of -1 or -2.
-    */
-    if (param->level >= 0) {
-        xsltFreeStackElemList(param);
-    }
+        param = ctxt->varsTab[ctxt->varsNr -1];
+        /*
+        * Free xsl:param items.
+        * xsl:with-param items will have a level of -1 or -2.
+        */
+        if (param->level >= 0) {
+            xsltFreeStackElemList(param);
+        }
     }
     if (ctxt->varsNr > 0)
         ctxt->vars = ctxt->varsTab[ctxt->varsNr - 1];
@@ -443,9 +443,9 @@ xsltPreCompEvalToBoolean(xsltTransformContextPtr ctxt, xmlNodePtr node,
 }
 
 /************************************************************************
- *                                  *
- *          XInclude default settings           *
- *                                  *
+ *                                                                      *
+ *                      XInclude default settings                       *
+ *                                                                      *
  ************************************************************************/
 
 static int xsltDoXIncludeDefault = 0;
@@ -482,7 +482,7 @@ static unsigned long xsltDefaultTrace = (unsigned long) XSLT_TRACE_ALL;
  * Set the default debug tracing level mask
  */
 void xsltDebugSetDefaultTrace(xsltDebugTraceCodes val) {
-    xsltDefaultTrace = val;
+        xsltDefaultTrace = val;
 }
 
 /**
@@ -493,13 +493,13 @@ void xsltDebugSetDefaultTrace(xsltDebugTraceCodes val) {
  * Returns the current default debug tracing level mask
  */
 xsltDebugTraceCodes xsltDebugGetDefaultTrace() {
-    return xsltDefaultTrace;
+        return xsltDefaultTrace;
 }
 
 /************************************************************************
- *                                  *
- *          Handling of Transformation Contexts     *
- *                                  *
+ *                                                                      *
+ *                      Handling of Transformation Contexts             *
+ *                                                                      *
  ************************************************************************/
 
 static xsltTransformCachePtr
@@ -509,9 +509,9 @@ xsltTransformCacheCreate(void)
 
     ret = (xsltTransformCachePtr) xmlMalloc(sizeof(xsltTransformCache));
     if (ret == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltTransformCacheCreate : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+            "xsltTransformCacheCreate : malloc failed\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltTransformCache));
     return(ret);
@@ -521,39 +521,39 @@ static void
 xsltTransformCacheFree(xsltTransformCachePtr cache)
 {
     if (cache == NULL)
-    return;
+        return;
     /*
     * Free tree fragments.
     */
     if (cache->RVT) {
-    xmlDocPtr tmp, cur = cache->RVT;
-    while (cur) {
-        tmp = cur;
-        cur = (xmlDocPtr) cur->next;
-        if (tmp->_private != NULL) {
-        /*
-        * Tree the document info.
-        */
-        xsltFreeDocumentKeys((xsltDocumentPtr) tmp->_private);
-        xmlFree(tmp->_private);
+        xmlDocPtr tmp, cur = cache->RVT;
+        while (cur) {
+            tmp = cur;
+            cur = (xmlDocPtr) cur->next;
+            if (tmp->_private != NULL) {
+                /*
+                * Tree the document info.
+                */
+                xsltFreeDocumentKeys((xsltDocumentPtr) tmp->_private);
+                xmlFree(tmp->_private);
+            }
+            xmlFreeDoc(tmp);
         }
-        xmlFreeDoc(tmp);
-    }
     }
     /*
     * Free vars/params.
     */
     if (cache->stackItems) {
-    xsltStackElemPtr tmp, cur = cache->stackItems;
-    while (cur) {
-        tmp = cur;
-        cur = cur->next;
-        /*
-        * REVISIT TODO: Should be call a destruction-function
-        * instead?
-        */
-        xmlFree(tmp);
-    }
+        xsltStackElemPtr tmp, cur = cache->stackItems;
+        while (cur) {
+            tmp = cur;
+            cur = cur->next;
+            /*
+            * REVISIT TODO: Should be call a destruction-function
+            * instead?
+            */
+            xmlFree(tmp);
+        }
     }
     xmlFree(cache);
 }
@@ -577,15 +577,15 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
 
     cur = (xsltTransformContextPtr) xmlMalloc(sizeof(xsltTransformContext));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, (xmlNodePtr)doc,
-        "xsltNewTransformContext : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, (xmlNodePtr)doc,
+                "xsltNewTransformContext : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltTransformContext));
 
     cur->cache = xsltTransformCacheCreate();
     if (cur->cache == NULL)
-    goto internal_err;
+        goto internal_err;
     /*
      * setup of the dictionary must be done early as some of the
      * processing later like key handling may need it.
@@ -594,18 +594,18 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
     cur->internalized = ((style->internalized) && (cur->dict != NULL));
 #ifdef WITH_XSLT_DEBUG
     xsltGenericDebug(xsltGenericDebugContext,
-         "Creating sub-dictionary from stylesheet for transformation\n");
+             "Creating sub-dictionary from stylesheet for transformation\n");
 #endif
 
     /*
      * initialize the template stack
      */
     cur->templTab = (xsltTemplatePtr *)
-            xmlMalloc(10 * sizeof(xsltTemplatePtr));
+                xmlMalloc(10 * sizeof(xsltTemplatePtr));
     if (cur->templTab == NULL) {
-    xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
-        "xsltNewTransformContext: out of memory\n");
-    goto internal_err;
+        xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
+                "xsltNewTransformContext: out of memory\n");
+        goto internal_err;
     }
     cur->templNr = 0;
     cur->templMax = 5;
@@ -616,11 +616,11 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
      * initialize the variables stack
      */
     cur->varsTab = (xsltStackElemPtr *)
-            xmlMalloc(10 * sizeof(xsltStackElemPtr));
+                xmlMalloc(10 * sizeof(xsltStackElemPtr));
     if (cur->varsTab == NULL) {
         xmlGenericError(xmlGenericErrorContext,
-        "xsltNewTransformContext: out of memory\n");
-    goto internal_err;
+                "xsltNewTransformContext: out of memory\n");
+        goto internal_err;
     }
     cur->varsNr = 0;
     cur->varsMax = 10;
@@ -640,37 +640,37 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
     xmlXPathInit();
     cur->xpathCtxt = xmlXPathNewContext(doc);
     if (cur->xpathCtxt == NULL) {
-    xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
-        "xsltNewTransformContext : xmlXPathNewContext failed\n");
-    goto internal_err;
+        xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
+                "xsltNewTransformContext : xmlXPathNewContext failed\n");
+        goto internal_err;
     }
     /*
     * Create an XPath cache.
     */
     if (xmlXPathContextSetCache(cur->xpathCtxt, 1, -1, 0) == -1)
-    goto internal_err;
+        goto internal_err;
     /*
      * Initialize the extras array
      */
     if (style->extrasNr != 0) {
-    cur->extrasMax = style->extrasNr + 20;
-    cur->extras = (xsltRuntimeExtraPtr)
-        xmlMalloc(cur->extrasMax * sizeof(xsltRuntimeExtra));
-    if (cur->extras == NULL) {
-        xmlGenericError(xmlGenericErrorContext,
-            "xsltNewTransformContext: out of memory\n");
-        goto internal_err;
-    }
-    cur->extrasNr = style->extrasNr;
-    for (i = 0;i < cur->extrasMax;i++) {
-        cur->extras[i].info = NULL;
-        cur->extras[i].deallocate = NULL;
-        cur->extras[i].val.ptr = NULL;
-    }
+        cur->extrasMax = style->extrasNr + 20;
+        cur->extras = (xsltRuntimeExtraPtr)
+            xmlMalloc(cur->extrasMax * sizeof(xsltRuntimeExtra));
+        if (cur->extras == NULL) {
+            xmlGenericError(xmlGenericErrorContext,
+                    "xsltNewTransformContext: out of memory\n");
+            goto internal_err;
+        }
+        cur->extrasNr = style->extrasNr;
+        for (i = 0;i < cur->extrasMax;i++) {
+            cur->extras[i].info = NULL;
+            cur->extras[i].deallocate = NULL;
+            cur->extras[i].val.ptr = NULL;
+        }
     } else {
-    cur->extras = NULL;
-    cur->extrasNr = 0;
-    cur->extrasMax = 0;
+        cur->extras = NULL;
+        cur->extrasNr = 0;
+        cur->extrasMax = 0;
     }
 
     XSLT_REGISTER_VARIABLE_LOOKUP(cur);
@@ -693,9 +693,9 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
     cur->parserOptions = XSLT_PARSE_OPTIONS;
     docu = xsltNewDocument(cur, doc);
     if (docu == NULL) {
-    xsltTransformError(cur, NULL, (xmlNodePtr)doc,
-        "xsltNewTransformContext : xsltNewDocument failed\n");
-    goto internal_err;
+        xsltTransformError(cur, NULL, (xmlNodePtr)doc,
+                "xsltNewTransformContext : xsltNewDocument failed\n");
+        goto internal_err;
     }
     docu->main = 1;
     cur->document = docu;
@@ -711,7 +711,7 @@ xsltNewTransformContext(xsltStylesheetPtr style, xmlDocPtr doc) {
 
 internal_err:
     if (cur != NULL)
-    xsltFreeTransformContext(cur);
+        xsltFreeTransformContext(cur);
     return(NULL);
 }
 
@@ -724,7 +724,7 @@ internal_err:
 void
 xsltFreeTransformContext(xsltTransformContextPtr ctxt) {
     if (ctxt == NULL)
-    return;
+        return;
 
     /*
      * Shutdown the extension modules associated to the stylesheet
@@ -733,24 +733,24 @@ xsltFreeTransformContext(xsltTransformContextPtr ctxt) {
     xsltShutdownCtxtExts(ctxt);
 
     if (ctxt->xpathCtxt != NULL) {
-    ctxt->xpathCtxt->nsHash = NULL;
-    xmlXPathFreeContext(ctxt->xpathCtxt);
+        ctxt->xpathCtxt->nsHash = NULL;
+        xmlXPathFreeContext(ctxt->xpathCtxt);
     }
     if (ctxt->templTab != NULL)
-    xmlFree(ctxt->templTab);
+        xmlFree(ctxt->templTab);
     if (ctxt->varsTab != NULL)
-    xmlFree(ctxt->varsTab);
+        xmlFree(ctxt->varsTab);
     if (ctxt->profTab != NULL)
-    xmlFree(ctxt->profTab);
+        xmlFree(ctxt->profTab);
     if ((ctxt->extrasNr > 0) && (ctxt->extras != NULL)) {
-    int i;
+        int i;
 
-    for (i = 0;i < ctxt->extrasNr;i++) {
-        if ((ctxt->extras[i].deallocate != NULL) &&
-        (ctxt->extras[i].info != NULL))
-        ctxt->extras[i].deallocate(ctxt->extras[i].info);
-    }
-    xmlFree(ctxt->extras);
+        for (i = 0;i < ctxt->extrasNr;i++) {
+            if ((ctxt->extras[i].deallocate != NULL) &&
+                (ctxt->extras[i].info != NULL))
+                ctxt->extras[i].deallocate(ctxt->extras[i].info);
+        }
+        xmlFree(ctxt->extras);
     }
     xsltFreeGlobalVariables(ctxt);
     xsltFreeDocuments(ctxt);
@@ -767,9 +767,9 @@ xsltFreeTransformContext(xsltTransformContextPtr ctxt) {
 }
 
 /************************************************************************
- *                                  *
- *          Copy of Nodes in an XSLT fashion        *
- *                                  *
+ *                                                                      *
+ *                      Copy of Nodes in an XSLT fashion                *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -811,7 +811,7 @@ xsltAddChild(xmlNodePtr parent, xmlNodePtr cur) {
  */
 static xmlNodePtr
 xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
-          const xmlChar *string, int len) {
+                  const xmlChar *string, int len) {
     /*
      * optimization
      */
@@ -830,8 +830,8 @@ xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
         minSize = ctxt->lasttuse + len + 1;
 
         if (ctxt->lasttsize < minSize) {
-        xmlChar *newbuf;
-        int size;
+            xmlChar *newbuf;
+            int size;
             int extra;
 
             /* Double buffer size but increase by at least 100 bytes. */
@@ -845,25 +845,25 @@ xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
                 size = ctxt->lasttsize + extra;
             }
 
-        newbuf = (xmlChar *) xmlRealloc(target->content,size);
-        if (newbuf == NULL) {
-        xsltTransformError(ctxt, NULL, target,
-         "xsltCopyText: text allocation failed\n");
-        return(NULL);
+            newbuf = (xmlChar *) xmlRealloc(target->content,size);
+            if (newbuf == NULL) {
+                xsltTransformError(ctxt, NULL, target,
+                 "xsltCopyText: text allocation failed\n");
+                return(NULL);
+            }
+            ctxt->lasttsize = size;
+            ctxt->lasttext = newbuf;
+            target->content = newbuf;
         }
-        ctxt->lasttsize = size;
-        ctxt->lasttext = newbuf;
-        target->content = newbuf;
-    }
-    memcpy(&(target->content[ctxt->lasttuse]), string, len);
-    ctxt->lasttuse += len;
-    target->content[ctxt->lasttuse] = 0;
+        memcpy(&(target->content[ctxt->lasttuse]), string, len);
+        ctxt->lasttuse += len;
+        target->content[ctxt->lasttuse] = 0;
     } else {
-    xmlNodeAddContent(target, string);
-    ctxt->lasttext = target->content;
-    len = xmlStrlen(target->content);
-    ctxt->lasttsize = len;
-    ctxt->lasttuse = len;
+        xmlNodeAddContent(target, string);
+        ctxt->lasttext = target->content;
+        len = xmlStrlen(target->content);
+        ctxt->lasttsize = len;
+        ctxt->lasttuse = len;
     }
     return(target);
 }
@@ -883,18 +883,18 @@ xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
  */
 xmlNodePtr
 xsltCopyTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
-               const xmlChar *string, int noescape)
+                   const xmlChar *string, int noescape)
 {
     xmlNodePtr copy;
     int len;
 
     if (string == NULL)
-    return(NULL);
+        return(NULL);
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopyTextString: copy text %s\n",
-             string));
+                     "xsltCopyTextString: copy text %s\n",
+                     string));
 #endif
 
     /*
@@ -902,65 +902,65 @@ xsltCopyTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
     * target node.
     */
     if ((target == NULL) || (target->children == NULL)) {
-    ctxt->lasttext = NULL;
+        ctxt->lasttext = NULL;
     }
 
     /* handle coalescing of text nodes here */
     len = xmlStrlen(string);
     if ((ctxt->type == XSLT_OUTPUT_XML) &&
-    (ctxt->style->cdataSection != NULL) &&
-    (target != NULL) &&
-    (target->type == XML_ELEMENT_NODE) &&
-    (((target->ns == NULL) &&
-      (xmlHashLookup2(ctxt->style->cdataSection,
-                  target->name, NULL) != NULL)) ||
-     ((target->ns != NULL) &&
-      (xmlHashLookup2(ctxt->style->cdataSection,
-                      target->name, target->ns->href) != NULL))))
+        (ctxt->style->cdataSection != NULL) &&
+        (target != NULL) &&
+        (target->type == XML_ELEMENT_NODE) &&
+        (((target->ns == NULL) &&
+          (xmlHashLookup2(ctxt->style->cdataSection,
+                          target->name, NULL) != NULL)) ||
+         ((target->ns != NULL) &&
+          (xmlHashLookup2(ctxt->style->cdataSection,
+                          target->name, target->ns->href) != NULL))))
     {
-    /*
-    * Process "cdata-section-elements".
-    */
-    if ((target->last != NULL) &&
-        (target->last->type == XML_CDATA_SECTION_NODE))
-    {
-        return(xsltAddTextString(ctxt, target->last, string, len));
-    }
-    copy = xmlNewCDataBlock(ctxt->output, string, len);
+        /*
+        * Process "cdata-section-elements".
+        */
+        if ((target->last != NULL) &&
+            (target->last->type == XML_CDATA_SECTION_NODE))
+        {
+            return(xsltAddTextString(ctxt, target->last, string, len));
+        }
+        copy = xmlNewCDataBlock(ctxt->output, string, len);
     } else if (noescape) {
-    /*
-    * Process "disable-output-escaping".
-    */
-    if ((target != NULL) && (target->last != NULL) &&
-        (target->last->type == XML_TEXT_NODE) &&
-        (target->last->name == xmlStringTextNoenc))
-    {
-        return(xsltAddTextString(ctxt, target->last, string, len));
-    }
-    copy = xmlNewTextLen(string, len);
-    if (copy != NULL)
-        copy->name = xmlStringTextNoenc;
+        /*
+        * Process "disable-output-escaping".
+        */
+        if ((target != NULL) && (target->last != NULL) &&
+            (target->last->type == XML_TEXT_NODE) &&
+            (target->last->name == xmlStringTextNoenc))
+        {
+            return(xsltAddTextString(ctxt, target->last, string, len));
+        }
+        copy = xmlNewTextLen(string, len);
+        if (copy != NULL)
+            copy->name = xmlStringTextNoenc;
     } else {
-    /*
-    * Default processing.
-    */
-    if ((target != NULL) && (target->last != NULL) &&
-        (target->last->type == XML_TEXT_NODE) &&
-        (target->last->name == xmlStringText)) {
-        return(xsltAddTextString(ctxt, target->last, string, len));
-    }
-    copy = xmlNewTextLen(string, len);
+        /*
+        * Default processing.
+        */
+        if ((target != NULL) && (target->last != NULL) &&
+            (target->last->type == XML_TEXT_NODE) &&
+            (target->last->name == xmlStringText)) {
+            return(xsltAddTextString(ctxt, target->last, string, len));
+        }
+        copy = xmlNewTextLen(string, len);
     }
     if (copy != NULL && target != NULL)
-    copy = xsltAddChild(target, copy);
+        copy = xsltAddChild(target, copy);
     if (copy != NULL) {
-    ctxt->lasttext = copy->content;
-    ctxt->lasttsize = len;
-    ctxt->lasttuse = len;
+        ctxt->lasttext = copy->content;
+        ctxt->lasttsize = len;
+        ctxt->lasttuse = len;
     } else {
-    xsltTransformError(ctxt, NULL, target,
-             "xsltCopyTextString: text copy failed\n");
-    ctxt->lasttext = NULL;
+        xsltTransformError(ctxt, NULL, target,
+                         "xsltCopyTextString: text copy failed\n");
+        ctxt->lasttext = NULL;
     }
     return(copy);
 }
@@ -979,29 +979,29 @@ xsltCopyTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
  */
 static xmlNodePtr
 xsltCopyText(xsltTransformContextPtr ctxt, xmlNodePtr target,
-         xmlNodePtr cur, int interned)
+             xmlNodePtr cur, int interned)
 {
     xmlNodePtr copy;
 
     if ((cur->type != XML_TEXT_NODE) &&
-    (cur->type != XML_CDATA_SECTION_NODE))
-    return(NULL);
+        (cur->type != XML_CDATA_SECTION_NODE))
+        return(NULL);
     if (cur->content == NULL)
-    return(NULL);
+        return(NULL);
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (cur->type == XML_CDATA_SECTION_NODE) {
-    XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopyText: copy CDATA text %s\n",
-             cur->content));
+        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltCopyText: copy CDATA text %s\n",
+                         cur->content));
     } else if (cur->name == xmlStringTextNoenc) {
-    XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopyText: copy unescaped text %s\n",
-             cur->content));
+        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltCopyText: copy unescaped text %s\n",
+                         cur->content));
     } else {
-    XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopyText: copy text %s\n",
-             cur->content));
+        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_TEXT,xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltCopyText: copy text %s\n",
+                         cur->content));
     }
 #endif
 
@@ -1010,130 +1010,130 @@ xsltCopyText(xsltTransformContextPtr ctxt, xmlNodePtr target,
     * target node.
     */
     if ((target == NULL) || (target->children == NULL)) {
-    ctxt->lasttext = NULL;
+        ctxt->lasttext = NULL;
     }
 
     if ((ctxt->style->cdataSection != NULL) &&
-    (ctxt->type == XSLT_OUTPUT_XML) &&
-    (target != NULL) &&
-    (target->type == XML_ELEMENT_NODE) &&
-    (((target->ns == NULL) &&
-      (xmlHashLookup2(ctxt->style->cdataSection,
-                  target->name, NULL) != NULL)) ||
-     ((target->ns != NULL) &&
-      (xmlHashLookup2(ctxt->style->cdataSection,
-                      target->name, target->ns->href) != NULL))))
-    {
-    /*
-    * Process "cdata-section-elements".
-    */
-    /*
-    * OPTIMIZE TODO: xsltCopyText() is also used for attribute content.
-    */
-    /*
-    * TODO: Since this doesn't merge adjacent CDATA-section nodes,
-    * we'll get: <![CDATA[x]]><!CDATA[y]]>.
-    * TODO: Reported in #321505.
-    */
-    if ((target->last != NULL) &&
-         (target->last->type == XML_CDATA_SECTION_NODE))
+        (ctxt->type == XSLT_OUTPUT_XML) &&
+        (target != NULL) &&
+        (target->type == XML_ELEMENT_NODE) &&
+        (((target->ns == NULL) &&
+          (xmlHashLookup2(ctxt->style->cdataSection,
+                          target->name, NULL) != NULL)) ||
+         ((target->ns != NULL) &&
+          (xmlHashLookup2(ctxt->style->cdataSection,
+                          target->name, target->ns->href) != NULL))))
     {
         /*
-        * Append to existing CDATA-section node.
+        * Process "cdata-section-elements".
         */
+        /*
+        * OPTIMIZE TODO: xsltCopyText() is also used for attribute content.
+        */
+        /*
+        * TODO: Since this doesn't merge adjacent CDATA-section nodes,
+        * we'll get: <![CDATA[x]]><!CDATA[y]]>.
+        * TODO: Reported in #321505.
+        */
+        if ((target->last != NULL) &&
+             (target->last->type == XML_CDATA_SECTION_NODE))
+        {
+            /*
+            * Append to existing CDATA-section node.
+            */
+            copy = xsltAddTextString(ctxt, target->last, cur->content,
+                xmlStrlen(cur->content));
+            goto exit;
+        } else {
+            unsigned int len;
+
+            len = xmlStrlen(cur->content);
+            copy = xmlNewCDataBlock(ctxt->output, cur->content, len);
+            if (copy == NULL)
+                goto exit;
+            ctxt->lasttext = copy->content;
+            ctxt->lasttsize = len;
+            ctxt->lasttuse = len;
+        }
+    } else if ((target != NULL) &&
+        (target->last != NULL) &&
+        /* both escaped or both non-escaped text-nodes */
+        (((target->last->type == XML_TEXT_NODE) &&
+        (target->last->name == cur->name)) ||
+        /* non-escaped text nodes and CDATA-section nodes */
+        (((target->last->type == XML_CDATA_SECTION_NODE) &&
+        (cur->name == xmlStringTextNoenc)))))
+    {
+        /*
+         * we are appending to an existing text node
+         */
         copy = xsltAddTextString(ctxt, target->last, cur->content,
-        xmlStrlen(cur->content));
+            xmlStrlen(cur->content));
         goto exit;
+    } else if ((interned) && (target != NULL) &&
+        (target->doc != NULL) &&
+        (target->doc->dict == ctxt->dict))
+    {
+        /*
+        * TODO: DO we want to use this also for "text" output?
+        */
+        copy = xmlNewTextLen(NULL, 0);
+        if (copy == NULL)
+            goto exit;
+        if (cur->name == xmlStringTextNoenc)
+            copy->name = xmlStringTextNoenc;
+
+        /*
+         * Must confirm that content is in dict (bug 302821)
+         * TODO: This check should be not needed for text coming
+         * from the stylesheets
+         */
+        if (xmlDictOwns(ctxt->dict, cur->content))
+            copy->content = cur->content;
+        else {
+            if ((copy->content = xmlStrdup(cur->content)) == NULL)
+                return NULL;
+        }
+
+        ctxt->lasttext = NULL;
     } else {
+        /*
+         * normal processing. keep counters to extend the text node
+         * in xsltAddTextString if needed.
+         */
         unsigned int len;
 
         len = xmlStrlen(cur->content);
-        copy = xmlNewCDataBlock(ctxt->output, cur->content, len);
+        copy = xmlNewTextLen(cur->content, len);
         if (copy == NULL)
-        goto exit;
+            goto exit;
+        if (cur->name == xmlStringTextNoenc)
+            copy->name = xmlStringTextNoenc;
         ctxt->lasttext = copy->content;
         ctxt->lasttsize = len;
         ctxt->lasttuse = len;
     }
-    } else if ((target != NULL) &&
-    (target->last != NULL) &&
-    /* both escaped or both non-escaped text-nodes */
-    (((target->last->type == XML_TEXT_NODE) &&
-    (target->last->name == cur->name)) ||
-        /* non-escaped text nodes and CDATA-section nodes */
-    (((target->last->type == XML_CDATA_SECTION_NODE) &&
-    (cur->name == xmlStringTextNoenc)))))
-    {
-    /*
-     * we are appending to an existing text node
-     */
-    copy = xsltAddTextString(ctxt, target->last, cur->content,
-        xmlStrlen(cur->content));
-    goto exit;
-    } else if ((interned) && (target != NULL) &&
-    (target->doc != NULL) &&
-    (target->doc->dict == ctxt->dict))
-    {
-    /*
-    * TODO: DO we want to use this also for "text" output?
-    */
-        copy = xmlNewTextLen(NULL, 0);
-    if (copy == NULL)
-        goto exit;
-    if (cur->name == xmlStringTextNoenc)
-        copy->name = xmlStringTextNoenc;
-
-    /*
-     * Must confirm that content is in dict (bug 302821)
-     * TODO: This check should be not needed for text coming
-     * from the stylesheets
-     */
-    if (xmlDictOwns(ctxt->dict, cur->content))
-        copy->content = cur->content;
-    else {
-        if ((copy->content = xmlStrdup(cur->content)) == NULL)
-        return NULL;
-    }
-
-    ctxt->lasttext = NULL;
-    } else {
-        /*
-     * normal processing. keep counters to extend the text node
-     * in xsltAddTextString if needed.
-     */
-        unsigned int len;
-
-    len = xmlStrlen(cur->content);
-    copy = xmlNewTextLen(cur->content, len);
-    if (copy == NULL)
-        goto exit;
-    if (cur->name == xmlStringTextNoenc)
-        copy->name = xmlStringTextNoenc;
-    ctxt->lasttext = copy->content;
-    ctxt->lasttsize = len;
-    ctxt->lasttuse = len;
-    }
     if (copy != NULL) {
-    if (target != NULL) {
-        copy->doc = target->doc;
-        /*
-        * MAYBE TODO: Maybe we should reset the ctxt->lasttext here
-        *  to ensure that the optimized text-merging mechanism
-        *  won't interfere with normal node-merging in any case.
-        */
-        copy = xsltAddChild(target, copy);
-    }
+        if (target != NULL) {
+            copy->doc = target->doc;
+            /*
+            * MAYBE TODO: Maybe we should reset the ctxt->lasttext here
+            *  to ensure that the optimized text-merging mechanism
+            *  won't interfere with normal node-merging in any case.
+            */
+            copy = xsltAddChild(target, copy);
+        }
     } else {
-    xsltTransformError(ctxt, NULL, target,
-             "xsltCopyText: text copy failed\n");
+        xsltTransformError(ctxt, NULL, target,
+                         "xsltCopyText: text copy failed\n");
     }
 
 exit:
     if ((copy == NULL) || (copy->content == NULL)) {
-    xsltTransformError(ctxt, NULL, target,
-        "Internal error in xsltCopyText(): "
-        "Failed to copy the string.\n");
-    ctxt->state = XSLT_STATE_STOPPED;
+        xsltTransformError(ctxt, NULL, target,
+            "Internal error in xsltCopyText(): "
+            "Failed to copy the string.\n");
+        ctxt->state = XSLT_STATE_STOPPED;
     }
     return(copy);
 }
@@ -1155,55 +1155,55 @@ exit:
  */
 static xmlAttrPtr
 xsltShallowCopyAttr(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
-         xmlNodePtr target, xmlAttrPtr attr)
+             xmlNodePtr target, xmlAttrPtr attr)
 {
     xmlAttrPtr copy;
     xmlChar *value;
 
     if (attr == NULL)
-    return(NULL);
+        return(NULL);
 
     if (target->type != XML_ELEMENT_NODE) {
-    xsltTransformError(ctxt, NULL, invocNode,
-        "Cannot add an attribute node to a non-element node.\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, invocNode,
+            "Cannot add an attribute node to a non-element node.\n");
+        return(NULL);
     }
 
     if (target->children != NULL) {
-    xsltTransformError(ctxt, NULL, invocNode,
-        "Attribute nodes must be added before "
-        "any child nodes to an element.\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, invocNode,
+            "Attribute nodes must be added before "
+            "any child nodes to an element.\n");
+        return(NULL);
     }
 
     value = xmlNodeListGetString(attr->doc, attr->children, 1);
     if (attr->ns != NULL) {
-    xmlNsPtr ns;
+        xmlNsPtr ns;
 
-    ns = xsltGetSpecialNamespace(ctxt, invocNode,
-        attr->ns->href, attr->ns->prefix, target);
-    if (ns == NULL) {
-        xsltTransformError(ctxt, NULL, invocNode,
-        "Namespace fixup error: Failed to acquire an in-scope "
-        "namespace binding of the copied attribute '{%s}%s'.\n",
-        attr->ns->href, attr->name);
+        ns = xsltGetSpecialNamespace(ctxt, invocNode,
+            attr->ns->href, attr->ns->prefix, target);
+        if (ns == NULL) {
+            xsltTransformError(ctxt, NULL, invocNode,
+                "Namespace fixup error: Failed to acquire an in-scope "
+                "namespace binding of the copied attribute '{%s}%s'.\n",
+                attr->ns->href, attr->name);
+            /*
+            * TODO: Should we just stop here?
+            */
+        }
         /*
-        * TODO: Should we just stop here?
+        * Note that xmlSetNsProp() will take care of duplicates
+        * and assigns the new namespace even to a duplicate.
         */
-    }
-    /*
-    * Note that xmlSetNsProp() will take care of duplicates
-    * and assigns the new namespace even to a duplicate.
-    */
-    copy = xmlSetNsProp(target, ns, attr->name, value);
+        copy = xmlSetNsProp(target, ns, attr->name, value);
     } else {
-    copy = xmlSetNsProp(target, NULL, attr->name, value);
+        copy = xmlSetNsProp(target, NULL, attr->name, value);
     }
     if (value != NULL)
-    xmlFree(value);
+        xmlFree(value);
 
     if (copy == NULL)
-    return(NULL);
+        return(NULL);
 
 #if 0
     /*
@@ -1218,19 +1218,19 @@ xsltShallowCopyAttr(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
     */
     value = xmlNodeListGetString(attr->doc, attr->children, 1);
     if (value != NULL) {
-    txtNode = xmlNewDocText(target->doc, NULL);
-    if (txtNode == NULL)
-        return(NULL);
-    if ((target->doc != NULL) &&
-        (target->doc->dict != NULL))
-    {
-        txtNode->content =
-        (xmlChar *) xmlDictLookup(target->doc->dict,
-            BAD_CAST value, -1);
-        xmlFree(value);
-    } else
-        txtNode->content = value;
-    copy->children = txtNode;
+        txtNode = xmlNewDocText(target->doc, NULL);
+        if (txtNode == NULL)
+            return(NULL);
+        if ((target->doc != NULL) &&
+            (target->doc->dict != NULL))
+        {
+            txtNode->content =
+                (xmlChar *) xmlDictLookup(target->doc->dict,
+                    BAD_CAST value, -1);
+            xmlFree(value);
+        } else
+            txtNode->content = value;
+        copy->children = txtNode;
     }
 #endif
 
@@ -1254,8 +1254,8 @@ xsltShallowCopyAttr(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
  */
 static int
 xsltCopyAttrListNoOverwrite(xsltTransformContextPtr ctxt,
-                xmlNodePtr invocNode,
-                xmlNodePtr target, xmlAttrPtr attr)
+                            xmlNodePtr invocNode,
+                            xmlNodePtr target, xmlAttrPtr attr)
 {
     xmlAttrPtr copy;
     xmlNsPtr origNs = NULL, copyNs = NULL;
@@ -1266,40 +1266,40 @@ xsltCopyAttrListNoOverwrite(xsltTransformContextPtr ctxt,
     * reconciliate namespaces.
     */
     while (attr != NULL) {
-    /*
-    * Find a namespace node in the tree of @target.
-    * Avoid searching for the same ns.
-    */
-    if (attr->ns != origNs) {
-        origNs = attr->ns;
-        if (attr->ns != NULL) {
-        copyNs = xsltGetSpecialNamespace(ctxt, invocNode,
-            attr->ns->href, attr->ns->prefix, target);
-        if (copyNs == NULL)
-            return(-1);
-        } else
-        copyNs = NULL;
-    }
-    /*
-     * If attribute has a value, we need to copy it (watching out
-     * for possible entities)
-     */
-    if ((attr->children) && (attr->children->type == XML_TEXT_NODE) &&
+        /*
+        * Find a namespace node in the tree of @target.
+        * Avoid searching for the same ns.
+        */
+        if (attr->ns != origNs) {
+            origNs = attr->ns;
+            if (attr->ns != NULL) {
+                copyNs = xsltGetSpecialNamespace(ctxt, invocNode,
+                    attr->ns->href, attr->ns->prefix, target);
+                if (copyNs == NULL)
+                    return(-1);
+            } else
+                copyNs = NULL;
+        }
+        /*
+         * If attribute has a value, we need to copy it (watching out
+         * for possible entities)
+         */
+        if ((attr->children) && (attr->children->type == XML_TEXT_NODE) &&
             (attr->children->next == NULL)) {
             copy = xmlNewNsProp(target, copyNs, attr->name,
                                 attr->children->content);
         } else if (attr->children != NULL) {
-        value = xmlNodeListGetString(attr->doc, attr->children, 1);
+            value = xmlNodeListGetString(attr->doc, attr->children, 1);
             copy = xmlNewNsProp(target, copyNs, attr->name, BAD_CAST value);
-        xmlFree(value);
+            xmlFree(value);
         } else {
             copy = xmlNewNsProp(target, copyNs, attr->name, NULL);
         }
 
-    if (copy == NULL)
-        return(-1);
+        if (copy == NULL)
+            return(-1);
 
-    attr = attr->next;
+        attr = attr->next;
     }
     return(0);
 }
@@ -1330,73 +1330,73 @@ xsltCopyAttrListNoOverwrite(xsltTransformContextPtr ctxt,
  */
 static xmlNodePtr
 xsltShallowCopyElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
-            xmlNodePtr insert, int isLRE)
+                    xmlNodePtr insert, int isLRE)
 {
     xmlNodePtr copy;
 
     if ((node->type == XML_DTD_NODE) || (insert == NULL))
-    return(NULL);
+        return(NULL);
     if ((node->type == XML_TEXT_NODE) ||
-    (node->type == XML_CDATA_SECTION_NODE))
-    return(xsltCopyText(ctxt, insert, node, 0));
+        (node->type == XML_CDATA_SECTION_NODE))
+        return(xsltCopyText(ctxt, insert, node, 0));
 
     copy = xmlDocCopyNode(node, insert->doc, 0);
     if (copy != NULL) {
-    copy->doc = ctxt->output;
-    copy = xsltAddChild(insert, copy);
+        copy->doc = ctxt->output;
+        copy = xsltAddChild(insert, copy);
         if (copy == NULL) {
              xsltTransformError(ctxt, NULL, node,
                 "xsltShallowCopyElem: copy failed\n");
              return (copy);
         }
 
-    if (node->type == XML_ELEMENT_NODE) {
-        /*
-         * Add namespaces as they are needed
-         */
-        if (node->nsDef != NULL) {
-        /*
-        * TODO: Remove the LRE case in the refactored code
-        * gets enabled.
-        */
-        if (isLRE)
-            xsltCopyNamespaceList(ctxt, copy, node->nsDef);
-        else
-            xsltCopyNamespaceListInternal(copy, node->nsDef);
-        }
-
-        /*
-        * URGENT TODO: The problem with this is that it does not
-        *  copy over all namespace nodes in scope.
-        *  The damn thing about this is, that we would need to
-        *  use the xmlGetNsList(), for every single node; this is
-        *  also done in xsltCopyTree(), but only for the top node.
-        */
-        if (node->ns != NULL) {
-        if (isLRE) {
+        if (node->type == XML_ELEMENT_NODE) {
             /*
-            * REVISIT TODO: Since the non-refactored code still does
-            *  ns-aliasing, we need to call xsltGetNamespace() here.
-            *  Remove this when ready.
-            */
-            copy->ns = xsltGetNamespace(ctxt, node, node->ns, copy);
-        } else {
-            copy->ns = xsltGetSpecialNamespace(ctxt,
-            node, node->ns->href, node->ns->prefix, copy);
+             * Add namespaces as they are needed
+             */
+            if (node->nsDef != NULL) {
+                /*
+                * TODO: Remove the LRE case in the refactored code
+                * gets enabled.
+                */
+                if (isLRE)
+                    xsltCopyNamespaceList(ctxt, copy, node->nsDef);
+                else
+                    xsltCopyNamespaceListInternal(copy, node->nsDef);
+            }
 
+            /*
+            * URGENT TODO: The problem with this is that it does not
+            *  copy over all namespace nodes in scope.
+            *  The damn thing about this is, that we would need to
+            *  use the xmlGetNsList(), for every single node; this is
+            *  also done in xsltCopyTree(), but only for the top node.
+            */
+            if (node->ns != NULL) {
+                if (isLRE) {
+                    /*
+                    * REVISIT TODO: Since the non-refactored code still does
+                    *  ns-aliasing, we need to call xsltGetNamespace() here.
+                    *  Remove this when ready.
+                    */
+                    copy->ns = xsltGetNamespace(ctxt, node, node->ns, copy);
+                } else {
+                    copy->ns = xsltGetSpecialNamespace(ctxt,
+                        node, node->ns->href, node->ns->prefix, copy);
+
+                }
+            } else if ((insert->type == XML_ELEMENT_NODE) &&
+                       (insert->ns != NULL))
+            {
+                /*
+                * "Undeclare" the default namespace.
+                */
+                xsltGetSpecialNamespace(ctxt, node, NULL, NULL, copy);
+            }
         }
-        } else if ((insert->type == XML_ELEMENT_NODE) &&
-               (insert->ns != NULL))
-        {
-        /*
-        * "Undeclare" the default namespace.
-        */
-        xsltGetSpecialNamespace(ctxt, node, NULL, NULL, copy);
-        }
-    }
     } else {
-    xsltTransformError(ctxt, NULL, node,
-        "xsltShallowCopyElem: copy %s failed\n", node->name);
+        xsltTransformError(ctxt, NULL, node,
+                "xsltShallowCopyElem: copy %s failed\n", node->name);
     }
     return(copy);
 }
@@ -1422,20 +1422,20 @@ xsltShallowCopyElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 static xmlNodePtr
 xsltCopyTreeList(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
-         xmlNodePtr list,
-         xmlNodePtr insert, int isLRE, int topElemVisited)
+                 xmlNodePtr list,
+                 xmlNodePtr insert, int isLRE, int topElemVisited)
 {
     xmlNodePtr copy, ret = NULL;
 
     while (list != NULL) {
-    copy = xsltCopyTree(ctxt, invocNode,
-        list, insert, isLRE, topElemVisited);
-    if (copy != NULL) {
-        if (ret == NULL) {
-        ret = copy;
+        copy = xsltCopyTree(ctxt, invocNode,
+            list, insert, isLRE, topElemVisited);
+        if (copy != NULL) {
+            if (ret == NULL) {
+                ret = copy;
+            }
         }
-    }
-    list = list->next;
+        list = list->next;
     }
     return(ret);
 }
@@ -1462,42 +1462,42 @@ xsltCopyNamespaceListInternal(xmlNodePtr elem, xmlNsPtr ns) {
     xmlNsPtr p = NULL, q, luNs;
 
     if (ns == NULL)
-    return(NULL);
+        return(NULL);
     /*
      * One can add namespaces only on element nodes
      */
     if ((elem != NULL) && (elem->type != XML_ELEMENT_NODE))
-    elem = NULL;
+        elem = NULL;
 
     do {
-    if (ns->type != XML_NAMESPACE_DECL)
-        break;
-    /*
-     * Avoid duplicating namespace declarations on the tree.
-     */
-    if (elem != NULL) {
-        if ((elem->ns != NULL) &&
-        xmlStrEqual(elem->ns->prefix, ns->prefix) &&
-        xmlStrEqual(elem->ns->href, ns->href))
-        {
-        ns = ns->next;
-        continue;
+        if (ns->type != XML_NAMESPACE_DECL)
+            break;
+        /*
+         * Avoid duplicating namespace declarations on the tree.
+         */
+        if (elem != NULL) {
+            if ((elem->ns != NULL) &&
+                xmlStrEqual(elem->ns->prefix, ns->prefix) &&
+                xmlStrEqual(elem->ns->href, ns->href))
+            {
+                ns = ns->next;
+                continue;
+            }
+            luNs = xmlSearchNs(elem->doc, elem, ns->prefix);
+            if ((luNs != NULL) && (xmlStrEqual(luNs->href, ns->href)))
+            {
+                ns = ns->next;
+                continue;
+            }
         }
-        luNs = xmlSearchNs(elem->doc, elem, ns->prefix);
-        if ((luNs != NULL) && (xmlStrEqual(luNs->href, ns->href)))
-        {
-        ns = ns->next;
-        continue;
+        q = xmlNewNs(elem, ns->href, ns->prefix);
+        if (p == NULL) {
+            ret = p = q;
+        } else if (q != NULL) {
+            p->next = q;
+            p = q;
         }
-    }
-    q = xmlNewNs(elem, ns->href, ns->prefix);
-    if (p == NULL) {
-        ret = p = q;
-    } else if (q != NULL) {
-        p->next = q;
-        p = q;
-    }
-    ns = ns->next;
+        ns = ns->next;
     } while (ns != NULL);
     return(ret);
 }
@@ -1515,9 +1515,9 @@ xsltCopyNamespaceListInternal(xmlNodePtr elem, xmlNsPtr ns) {
  */
 static xmlNsPtr
 xsltShallowCopyNsNode(xsltTransformContextPtr ctxt,
-              xmlNodePtr invocNode,
-              xmlNodePtr insert,
-              xmlNsPtr ns)
+                      xmlNodePtr invocNode,
+                      xmlNodePtr insert,
+                      xmlNsPtr ns)
 {
     /*
      * TODO: Contrary to header comments, this is declared as int.
@@ -1526,13 +1526,13 @@ xsltShallowCopyNsNode(xsltTransformContextPtr ctxt,
     xmlNsPtr tmpns;
 
     if ((insert == NULL) || (insert->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     if (insert->children != NULL) {
-    xsltTransformError(ctxt, NULL, invocNode,
-        "Namespace nodes must be added before "
-        "any child nodes are added to an element.\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, invocNode,
+            "Namespace nodes must be added before "
+            "any child nodes are added to an element.\n");
+        return(NULL);
     }
     /*
      * BIG NOTE: Xalan-J simply overwrites any ns-decls with
@@ -1549,46 +1549,46 @@ xsltShallowCopyNsNode(xsltTransformContextPtr ctxt,
      * REVISIT TODO: Check if it's better to follow Saxon here.
      */
     if (ns->prefix == NULL) {
-    /*
-    * If we are adding ns-nodes to an element using e.g.
-    * <xsl:copy-of select="/foo/namespace::*">, then we need
-    * to ensure that we don't incorrectly declare a default
-    * namespace on an element in no namespace, which otherwise
-    * would move the element incorrectly into a namespace, if
-    * the node tree is serialized.
-    */
-    if (insert->ns == NULL)
-        goto occupied;
+        /*
+        * If we are adding ns-nodes to an element using e.g.
+        * <xsl:copy-of select="/foo/namespace::*">, then we need
+        * to ensure that we don't incorrectly declare a default
+        * namespace on an element in no namespace, which otherwise
+        * would move the element incorrectly into a namespace, if
+        * the node tree is serialized.
+        */
+        if (insert->ns == NULL)
+            goto occupied;
     } else if ((ns->prefix[0] == 'x') &&
-    xmlStrEqual(ns->prefix, BAD_CAST "xml"))
+        xmlStrEqual(ns->prefix, BAD_CAST "xml"))
     {
-    /*
-    * The XML namespace is built in.
-    */
-    return(NULL);
+        /*
+        * The XML namespace is built in.
+        */
+        return(NULL);
     }
 
     if (insert->nsDef != NULL) {
-    tmpns = insert->nsDef;
-    do {
-        if ((tmpns->prefix == NULL) == (ns->prefix == NULL)) {
-        if ((tmpns->prefix == ns->prefix) ||
-            xmlStrEqual(tmpns->prefix, ns->prefix))
-        {
-            /*
-            * Same prefix.
-            */
-            if (xmlStrEqual(tmpns->href, ns->href))
-            return(NULL);
-            goto occupied;
-        }
-        }
-        tmpns = tmpns->next;
-    } while (tmpns != NULL);
+        tmpns = insert->nsDef;
+        do {
+            if ((tmpns->prefix == NULL) == (ns->prefix == NULL)) {
+                if ((tmpns->prefix == ns->prefix) ||
+                    xmlStrEqual(tmpns->prefix, ns->prefix))
+                {
+                    /*
+                    * Same prefix.
+                    */
+                    if (xmlStrEqual(tmpns->href, ns->href))
+                        return(NULL);
+                    goto occupied;
+                }
+            }
+            tmpns = tmpns->next;
+        } while (tmpns != NULL);
     }
     tmpns = xmlSearchNs(insert->doc, insert, ns->prefix);
     if ((tmpns != NULL) && xmlStrEqual(tmpns->href, ns->href))
-    return(NULL);
+        return(NULL);
     /*
     * Declare a new namespace.
     * TODO: The problem (wrt efficiency) with this xmlNewNs() is
@@ -1626,13 +1626,13 @@ occupied:
  */
 static xmlNodePtr
 xsltCopyTree(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
-         xmlNodePtr node, xmlNodePtr insert, int isLRE,
-         int topElemVisited)
+             xmlNodePtr node, xmlNodePtr insert, int isLRE,
+             int topElemVisited)
 {
     xmlNodePtr copy;
 
     if (node == NULL)
-    return(NULL);
+        return(NULL);
     switch (node->type) {
         case XML_ELEMENT_NODE:
         case XML_ENTITY_REF_NODE:
@@ -1644,19 +1644,19 @@ xsltCopyTree(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
 #ifdef LIBXML_DOCB_ENABLED
         case XML_DOCB_DOCUMENT_NODE:
 #endif
-        break;
+            break;
         case XML_TEXT_NODE: {
-        int noenc = (node->name == xmlStringTextNoenc);
-        return(xsltCopyTextString(ctxt, insert, node->content, noenc));
-        }
+            int noenc = (node->name == xmlStringTextNoenc);
+            return(xsltCopyTextString(ctxt, insert, node->content, noenc));
+            }
         case XML_CDATA_SECTION_NODE:
-        return(xsltCopyTextString(ctxt, insert, node->content, 0));
+            return(xsltCopyTextString(ctxt, insert, node->content, 0));
         case XML_ATTRIBUTE_NODE:
-        return((xmlNodePtr)
-        xsltShallowCopyAttr(ctxt, invocNode, insert, (xmlAttrPtr) node));
+            return((xmlNodePtr)
+                xsltShallowCopyAttr(ctxt, invocNode, insert, (xmlAttrPtr) node));
         case XML_NAMESPACE_DECL:
-        return((xmlNodePtr) xsltShallowCopyNsNode(ctxt, invocNode,
-        insert, (xmlNsPtr) node));
+            return((xmlNodePtr) xsltShallowCopyNsNode(ctxt, invocNode,
+                insert, (xmlNsPtr) node));
 
         case XML_DOCUMENT_TYPE_NODE:
         case XML_DOCUMENT_FRAG_NODE:
@@ -1670,159 +1670,159 @@ xsltCopyTree(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
             return(NULL);
     }
     if (XSLT_IS_RES_TREE_FRAG(node)) {
-    if (node->children != NULL)
-        copy = xsltCopyTreeList(ctxt, invocNode,
-        node->children, insert, 0, 0);
-    else
-        copy = NULL;
-    return(copy);
+        if (node->children != NULL)
+            copy = xsltCopyTreeList(ctxt, invocNode,
+                node->children, insert, 0, 0);
+        else
+            copy = NULL;
+        return(copy);
     }
     copy = xmlDocCopyNode(node, insert->doc, 0);
     if (copy != NULL) {
-    copy->doc = ctxt->output;
-    copy = xsltAddChild(insert, copy);
+        copy->doc = ctxt->output;
+        copy = xsltAddChild(insert, copy);
         if (copy == NULL) {
             xsltTransformError(ctxt, NULL, invocNode,
             "xsltCopyTree: Copying of '%s' failed.\n", node->name);
             return (copy);
         }
-    /*
-     * The node may have been coalesced into another text node.
-     */
-    if (insert->last != copy)
-        return(insert->last);
-    copy->next = NULL;
-
-    if (node->type == XML_ELEMENT_NODE) {
         /*
-        * Copy in-scope namespace nodes.
-        *
-        * REVISIT: Since we try to reuse existing in-scope ns-decls by
-        *  using xmlSearchNsByHref(), this will eventually change
-        *  the prefix of an original ns-binding; thus it might
-        *  break QNames in element/attribute content.
-        * OPTIMIZE TODO: If we had a xmlNsPtr * on the transformation
-        *  context, plus a ns-lookup function, which writes directly
-        *  to a given list, then we wouldn't need to create/free the
-        *  nsList every time.
-        */
-        if ((topElemVisited == 0) &&
-        (node->parent != NULL) &&
-        (node->parent->type != XML_DOCUMENT_NODE) &&
-        (node->parent->type != XML_HTML_DOCUMENT_NODE))
-        {
-        xmlNsPtr *nsList, *curns, ns;
+         * The node may have been coalesced into another text node.
+         */
+        if (insert->last != copy)
+            return(insert->last);
+        copy->next = NULL;
 
-        /*
-        * If this is a top-most element in a tree to be
-        * copied, then we need to ensure that all in-scope
-        * namespaces are copied over. For nodes deeper in the
-        * tree, it is sufficient to reconcile only the ns-decls
-        * (node->nsDef entries).
-        */
-
-        nsList = xmlGetNsList(node->doc, node);
-        if (nsList != NULL) {
-            curns = nsList;
-            do {
+        if (node->type == XML_ELEMENT_NODE) {
             /*
-            * Search by prefix first in order to break as less
-            * QNames in element/attribute content as possible.
+            * Copy in-scope namespace nodes.
+            *
+            * REVISIT: Since we try to reuse existing in-scope ns-decls by
+            *  using xmlSearchNsByHref(), this will eventually change
+            *  the prefix of an original ns-binding; thus it might
+            *  break QNames in element/attribute content.
+            * OPTIMIZE TODO: If we had a xmlNsPtr * on the transformation
+            *  context, plus a ns-lookup function, which writes directly
+            *  to a given list, then we wouldn't need to create/free the
+            *  nsList every time.
             */
-            ns = xmlSearchNs(insert->doc, insert,
-                (*curns)->prefix);
-
-            if ((ns == NULL) ||
-                (! xmlStrEqual(ns->href, (*curns)->href)))
+            if ((topElemVisited == 0) &&
+                (node->parent != NULL) &&
+                (node->parent->type != XML_DOCUMENT_NODE) &&
+                (node->parent->type != XML_HTML_DOCUMENT_NODE))
             {
-                ns = NULL;
+                xmlNsPtr *nsList, *curns, ns;
+
                 /*
-                * Search by namespace name.
-                * REVISIT TODO: Currently disabled.
+                * If this is a top-most element in a tree to be
+                * copied, then we need to ensure that all in-scope
+                * namespaces are copied over. For nodes deeper in the
+                * tree, it is sufficient to reconcile only the ns-decls
+                * (node->nsDef entries).
                 */
+
+                nsList = xmlGetNsList(node->doc, node);
+                if (nsList != NULL) {
+                    curns = nsList;
+                    do {
+                        /*
+                        * Search by prefix first in order to break as less
+                        * QNames in element/attribute content as possible.
+                        */
+                        ns = xmlSearchNs(insert->doc, insert,
+                            (*curns)->prefix);
+
+                        if ((ns == NULL) ||
+                            (! xmlStrEqual(ns->href, (*curns)->href)))
+                        {
+                            ns = NULL;
+                            /*
+                            * Search by namespace name.
+                            * REVISIT TODO: Currently disabled.
+                            */
 #if 0
-                ns = xmlSearchNsByHref(insert->doc,
-                insert, (*curns)->href);
+                            ns = xmlSearchNsByHref(insert->doc,
+                                insert, (*curns)->href);
 #endif
-            }
-            if (ns == NULL) {
+                        }
+                        if (ns == NULL) {
+                            /*
+                            * Declare a new namespace on the copied element.
+                            */
+                            ns = xmlNewNs(copy, (*curns)->href,
+                                (*curns)->prefix);
+                            /* TODO: Handle errors */
+                        }
+                        if (node->ns == *curns) {
+                            /*
+                            * If this was the original's namespace then set
+                            * the generated counterpart on the copy.
+                            */
+                            copy->ns = ns;
+                        }
+                        curns++;
+                    } while (*curns != NULL);
+                    xmlFree(nsList);
+                }
+            } else if (node->nsDef != NULL) {
                 /*
-                * Declare a new namespace on the copied element.
+                * Copy over all namespace declaration attributes.
                 */
-                ns = xmlNewNs(copy, (*curns)->href,
-                (*curns)->prefix);
-                /* TODO: Handle errors */
+                if (node->nsDef != NULL) {
+                    if (isLRE)
+                        xsltCopyNamespaceList(ctxt, copy, node->nsDef);
+                    else
+                        xsltCopyNamespaceListInternal(copy, node->nsDef);
+                }
             }
-            if (node->ns == *curns) {
-                /*
-                * If this was the original's namespace then set
-                * the generated counterpart on the copy.
-                */
-                copy->ns = ns;
-            }
-            curns++;
-            } while (*curns != NULL);
-            xmlFree(nsList);
-        }
-        } else if (node->nsDef != NULL) {
-        /*
-        * Copy over all namespace declaration attributes.
-        */
-        if (node->nsDef != NULL) {
-            if (isLRE)
-            xsltCopyNamespaceList(ctxt, copy, node->nsDef);
-            else
-            xsltCopyNamespaceListInternal(copy, node->nsDef);
-        }
-        }
-        /*
-        * Set the namespace.
-        */
-        if (node->ns != NULL) {
-        if (copy->ns == NULL) {
             /*
-            * This will map copy->ns to one of the newly created
-            * in-scope ns-decls, OR create a new ns-decl on @copy.
+            * Set the namespace.
             */
-            copy->ns = xsltGetSpecialNamespace(ctxt, invocNode,
-            node->ns->href, node->ns->prefix, copy);
+            if (node->ns != NULL) {
+                if (copy->ns == NULL) {
+                    /*
+                    * This will map copy->ns to one of the newly created
+                    * in-scope ns-decls, OR create a new ns-decl on @copy.
+                    */
+                    copy->ns = xsltGetSpecialNamespace(ctxt, invocNode,
+                        node->ns->href, node->ns->prefix, copy);
+                }
+            } else if ((insert->type == XML_ELEMENT_NODE) &&
+                (insert->ns != NULL))
+            {
+                /*
+                * "Undeclare" the default namespace on @copy with xmlns="".
+                */
+                xsltGetSpecialNamespace(ctxt, invocNode, NULL, NULL, copy);
+            }
+            /*
+            * Copy attribute nodes.
+            */
+            if (node->properties != NULL) {
+                xsltCopyAttrListNoOverwrite(ctxt, invocNode,
+                    copy, node->properties);
+            }
+            if (topElemVisited == 0)
+                topElemVisited = 1;
         }
-        } else if ((insert->type == XML_ELEMENT_NODE) &&
-        (insert->ns != NULL))
-        {
         /*
-        * "Undeclare" the default namespace on @copy with xmlns="".
+        * Copy the subtree.
         */
-        xsltGetSpecialNamespace(ctxt, invocNode, NULL, NULL, copy);
+        if (node->children != NULL) {
+            xsltCopyTreeList(ctxt, invocNode,
+                node->children, copy, isLRE, topElemVisited);
         }
-        /*
-        * Copy attribute nodes.
-        */
-        if (node->properties != NULL) {
-        xsltCopyAttrListNoOverwrite(ctxt, invocNode,
-            copy, node->properties);
-        }
-        if (topElemVisited == 0)
-        topElemVisited = 1;
-    }
-    /*
-    * Copy the subtree.
-    */
-    if (node->children != NULL) {
-        xsltCopyTreeList(ctxt, invocNode,
-        node->children, copy, isLRE, topElemVisited);
-    }
     } else {
-    xsltTransformError(ctxt, NULL, invocNode,
-        "xsltCopyTree: Copying of '%s' failed.\n", node->name);
+        xsltTransformError(ctxt, NULL, invocNode,
+            "xsltCopyTree: Copying of '%s' failed.\n", node->name);
     }
     return(copy);
 }
 
 /************************************************************************
- *                                  *
- *      Error/fallback processing               *
- *                                  *
+ *                                                                      *
+ *              Error/fallback processing                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1837,36 +1837,36 @@ xsltCopyTree(xsltTransformContextPtr ctxt, xmlNodePtr invocNode,
  */
 static int
 xsltApplyFallbacks(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst) {
+                   xmlNodePtr inst) {
 
     xmlNodePtr child;
     int ret = 0;
 
     if ((ctxt == NULL) || (node == NULL) || (inst == NULL) ||
-    (inst->children == NULL))
-    return(0);
+        (inst->children == NULL))
+        return(0);
 
     child = inst->children;
     while (child != NULL) {
         if ((IS_XSLT_ELEM(child)) &&
             (xmlStrEqual(child->name, BAD_CAST "fallback"))) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-                 "applying xsl:fallback\n");
+            xsltGenericDebug(xsltGenericDebugContext,
+                             "applying xsl:fallback\n");
 #endif
-        ret++;
-        xsltApplySequenceConstructor(ctxt, node, child->children,
-        NULL);
-    }
-    child = child->next;
+            ret++;
+            xsltApplySequenceConstructor(ctxt, node, child->children,
+                NULL);
+        }
+        child = child->next;
     }
     return(ret);
 }
 
 /************************************************************************
- *                                  *
- *          Default processing              *
- *                                  *
+ *                                                                      *
+ *                      Default processing                              *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1893,9 +1893,9 @@ xsltApplyFallbacks(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 static void
 xsltDefaultProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr node,
-              xsltStackElemPtr params) {
+                          xsltStackElemPtr params) {
     xmlNodePtr copy;
-    xmlNodePtr delete = NULL, cur;
+    xmlNodePtr cur;
     int nbchild = 0, oldSize;
     int childno = 0, oldPos;
     xsltTemplatePtr template;
@@ -1905,117 +1905,76 @@ xsltDefaultProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr node,
      * Handling of leaves
      */
     switch (node->type) {
-    case XML_DOCUMENT_NODE:
-    case XML_HTML_DOCUMENT_NODE:
-    case XML_ELEMENT_NODE:
-        break;
-    case XML_CDATA_SECTION_NODE:
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: copy CDATA %s\n",
-        node->content));
-#endif
-        copy = xsltCopyText(ctxt, ctxt->insert, node, 0);
-        if (copy == NULL) {
-        xsltTransformError(ctxt, NULL, node,
-         "xsltDefaultProcessOneNode: cdata copy failed\n");
-        }
-        return;
-    case XML_TEXT_NODE:
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        if (node->content == NULL) {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: copy empty text\n"));
-        return;
-        } else {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: copy text %s\n",
-            node->content));
-            }
-#endif
-        copy = xsltCopyText(ctxt, ctxt->insert, node, 0);
-        if (copy == NULL) {
-        xsltTransformError(ctxt, NULL, node,
-         "xsltDefaultProcessOneNode: text copy failed\n");
-        }
-        return;
-    case XML_ATTRIBUTE_NODE:
-        cur = node->children;
-        while ((cur != NULL) && (cur->type != XML_TEXT_NODE))
-        cur = cur->next;
-        if (cur == NULL) {
-        xsltTransformError(ctxt, NULL, node,
-         "xsltDefaultProcessOneNode: no text for attribute\n");
-        } else {
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        if (cur->content == NULL) {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: copy empty text\n"));
-        } else {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: copy text %s\n",
-            cur->content));
-                }
-#endif
-        copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
-        if (copy == NULL) {
-            xsltTransformError(ctxt, NULL, node,
-             "xsltDefaultProcessOneNode: text copy failed\n");
-        }
-        }
-        return;
-    default:
-        return;
-    }
-    /*
-     * Handling of Elements: first pass, cleanup and counting
-     */
-    cur = node->children;
-    while (cur != NULL) {
-    switch (cur->type) {
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
         case XML_DOCUMENT_NODE:
         case XML_HTML_DOCUMENT_NODE:
         case XML_ELEMENT_NODE:
-        case XML_PI_NODE:
-        case XML_COMMENT_NODE:
-        nbchild++;
-        break;
-            case XML_DTD_NODE:
-        /* Unlink the DTD, it's still reachable using doc->intSubset */
-        if (cur->next != NULL)
-            cur->next->prev = cur->prev;
-        if (cur->prev != NULL)
-            cur->prev->next = cur->next;
-        break;
+            break;
+        case XML_CDATA_SECTION_NODE:
+#ifdef WITH_XSLT_DEBUG_PROCESS
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltDefaultProcessOneNode: copy CDATA %s\n",
+                node->content));
+#endif
+            copy = xsltCopyText(ctxt, ctxt->insert, node, 0);
+            if (copy == NULL) {
+                xsltTransformError(ctxt, NULL, node,
+                 "xsltDefaultProcessOneNode: cdata copy failed\n");
+            }
+            return;
+        case XML_TEXT_NODE:
+#ifdef WITH_XSLT_DEBUG_PROCESS
+            if (node->content == NULL) {
+                XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltDefaultProcessOneNode: copy empty text\n"));
+                return;
+            } else {
+                XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltDefaultProcessOneNode: copy text %s\n",
+                        node->content));
+            }
+#endif
+            copy = xsltCopyText(ctxt, ctxt->insert, node, 0);
+            if (copy == NULL) {
+                xsltTransformError(ctxt, NULL, node,
+                 "xsltDefaultProcessOneNode: text copy failed\n");
+            }
+            return;
+        case XML_ATTRIBUTE_NODE:
+            cur = node->children;
+            while ((cur != NULL) && (cur->type != XML_TEXT_NODE))
+                cur = cur->next;
+            if (cur == NULL) {
+                xsltTransformError(ctxt, NULL, node,
+                 "xsltDefaultProcessOneNode: no text for attribute\n");
+            } else {
+#ifdef WITH_XSLT_DEBUG_PROCESS
+                if (cur->content == NULL) {
+                    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: copy empty text\n"));
+                } else {
+                    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: copy text %s\n",
+                        cur->content));
+                }
+#endif
+                copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
+                if (copy == NULL) {
+                    xsltTransformError(ctxt, NULL, node,
+                     "xsltDefaultProcessOneNode: text copy failed\n");
+                }
+            }
+            return;
         default:
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: skipping node type %d\n",
-                         cur->type));
-#endif
-        delete = cur;
+            return;
     }
-    cur = cur->next;
-    if (delete != NULL) {
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: removing ignorable blank node\n"));
-#endif
-        xmlUnlinkNode(delete);
-        xmlFreeNode(delete);
-        delete = NULL;
-    }
-    }
-    if (delete != NULL) {
-#ifdef WITH_XSLT_DEBUG_PROCESS
-    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: removing ignorable blank node\n"));
-#endif
-    xmlUnlinkNode(delete);
-    xmlFreeNode(delete);
-    delete = NULL;
+    /*
+     * Handling of Elements: first pass, counting
+     */
+    cur = node->children;
+    while (cur != NULL) {
+        if (IS_XSLT_REAL_NODE(cur))
+            nbchild++;
+        cur = cur->next;
     }
 
     /*
@@ -2028,101 +1987,101 @@ xsltDefaultProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr node,
     oldPos = ctxt->xpathCtxt->proximityPosition;
     cur = node->children;
     while (cur != NULL) {
-    childno++;
-    switch (cur->type) {
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-        case XML_ELEMENT_NODE:
-        ctxt->xpathCtxt->contextSize = nbchild;
-        ctxt->xpathCtxt->proximityPosition = childno;
-        xsltProcessOneNode(ctxt, cur, params);
-        break;
-        case XML_CDATA_SECTION_NODE:
-        template = xsltGetTemplate(ctxt, cur, NULL);
-        if (template) {
+        childno++;
+        switch (cur->type) {
+            case XML_DOCUMENT_NODE:
+            case XML_HTML_DOCUMENT_NODE:
+            case XML_ELEMENT_NODE:
+                ctxt->xpathCtxt->contextSize = nbchild;
+                ctxt->xpathCtxt->proximityPosition = childno;
+                xsltProcessOneNode(ctxt, cur, params);
+                break;
+            case XML_CDATA_SECTION_NODE:
+                template = xsltGetTemplate(ctxt, cur, NULL);
+                if (template) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: applying template for CDATA %s\n",
-                     cur->content));
+                    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltDefaultProcessOneNode: applying template for CDATA %s\n",
+                                     cur->content));
 #endif
-            /*
-            * Instantiate the xsl:template.
-            */
-            xsltApplyXSLTTemplate(ctxt, cur, template->content,
-            template, params);
-        } else /* if (ctxt->mode == NULL) */ {
+                    /*
+                    * Instantiate the xsl:template.
+                    */
+                    xsltApplyXSLTTemplate(ctxt, cur, template->content,
+                        template, params);
+                } else /* if (ctxt->mode == NULL) */ {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: copy CDATA %s\n",
-                     cur->content));
+                    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: copy CDATA %s\n",
+                                     cur->content));
 #endif
-            copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
-            if (copy == NULL) {
-            xsltTransformError(ctxt, NULL, cur,
-                "xsltDefaultProcessOneNode: cdata copy failed\n");
-            }
-        }
-        break;
-        case XML_TEXT_NODE:
-        template = xsltGetTemplate(ctxt, cur, NULL);
-        if (template) {
+                    copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
+                    if (copy == NULL) {
+                        xsltTransformError(ctxt, NULL, cur,
+                            "xsltDefaultProcessOneNode: cdata copy failed\n");
+                    }
+                }
+                break;
+            case XML_TEXT_NODE:
+                template = xsltGetTemplate(ctxt, cur, NULL);
+                if (template) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltDefaultProcessOneNode: applying template for text %s\n",
-                     cur->content));
+                    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltDefaultProcessOneNode: applying template for text %s\n",
+                                     cur->content));
 #endif
-            ctxt->xpathCtxt->contextSize = nbchild;
-            ctxt->xpathCtxt->proximityPosition = childno;
-            /*
-            * Instantiate the xsl:template.
-            */
-            xsltApplyXSLTTemplate(ctxt, cur, template->content,
-            template, params);
-        } else /* if (ctxt->mode == NULL) */ {
+                    ctxt->xpathCtxt->contextSize = nbchild;
+                    ctxt->xpathCtxt->proximityPosition = childno;
+                    /*
+                    * Instantiate the xsl:template.
+                    */
+                    xsltApplyXSLTTemplate(ctxt, cur, template->content,
+                        template, params);
+                } else /* if (ctxt->mode == NULL) */ {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            if (cur->content == NULL) {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: copy empty text\n"));
-            } else {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: copy text %s\n",
-                     cur->content));
+                    if (cur->content == NULL) {
+                        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltDefaultProcessOneNode: copy empty text\n"));
+                    } else {
+                        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: copy text %s\n",
+                                         cur->content));
                     }
 #endif
-            copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
-            if (copy == NULL) {
-            xsltTransformError(ctxt, NULL, cur,
-                "xsltDefaultProcessOneNode: text copy failed\n");
-            }
-        }
-        break;
-        case XML_PI_NODE:
-        case XML_COMMENT_NODE:
-        template = xsltGetTemplate(ctxt, cur, NULL);
-        if (template) {
+                    copy = xsltCopyText(ctxt, ctxt->insert, cur, 0);
+                    if (copy == NULL) {
+                        xsltTransformError(ctxt, NULL, cur,
+                            "xsltDefaultProcessOneNode: text copy failed\n");
+                    }
+                }
+                break;
+            case XML_PI_NODE:
+            case XML_COMMENT_NODE:
+                template = xsltGetTemplate(ctxt, cur, NULL);
+                if (template) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            if (cur->type == XML_PI_NODE) {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: template found for PI %s\n",
-                             cur->name));
-            } else if (cur->type == XML_COMMENT_NODE) {
-            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltDefaultProcessOneNode: template found for comment\n"));
+                    if (cur->type == XML_PI_NODE) {
+                        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: template found for PI %s\n",
+                                         cur->name));
+                    } else if (cur->type == XML_COMMENT_NODE) {
+                        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+                     "xsltDefaultProcessOneNode: template found for comment\n"));
                     }
 #endif
-            ctxt->xpathCtxt->contextSize = nbchild;
-            ctxt->xpathCtxt->proximityPosition = childno;
-            /*
-            * Instantiate the xsl:template.
-            */
-            xsltApplyXSLTTemplate(ctxt, cur, template->content,
-            template, params);
+                    ctxt->xpathCtxt->contextSize = nbchild;
+                    ctxt->xpathCtxt->proximityPosition = childno;
+                    /*
+                    * Instantiate the xsl:template.
+                    */
+                    xsltApplyXSLTTemplate(ctxt, cur, template->content,
+                        template, params);
+                }
+                break;
+            default:
+                break;
         }
-        break;
-        default:
-        break;
-    }
-    cur = cur->next;
+        cur = cur->next;
     }
     ctxt->xpathCtxt->contextSize = oldSize;
     ctxt->xpathCtxt->proximityPosition = oldPos;
@@ -2139,7 +2098,7 @@ xsltDefaultProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
-               xsltStackElemPtr withParams)
+                   xsltStackElemPtr withParams)
 {
     xsltTemplatePtr templ;
     xmlNodePtr oldNode;
@@ -2150,74 +2109,74 @@ xsltProcessOneNode(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
      */
     if (templ == NULL) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-    if (contextNode->type == XML_DOCUMENT_NODE) {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: no template found for /\n"));
-    } else if (contextNode->type == XML_CDATA_SECTION_NODE) {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: no template found for CDATA\n"));
-    } else if (contextNode->type == XML_ATTRIBUTE_NODE) {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: no template found for attribute %s\n",
-                         ((xmlAttrPtr) contextNode)->name));
-    } else  {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: no template found for %s\n", contextNode->name));
+        if (contextNode->type == XML_DOCUMENT_NODE) {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: no template found for /\n"));
+        } else if (contextNode->type == XML_CDATA_SECTION_NODE) {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: no template found for CDATA\n"));
+        } else if (contextNode->type == XML_ATTRIBUTE_NODE) {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: no template found for attribute %s\n",
+                             ((xmlAttrPtr) contextNode)->name));
+        } else  {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: no template found for %s\n", contextNode->name));
         }
 #endif
-    oldNode = ctxt->node;
-    ctxt->node = contextNode;
-    xsltDefaultProcessOneNode(ctxt, contextNode, withParams);
-    ctxt->node = oldNode;
-    return;
+        oldNode = ctxt->node;
+        ctxt->node = contextNode;
+        xsltDefaultProcessOneNode(ctxt, contextNode, withParams);
+        ctxt->node = oldNode;
+        return;
     }
 
     if (contextNode->type == XML_ATTRIBUTE_NODE) {
-    xsltTemplatePtr oldCurTempRule = ctxt->currentTemplateRule;
-    /*
-    * Set the "current template rule".
-    */
-    ctxt->currentTemplateRule = templ;
+        xsltTemplatePtr oldCurTempRule = ctxt->currentTemplateRule;
+        /*
+        * Set the "current template rule".
+        */
+        ctxt->currentTemplateRule = templ;
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-    XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: applying template '%s' for attribute %s\n",
-                     templ->match, contextNode->name));
-#endif
-    xsltApplyXSLTTemplate(ctxt, contextNode, templ->content, templ, withParams);
-
-    ctxt->currentTemplateRule = oldCurTempRule;
-    } else {
-    xsltTemplatePtr oldCurTempRule = ctxt->currentTemplateRule;
-    /*
-    * Set the "current template rule".
-    */
-    ctxt->currentTemplateRule = templ;
-
-#ifdef WITH_XSLT_DEBUG_PROCESS
-    if (contextNode->type == XML_DOCUMENT_NODE) {
         XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: applying template '%s' for /\n",
-                         templ->match));
-    } else {
-        XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessOneNode: applying template '%s' for %s\n",
+             "xsltProcessOneNode: applying template '%s' for attribute %s\n",
                          templ->match, contextNode->name));
+#endif
+        xsltApplyXSLTTemplate(ctxt, contextNode, templ->content, templ, withParams);
+
+        ctxt->currentTemplateRule = oldCurTempRule;
+    } else {
+        xsltTemplatePtr oldCurTempRule = ctxt->currentTemplateRule;
+        /*
+        * Set the "current template rule".
+        */
+        ctxt->currentTemplateRule = templ;
+
+#ifdef WITH_XSLT_DEBUG_PROCESS
+        if (contextNode->type == XML_DOCUMENT_NODE) {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: applying template '%s' for /\n",
+                             templ->match));
+        } else {
+            XSLT_TRACE(ctxt,XSLT_TRACE_PROCESS_NODE,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessOneNode: applying template '%s' for %s\n",
+                             templ->match, contextNode->name));
         }
 #endif
-    xsltApplyXSLTTemplate(ctxt, contextNode, templ->content, templ, withParams);
+        xsltApplyXSLTTemplate(ctxt, contextNode, templ->content, templ, withParams);
 
-    ctxt->currentTemplateRule = oldCurTempRule;
+        ctxt->currentTemplateRule = oldCurTempRule;
     }
 }
 
 #ifdef WITH_DEBUGGER
 static xmlNodePtr
 xsltDebuggerStartSequenceConstructor(xsltTransformContextPtr ctxt,
-                     xmlNodePtr contextNode,
-                     xmlNodePtr list,
-                     xsltTemplatePtr templ,
-                     int *addCallResult)
+                                     xmlNodePtr contextNode,
+                                     xmlNodePtr list,
+                                     xsltTemplatePtr templ,
+                                     int *addCallResult)
 {
     xmlNodePtr debugedNode = NULL;
 
@@ -2263,29 +2222,29 @@ xsltDebuggerStartSequenceConstructor(xsltTransformContextPtr ctxt,
  */
 int
 xsltLocalVariablePush(xsltTransformContextPtr ctxt,
-              xsltStackElemPtr variable,
-              int level)
+                      xsltStackElemPtr variable,
+                      int level)
 {
     if (ctxt->varsMax == 0) {
-    ctxt->varsMax = 10;
-    ctxt->varsTab =
-        (xsltStackElemPtr *) xmlMalloc(ctxt->varsMax *
-        sizeof(ctxt->varsTab[0]));
-    if (ctxt->varsTab == NULL) {
-        xmlGenericError(xmlGenericErrorContext, "malloc failed !\n");
-        return (-1);
-    }
+        ctxt->varsMax = 10;
+        ctxt->varsTab =
+            (xsltStackElemPtr *) xmlMalloc(ctxt->varsMax *
+            sizeof(ctxt->varsTab[0]));
+        if (ctxt->varsTab == NULL) {
+            xmlGenericError(xmlGenericErrorContext, "malloc failed !\n");
+            return (-1);
+        }
     }
     if (ctxt->varsNr >= ctxt->varsMax) {
-    ctxt->varsMax *= 2;
-    ctxt->varsTab =
-        (xsltStackElemPtr *) xmlRealloc(ctxt->varsTab,
-        ctxt->varsMax *
-        sizeof(ctxt->varsTab[0]));
-    if (ctxt->varsTab == NULL) {
-        xmlGenericError(xmlGenericErrorContext, "realloc failed !\n");
-        return (-1);
-    }
+        ctxt->varsMax *= 2;
+        ctxt->varsTab =
+            (xsltStackElemPtr *) xmlRealloc(ctxt->varsTab,
+            ctxt->varsMax *
+            sizeof(ctxt->varsTab[0]));
+        if (ctxt->varsTab == NULL) {
+            xmlGenericError(xmlGenericErrorContext, "realloc failed !\n");
+            return (-1);
+        }
     }
     ctxt->varsTab[ctxt->varsNr++] = variable;
     ctxt->vars = variable;
@@ -2353,8 +2312,8 @@ xsltReleaseLocalRVTs(xsltTransformContextPtr ctxt, xmlDocPtr base)
  */
 static void
 xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
-                 xmlNodePtr contextNode, xmlNodePtr list,
-                 xsltTemplatePtr templ)
+                             xmlNodePtr contextNode, xmlNodePtr list,
+                             xsltTemplatePtr templ)
 {
     xmlNodePtr oldInsert, oldInst, oldCurInst, oldContextNode;
     xmlNodePtr cur, insert, copy = NULL;
@@ -2371,15 +2330,15 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 #endif
 
     if (ctxt == NULL)
-    return;
+        return;
 
 #ifdef WITH_DEBUGGER
     if (ctxt->debugStatus != XSLT_DEBUG_NONE) {
-    debuggedNode =
-        xsltDebuggerStartSequenceConstructor(ctxt, contextNode,
-        list, templ, &addCallResult);
-    if (debuggedNode == NULL)
-        return;
+        debuggedNode =
+            xsltDebuggerStartSequenceConstructor(ctxt, contextNode,
+                list, templ, &addCallResult);
+        if (debuggedNode == NULL)
+            return;
     }
 #endif
 
@@ -2393,14 +2352,14 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
     */
     if (ctxt->depth >= ctxt->maxTemplateDepth) {
         xsltTransformError(ctxt, NULL, list,
-        "xsltApplySequenceConstructor: A potential infinite template "
+            "xsltApplySequenceConstructor: A potential infinite template "
             "recursion was detected.\n"
-        "You can adjust xsltMaxDepth (--maxdepth) in order to "
-        "raise the maximum number of nested template calls and "
-        "variables/params (currently set to %d).\n",
-        ctxt->maxTemplateDepth);
+            "You can adjust xsltMaxDepth (--maxdepth) in order to "
+            "raise the maximum number of nested template calls and "
+            "variables/params (currently set to %d).\n",
+            ctxt->maxTemplateDepth);
         xsltDebug(ctxt, contextNode, list, NULL);
-    ctxt->state = XSLT_STATE_STOPPED;
+        ctxt->state = XSLT_STATE_STOPPED;
         return;
     }
     ctxt->depth++;
@@ -2421,10 +2380,10 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
     while (cur != NULL) {
         if (ctxt->opLimit != 0) {
             if (ctxt->opCount >= ctxt->opLimit) {
-        xsltTransformError(ctxt, NULL, cur,
-            "xsltApplySequenceConstructor: "
+                xsltTransformError(ctxt, NULL, cur,
+                    "xsltApplySequenceConstructor: "
                     "Operation limit exceeded\n");
-            ctxt->state = XSLT_STATE_STOPPED;
+                ctxt->state = XSLT_STATE_STOPPED;
                 goto error;
             }
             ctxt->opCount += 1;
@@ -2447,7 +2406,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
             XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltApplySequenceConstructor: insert == NULL !\n"));
+                "xsltApplySequenceConstructor: insert == NULL !\n"));
 #endif
             goto error;
         }
@@ -2458,262 +2417,262 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 #endif
 
 #ifdef XSLT_REFACTORED
-    if (cur->type == XML_ELEMENT_NODE) {
-        info = (xsltStylePreCompPtr) cur->psvi;
-        /*
-        * We expect a compiled representation on:
-        * 1) XSLT instructions of this XSLT version (1.0)
-        *    (with a few exceptions)
-        * 2) Literal result elements
-        * 3) Extension instructions
-        * 4) XSLT instructions of future XSLT versions
-        *    (forwards-compatible mode).
-        */
-        if (info == NULL) {
-        /*
-        * Handle the rare cases where we don't expect a compiled
-        * representation on an XSLT element.
-        */
-        if (IS_XSLT_ELEM_FAST(cur) && IS_XSLT_NAME(cur, "message")) {
-            xsltMessage(ctxt, contextNode, cur);
-            goto skip_children;
-        }
-        /*
-        * Something really went wrong:
-        */
-        xsltTransformError(ctxt, NULL, cur,
-            "Internal error in xsltApplySequenceConstructor(): "
-            "The element '%s' in the stylesheet has no compiled "
-            "representation.\n",
-            cur->name);
+        if (cur->type == XML_ELEMENT_NODE) {
+            info = (xsltStylePreCompPtr) cur->psvi;
+            /*
+            * We expect a compiled representation on:
+            * 1) XSLT instructions of this XSLT version (1.0)
+            *    (with a few exceptions)
+            * 2) Literal result elements
+            * 3) Extension instructions
+            * 4) XSLT instructions of future XSLT versions
+            *    (forwards-compatible mode).
+            */
+            if (info == NULL) {
+                /*
+                * Handle the rare cases where we don't expect a compiled
+                * representation on an XSLT element.
+                */
+                if (IS_XSLT_ELEM_FAST(cur) && IS_XSLT_NAME(cur, "message")) {
+                    xsltMessage(ctxt, contextNode, cur);
+                    goto skip_children;
+                }
+                /*
+                * Something really went wrong:
+                */
+                xsltTransformError(ctxt, NULL, cur,
+                    "Internal error in xsltApplySequenceConstructor(): "
+                    "The element '%s' in the stylesheet has no compiled "
+                    "representation.\n",
+                    cur->name);
                 goto skip_children;
             }
 
-        if (info->type == XSLT_FUNC_LITERAL_RESULT_ELEMENT) {
-        xsltStyleItemLRElementInfoPtr lrInfo =
-            (xsltStyleItemLRElementInfoPtr) info;
-        /*
-        * Literal result elements
-        * --------------------------------------------------------
-        */
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: copy literal result "
-            "element '%s'\n", cur->name));
-#endif
-        /*
-        * Copy the raw element-node.
-        * OLD: if ((copy = xsltShallowCopyElem(ctxt, cur, insert))
-        *     == NULL)
-        *   goto error;
-        */
-        copy = xmlDocCopyNode(cur, insert->doc, 0);
-        if (copy == NULL) {
-            xsltTransformError(ctxt, NULL, cur,
-            "Internal error in xsltApplySequenceConstructor(): "
-            "Failed to copy literal result element '%s'.\n",
-            cur->name);
-            goto error;
-        } else {
-            /*
-            * Add the element-node to the result tree.
-            */
-            copy->doc = ctxt->output;
-            copy = xsltAddChild(insert, copy);
-            /*
-            * Create effective namespaces declarations.
-            * OLD: xsltCopyNamespaceList(ctxt, copy, cur->nsDef);
-            */
-            if (lrInfo->effectiveNs != NULL) {
-            xsltEffectiveNsPtr effNs = lrInfo->effectiveNs;
-            xmlNsPtr ns, lastns = NULL;
-
-            while (effNs != NULL) {
+            if (info->type == XSLT_FUNC_LITERAL_RESULT_ELEMENT) {
+                xsltStyleItemLRElementInfoPtr lrInfo =
+                    (xsltStyleItemLRElementInfoPtr) info;
                 /*
-                * Avoid generating redundant namespace
-                * declarations; thus lookup if there is already
-                * such a ns-decl in the result.
+                * Literal result elements
+                * --------------------------------------------------------
                 */
-                ns = xmlSearchNs(copy->doc, copy, effNs->prefix);
-                if ((ns != NULL) &&
-                (xmlStrEqual(ns->href, effNs->nsName)))
-                {
-                effNs = effNs->next;
-                continue;
-                }
-                ns = xmlNewNs(copy, effNs->nsName, effNs->prefix);
-                if (ns == NULL) {
-                xsltTransformError(ctxt, NULL, cur,
-                    "Internal error in "
-                    "xsltApplySequenceConstructor(): "
-                    "Failed to copy a namespace "
-                    "declaration.\n");
-                goto error;
-                }
-
-                if (lastns == NULL)
-                copy->nsDef = ns;
-                else
-                lastns->next =ns;
-                lastns = ns;
-
-                effNs = effNs->next;
-            }
-
-            }
-            /*
-            * NOTE that we don't need to apply ns-alising: this was
-            *  already done at compile-time.
-            */
-            if (cur->ns != NULL) {
-            /*
-            * If there's no such ns-decl in the result tree,
-            * then xsltGetSpecialNamespace() will
-            * create a ns-decl on the copied node.
-            */
-            copy->ns = xsltGetSpecialNamespace(ctxt, cur,
-                cur->ns->href, cur->ns->prefix, copy);
-            } else {
-            /*
-            * Undeclare the default namespace if needed.
-            * This can be skipped, if the result element has
-            *  no ns-decls, in which case the result element
-            *  obviously does not declare a default namespace;
-            *  AND there's either no parent, or the parent
-            *  element is in no namespace; this means there's no
-            *  default namespace is scope to care about.
-            *
-            * REVISIT: This might result in massive
-            *  generation of ns-decls if nodes in a default
-            *  namespaces are mixed with nodes in no namespace.
-            *
-            */
-            if (copy->nsDef ||
-                ((insert != NULL) &&
-                 (insert->type == XML_ELEMENT_NODE) &&
-                 (insert->ns != NULL)))
-            {
-                xsltGetSpecialNamespace(ctxt, cur,
-                NULL, NULL, copy);
-            }
-            }
-        }
-        /*
-        * SPEC XSLT 2.0 "Each attribute of the literal result
-        *  element, other than an attribute in the XSLT namespace,
-        *  is processed to produce an attribute for the element in
-        *  the result tree."
-        * NOTE: See bug #341325.
-        */
-        if (cur->properties != NULL) {
-            xsltAttrListTemplateProcess(ctxt, copy, cur->properties);
-        }
-        } else if (IS_XSLT_ELEM_FAST(cur)) {
-        /*
-        * XSLT instructions
-        * --------------------------------------------------------
-        */
-        if (info->type == XSLT_FUNC_UNKOWN_FORWARDS_COMPAT) {
-            /*
-            * We hit an unknown XSLT element.
-            * Try to apply one of the fallback cases.
-            */
-            ctxt->insert = insert;
-            if (!xsltApplyFallbacks(ctxt, contextNode, cur)) {
-            xsltTransformError(ctxt, NULL, cur,
-                "The is no fallback behaviour defined for "
-                "the unknown XSLT element '%s'.\n",
-                cur->name);
-            }
-            ctxt->insert = oldInsert;
-        } else if (info->func != NULL) {
-            /*
-            * Execute the XSLT instruction.
-            */
-            ctxt->insert = insert;
-
-            info->func(ctxt, contextNode, cur,
-            (xsltElemPreCompPtr) info);
-
-            /*
-            * Cleanup temporary tree fragments.
-            */
-            if (oldLocalFragmentTop != ctxt->localRVT)
-            xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
-
-            ctxt->insert = oldInsert;
-        } else if (info->type == XSLT_FUNC_VARIABLE) {
-            xsltStackElemPtr tmpvar = ctxt->vars;
-
-            xsltParseStylesheetVariable(ctxt, cur);
-
-            if (tmpvar != ctxt->vars) {
-            /*
-            * TODO: Using a @tmpvar is an annoying workaround, but
-            *  the current mechanisms do not provide any other way
-            *  of knowing if the var was really pushed onto the
-            *  stack.
-            */
-            ctxt->vars->level = level;
-            }
-        } else if (info->type == XSLT_FUNC_MESSAGE) {
-            /*
-            * TODO: Won't be hit, since we don't compile xsl:message.
-            */
-            xsltMessage(ctxt, contextNode, cur);
-        } else {
-            xsltTransformError(ctxt, NULL, cur,
-            "Unexpected XSLT element '%s'.\n", cur->name);
-        }
-        goto skip_children;
-
-        } else {
-        xsltTransformFunction func;
-        /*
-        * Extension intructions (elements)
-        * --------------------------------------------------------
-        */
-        if (cur->psvi == xsltExtMarker) {
-            /*
-            * The xsltExtMarker was set during the compilation
-            * of extension instructions if there was no registered
-            * handler for this specific extension function at
-            * compile-time.
-            * Libxslt will now lookup if a handler is
-            * registered in the context of this transformation.
-            */
-            func = xsltExtElementLookup(ctxt, cur->name,
-                                                cur->ns->href);
-        } else
-            func = ((xsltElemPreCompPtr) cur->psvi)->func;
-
-        if (func == NULL) {
-            /*
-            * No handler available.
-            * Try to execute fallback behaviour via xsl:fallback.
-            */
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
-            xsltGenericDebug(xsltGenericDebugContext,
-                "xsltApplySequenceConstructor: unknown extension %s\n",
-                cur->name));
+                XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
+                    xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltApplySequenceConstructor: copy literal result "
+                    "element '%s'\n", cur->name));
 #endif
-            ctxt->insert = insert;
-            if (!xsltApplyFallbacks(ctxt, contextNode, cur)) {
-            xsltTransformError(ctxt, NULL, cur,
-                "Unknown extension instruction '{%s}%s'.\n",
-                cur->ns->href, cur->name);
-            }
-            ctxt->insert = oldInsert;
-        } else {
-            /*
-            * Execute the handler-callback.
-            */
+                /*
+                * Copy the raw element-node.
+                * OLD: if ((copy = xsltShallowCopyElem(ctxt, cur, insert))
+                *     == NULL)
+                *   goto error;
+                */
+                copy = xmlDocCopyNode(cur, insert->doc, 0);
+                if (copy == NULL) {
+                    xsltTransformError(ctxt, NULL, cur,
+                        "Internal error in xsltApplySequenceConstructor(): "
+                        "Failed to copy literal result element '%s'.\n",
+                        cur->name);
+                    goto error;
+                } else {
+                    /*
+                    * Add the element-node to the result tree.
+                    */
+                    copy->doc = ctxt->output;
+                    copy = xsltAddChild(insert, copy);
+                    /*
+                    * Create effective namespaces declarations.
+                    * OLD: xsltCopyNamespaceList(ctxt, copy, cur->nsDef);
+                    */
+                    if (lrInfo->effectiveNs != NULL) {
+                        xsltEffectiveNsPtr effNs = lrInfo->effectiveNs;
+                        xmlNsPtr ns, lastns = NULL;
+
+                        while (effNs != NULL) {
+                            /*
+                            * Avoid generating redundant namespace
+                            * declarations; thus lookup if there is already
+                            * such a ns-decl in the result.
+                            */
+                            ns = xmlSearchNs(copy->doc, copy, effNs->prefix);
+                            if ((ns != NULL) &&
+                                (xmlStrEqual(ns->href, effNs->nsName)))
+                            {
+                                effNs = effNs->next;
+                                continue;
+                            }
+                            ns = xmlNewNs(copy, effNs->nsName, effNs->prefix);
+                            if (ns == NULL) {
+                                xsltTransformError(ctxt, NULL, cur,
+                                    "Internal error in "
+                                    "xsltApplySequenceConstructor(): "
+                                    "Failed to copy a namespace "
+                                    "declaration.\n");
+                                goto error;
+                            }
+
+                            if (lastns == NULL)
+                                copy->nsDef = ns;
+                            else
+                                lastns->next =ns;
+                            lastns = ns;
+
+                            effNs = effNs->next;
+                        }
+
+                    }
+                    /*
+                    * NOTE that we don't need to apply ns-alising: this was
+                    *  already done at compile-time.
+                    */
+                    if (cur->ns != NULL) {
+                        /*
+                        * If there's no such ns-decl in the result tree,
+                        * then xsltGetSpecialNamespace() will
+                        * create a ns-decl on the copied node.
+                        */
+                        copy->ns = xsltGetSpecialNamespace(ctxt, cur,
+                            cur->ns->href, cur->ns->prefix, copy);
+                    } else {
+                        /*
+                        * Undeclare the default namespace if needed.
+                        * This can be skipped, if the result element has
+                        *  no ns-decls, in which case the result element
+                        *  obviously does not declare a default namespace;
+                        *  AND there's either no parent, or the parent
+                        *  element is in no namespace; this means there's no
+                        *  default namespace is scope to care about.
+                        *
+                        * REVISIT: This might result in massive
+                        *  generation of ns-decls if nodes in a default
+                        *  namespaces are mixed with nodes in no namespace.
+                        *
+                        */
+                        if (copy->nsDef ||
+                            ((insert != NULL) &&
+                             (insert->type == XML_ELEMENT_NODE) &&
+                             (insert->ns != NULL)))
+                        {
+                            xsltGetSpecialNamespace(ctxt, cur,
+                                NULL, NULL, copy);
+                        }
+                    }
+                }
+                /*
+                * SPEC XSLT 2.0 "Each attribute of the literal result
+                *  element, other than an attribute in the XSLT namespace,
+                *  is processed to produce an attribute for the element in
+                *  the result tree."
+                * NOTE: See bug #341325.
+                */
+                if (cur->properties != NULL) {
+                    xsltAttrListTemplateProcess(ctxt, copy, cur->properties);
+                }
+            } else if (IS_XSLT_ELEM_FAST(cur)) {
+                /*
+                * XSLT instructions
+                * --------------------------------------------------------
+                */
+                if (info->type == XSLT_FUNC_UNKOWN_FORWARDS_COMPAT) {
+                    /*
+                    * We hit an unknown XSLT element.
+                    * Try to apply one of the fallback cases.
+                    */
+                    ctxt->insert = insert;
+                    if (!xsltApplyFallbacks(ctxt, contextNode, cur)) {
+                        xsltTransformError(ctxt, NULL, cur,
+                            "The is no fallback behaviour defined for "
+                            "the unknown XSLT element '%s'.\n",
+                            cur->name);
+                    }
+                    ctxt->insert = oldInsert;
+                } else if (info->func != NULL) {
+                    /*
+                    * Execute the XSLT instruction.
+                    */
+                    ctxt->insert = insert;
+
+                    info->func(ctxt, contextNode, cur,
+                        (xsltElemPreCompPtr) info);
+
+                    /*
+                    * Cleanup temporary tree fragments.
+                    */
+                    if (oldLocalFragmentTop != ctxt->localRVT)
+                        xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+
+                    ctxt->insert = oldInsert;
+                } else if (info->type == XSLT_FUNC_VARIABLE) {
+                    xsltStackElemPtr tmpvar = ctxt->vars;
+
+                    xsltParseStylesheetVariable(ctxt, cur);
+
+                    if (tmpvar != ctxt->vars) {
+                        /*
+                        * TODO: Using a @tmpvar is an annoying workaround, but
+                        *  the current mechanisms do not provide any other way
+                        *  of knowing if the var was really pushed onto the
+                        *  stack.
+                        */
+                        ctxt->vars->level = level;
+                    }
+                } else if (info->type == XSLT_FUNC_MESSAGE) {
+                    /*
+                    * TODO: Won't be hit, since we don't compile xsl:message.
+                    */
+                    xsltMessage(ctxt, contextNode, cur);
+                } else {
+                    xsltTransformError(ctxt, NULL, cur,
+                        "Unexpected XSLT element '%s'.\n", cur->name);
+                }
+                goto skip_children;
+
+            } else {
+                xsltTransformFunction func;
+                /*
+                * Extension intructions (elements)
+                * --------------------------------------------------------
+                */
+                if (cur->psvi == xsltExtMarker) {
+                    /*
+                    * The xsltExtMarker was set during the compilation
+                    * of extension instructions if there was no registered
+                    * handler for this specific extension function at
+                    * compile-time.
+                    * Libxslt will now lookup if a handler is
+                    * registered in the context of this transformation.
+                    */
+                    func = xsltExtElementLookup(ctxt, cur->name,
+                                                cur->ns->href);
+                } else
+                    func = ((xsltElemPreCompPtr) cur->psvi)->func;
+
+                if (func == NULL) {
+                    /*
+                    * No handler available.
+                    * Try to execute fallback behaviour via xsl:fallback.
+                    */
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: extension construct %s\n",
-            cur->name));
+                    XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
+                        xsltGenericDebug(xsltGenericDebugContext,
+                            "xsltApplySequenceConstructor: unknown extension %s\n",
+                            cur->name));
+#endif
+                    ctxt->insert = insert;
+                    if (!xsltApplyFallbacks(ctxt, contextNode, cur)) {
+                        xsltTransformError(ctxt, NULL, cur,
+                            "Unknown extension instruction '{%s}%s'.\n",
+                            cur->ns->href, cur->name);
+                    }
+                    ctxt->insert = oldInsert;
+                } else {
+                    /*
+                    * Execute the handler-callback.
+                    */
+#ifdef WITH_XSLT_DEBUG_PROCESS
+                    XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltApplySequenceConstructor: extension construct %s\n",
+                        cur->name));
 #endif
                     /*
                      * Disable the xsltCopyTextString optimization for
@@ -2727,42 +2686,42 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
                         ctxt->lasttext = NULL;
                     }
 
-            ctxt->insert = insert;
+                    ctxt->insert = insert;
 
-            func(ctxt, contextNode, cur, cur->psvi);
+                    func(ctxt, contextNode, cur, cur->psvi);
 
+                    /*
+                    * Cleanup temporary tree fragments.
+                    */
+                    if (oldLocalFragmentTop != ctxt->localRVT)
+                        xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+
+                    ctxt->insert = oldInsert;
+                }
+                goto skip_children;
+            }
+
+        } else if (XSLT_IS_TEXT_NODE(cur)) {
             /*
-            * Cleanup temporary tree fragments.
+            * Text
+            * ------------------------------------------------------------
             */
-            if (oldLocalFragmentTop != ctxt->localRVT)
-            xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
-
-            ctxt->insert = oldInsert;
-        }
-        goto skip_children;
-        }
-
-    } else if (XSLT_IS_TEXT_NODE(cur)) {
-        /*
-        * Text
-        * ------------------------------------------------------------
-        */
 #ifdef WITH_XSLT_DEBUG_PROCESS
             if (cur->name == xmlStringTextNoenc) {
                 XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: copy unescaped text '%s'\n",
-            cur->content));
+                    xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltApplySequenceConstructor: copy unescaped text '%s'\n",
+                    cur->content));
             } else {
                 XSLT_TRACE(ctxt, XSLT_TRACE_APPLY_TEMPLATE,
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: copy text '%s'\n",
-            cur->content));
+                    xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltApplySequenceConstructor: copy text '%s'\n",
+                    cur->content));
             }
 #endif
             if (xsltCopyText(ctxt, insert, cur, ctxt->internalized) == NULL)
-        goto error;
-    }
+                goto error;
+        }
 
 #else /* XSLT_REFACTORED */
 
@@ -2782,8 +2741,8 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
                     ctxt->insert = insert;
                     if (!xsltApplyFallbacks(ctxt, contextNode, cur)) {
                         xsltGenericError(xsltGenericErrorContext,
-                "xsltApplySequenceConstructor: %s was not compiled\n",
-                cur->name);
+                            "xsltApplySequenceConstructor: %s was not compiled\n",
+                            cur->name);
                     }
                     ctxt->insert = oldInsert;
                 }
@@ -2791,47 +2750,47 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
             }
 
             if (info->func != NULL) {
-        oldCurInst = ctxt->inst;
-        ctxt->inst = cur;
+                oldCurInst = ctxt->inst;
+                ctxt->inst = cur;
                 ctxt->insert = insert;
 
                 info->func(ctxt, contextNode, cur, (xsltElemPreCompPtr) info);
 
-        /*
-        * Cleanup temporary tree fragments.
-        */
-        if (oldLocalFragmentTop != ctxt->localRVT)
-            xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+                /*
+                * Cleanup temporary tree fragments.
+                */
+                if (oldLocalFragmentTop != ctxt->localRVT)
+                    xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
 
                 ctxt->insert = oldInsert;
-        ctxt->inst = oldCurInst;
+                ctxt->inst = oldCurInst;
                 goto skip_children;
             }
 
             if (IS_XSLT_NAME(cur, "variable")) {
-        xsltStackElemPtr tmpvar = ctxt->vars;
+                xsltStackElemPtr tmpvar = ctxt->vars;
 
-        oldCurInst = ctxt->inst;
-        ctxt->inst = cur;
+                oldCurInst = ctxt->inst;
+                ctxt->inst = cur;
 
-        xsltParseStylesheetVariable(ctxt, cur);
+                xsltParseStylesheetVariable(ctxt, cur);
 
-        ctxt->inst = oldCurInst;
+                ctxt->inst = oldCurInst;
 
-        if (tmpvar != ctxt->vars) {
-            /*
-            * TODO: Using a @tmpvar is an annoying workaround, but
-            *  the current mechanisms do not provide any other way
-            *  of knowing if the var was really pushed onto the
-            *  stack.
-            */
-            ctxt->vars->level = level;
-        }
+                if (tmpvar != ctxt->vars) {
+                    /*
+                    * TODO: Using a @tmpvar is an annoying workaround, but
+                    *  the current mechanisms do not provide any other way
+                    *  of knowing if the var was really pushed onto the
+                    *  stack.
+                    */
+                    ctxt->vars->level = level;
+                }
             } else if (IS_XSLT_NAME(cur, "message")) {
                 xsltMessage(ctxt, contextNode, cur);
             } else {
-        xsltTransformError(ctxt, NULL, cur,
-            "Unexpected XSLT element '%s'.\n", cur->name);
+                xsltTransformError(ctxt, NULL, cur,
+                    "Unexpected XSLT element '%s'.\n", cur->name);
             }
             goto skip_children;
         } else if ((cur->type == XML_TEXT_NODE) ||
@@ -2858,13 +2817,13 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
             }
 #endif
             if (xsltCopyText(ctxt, insert, cur, ctxt->internalized) == NULL)
-        goto error;
+                goto error;
         } else if ((cur->type == XML_ELEMENT_NODE) &&
                    (cur->ns != NULL) && (cur->psvi != NULL)) {
             xsltTransformFunction function;
 
-        oldCurInst = ctxt->inst;
-        ctxt->inst = cur;
+            oldCurInst = ctxt->inst;
+            ctxt->inst = cur;
             /*
              * Flagged as an extension element
              */
@@ -2880,7 +2839,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
                 XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: unknown extension %s\n",
+                    "xsltApplySequenceConstructor: unknown extension %s\n",
                     cur->name));
 #endif
                 /*
@@ -2891,10 +2850,10 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
                 while (child != NULL) {
                     if ((IS_XSLT_ELEM(child)) &&
                         (IS_XSLT_NAME(child, "fallback")))
-            {
+                    {
                         found = 1;
                         xsltApplySequenceConstructor(ctxt, contextNode,
-                child->children, NULL);
+                            child->children, NULL);
                     }
                     child = child->next;
                 }
@@ -2902,13 +2861,13 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
 
                 if (!found) {
                     xsltTransformError(ctxt, NULL, cur,
-            "xsltApplySequenceConstructor: failed to find extension %s\n",
-            cur->name);
+                        "xsltApplySequenceConstructor: failed to find extension %s\n",
+                        cur->name);
                 }
             } else {
 #ifdef WITH_XSLT_DEBUG_PROCESS
                 XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltApplySequenceConstructor: extension construct %s\n",
+                    "xsltApplySequenceConstructor: extension construct %s\n",
                     cur->name));
 #endif
 
@@ -2921,38 +2880,38 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
                  * #777432.
                  */
                 if (cur->psvi == xsltExtMarker) {
-                ctxt->lasttext = NULL;
+                    ctxt->lasttext = NULL;
                 }
 
                 ctxt->insert = insert;
 
                 function(ctxt, contextNode, cur, cur->psvi);
-        /*
-        * Cleanup temporary tree fragments.
-        */
-        if (oldLocalFragmentTop != ctxt->localRVT)
-            xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+                /*
+                * Cleanup temporary tree fragments.
+                */
+                if (oldLocalFragmentTop != ctxt->localRVT)
+                    xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
 
                 ctxt->insert = oldInsert;
 
             }
-        ctxt->inst = oldCurInst;
+            ctxt->inst = oldCurInst;
             goto skip_children;
         } else if (cur->type == XML_ELEMENT_NODE) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
             XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltApplySequenceConstructor: copy node %s\n",
+                "xsltApplySequenceConstructor: copy node %s\n",
                 cur->name));
 #endif
-        oldCurInst = ctxt->inst;
-        ctxt->inst = cur;
+            oldCurInst = ctxt->inst;
+            ctxt->inst = cur;
 
             if ((copy = xsltShallowCopyElem(ctxt, cur, insert, 1)) == NULL)
-        goto error;
+                goto error;
             /*
              * Add extra namespaces inherited from the current template
              * if we are in the first level children and this is a
-         * "real" template.
+             * "real" template.
              */
             if ((templ != NULL) && (oldInsert == insert) &&
                 (ctxt->templ != NULL) && (ctxt->templ->inheritedNs != NULL)) {
@@ -2960,55 +2919,55 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
                 xmlNsPtr ns, ret;
 
                 for (i = 0; i < ctxt->templ->inheritedNsNr; i++) {
-            const xmlChar *URI = NULL;
-            xsltStylesheetPtr style;
+                    const xmlChar *URI = NULL;
+                    xsltStylesheetPtr style;
                     ns = ctxt->templ->inheritedNs[i];
 
-            /* Note that the XSLT namespace was already excluded
-            * in xsltGetInheritedNsList().
-            */
+                    /* Note that the XSLT namespace was already excluded
+                    * in xsltGetInheritedNsList().
+                    */
 #if 0
-            if (xmlStrEqual(ns->href, XSLT_NAMESPACE))
-            continue;
+                    if (xmlStrEqual(ns->href, XSLT_NAMESPACE))
+                        continue;
 #endif
-            style = ctxt->style;
-            while (style != NULL) {
-            if (style->nsAliases != NULL)
-                URI = (const xmlChar *)
-                xmlHashLookup(style->nsAliases, ns->href);
-            if (URI != NULL)
-                break;
+                    style = ctxt->style;
+                    while (style != NULL) {
+                        if (style->nsAliases != NULL)
+                            URI = (const xmlChar *)
+                                xmlHashLookup(style->nsAliases, ns->href);
+                        if (URI != NULL)
+                            break;
 
-            style = xsltNextImport(style);
-            }
-            if (URI == UNDEFINED_DEFAULT_NS)
-            continue;
-            if (URI == NULL)
-            URI = ns->href;
-            /*
-            * TODO: The following will still be buggy for the
-            * non-refactored code.
-            */
-            ret = xmlSearchNs(copy->doc, copy, ns->prefix);
-            if ((ret == NULL) || (!xmlStrEqual(ret->href, URI)))
-            {
-            xmlNewNs(copy, URI, ns->prefix);
-            }
+                        style = xsltNextImport(style);
+                    }
+                    if (URI == UNDEFINED_DEFAULT_NS)
+                        continue;
+                    if (URI == NULL)
+                        URI = ns->href;
+                    /*
+                    * TODO: The following will still be buggy for the
+                    * non-refactored code.
+                    */
+                    ret = xmlSearchNs(copy->doc, copy, ns->prefix);
+                    if ((ret == NULL) || (!xmlStrEqual(ret->href, URI)))
+                    {
+                        xmlNewNs(copy, URI, ns->prefix);
+                    }
                 }
-        if (copy->ns != NULL) {
-            /*
-             * Fix the node namespace if needed
-             */
-            copy->ns = xsltGetNamespace(ctxt, cur, copy->ns, copy);
-        }
+                if (copy->ns != NULL) {
+                    /*
+                     * Fix the node namespace if needed
+                     */
+                    copy->ns = xsltGetNamespace(ctxt, cur, copy->ns, copy);
+                }
             }
-        /*
+            /*
              * all the attributes are directly inherited
              */
             if (cur->properties != NULL) {
                 xsltAttrListTemplateProcess(ctxt, copy, cur->properties);
             }
-        ctxt->inst = oldCurInst;
+            ctxt->inst = oldCurInst;
         }
 #endif /* else of XSLT_REFACTORED */
 
@@ -3018,7 +2977,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
         if (cur->children != NULL) {
             if (cur->children->type != XML_ENTITY_DECL) {
                 cur = cur->children;
-        level++;
+                level++;
                 if (copy != NULL)
                     insert = copy;
                 continue;
@@ -3026,14 +2985,14 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
         }
 
 skip_children:
-    /*
-    * If xslt:message was just processed, we might have hit a
-    * terminate='yes'; if so, then break the loop and clean up.
-    * TODO: Do we need to check this also before trying to descend
-    *  into the content?
-    */
-    if (ctxt->state == XSLT_STATE_STOPPED)
-        break;
+        /*
+        * If xslt:message was just processed, we might have hit a
+        * terminate='yes'; if so, then break the loop and clean up.
+        * TODO: Do we need to check this also before trying to descend
+        *  into the content?
+        */
+        if (ctxt->state == XSLT_STATE_STOPPED)
+            break;
         if (cur->next != NULL) {
             cur = cur->next;
             continue;
@@ -3041,13 +3000,13 @@ skip_children:
 
         do {
             cur = cur->parent;
-        level--;
-        /*
-        * Pop variables/params (xsl:variable and xsl:param).
-        */
-        if ((ctxt->varsNr > oldVarsNr) && (ctxt->vars->level > level)) {
-        xsltLocalVariablePop(ctxt, oldVarsNr, level);
-        }
+            level--;
+            /*
+            * Pop variables/params (xsl:variable and xsl:param).
+            */
+            if ((ctxt->varsNr > oldVarsNr) && (ctxt->vars->level > level)) {
+                xsltLocalVariablePop(ctxt, oldVarsNr, level);
+            }
 
             insert = insert->parent;
             if (cur == NULL)
@@ -3068,7 +3027,7 @@ error:
     * In case of errors: pop remaining variables.
     */
     if (ctxt->varsNr > oldVarsNr)
-    xsltLocalVariablePop(ctxt, oldVarsNr, -1);
+        xsltLocalVariablePop(ctxt, oldVarsNr, -1);
 
     ctxt->node = oldContextNode;
     ctxt->inst = oldInst;
@@ -3101,10 +3060,10 @@ error:
 */
 static void
 xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
-              xmlNodePtr contextNode,
-              xmlNodePtr list,
-              xsltTemplatePtr templ,
-              xsltStackElemPtr withParams)
+                      xmlNodePtr contextNode,
+                      xmlNodePtr list,
+                      xsltTemplatePtr templ,
+                      xsltStackElemPtr withParams)
 {
     int oldVarsBase = 0;
     xmlNodePtr cur;
@@ -3125,18 +3084,18 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
 #endif
 
     if (ctxt == NULL)
-    return;
+        return;
     if (templ == NULL) {
-    xsltTransformError(ctxt, NULL, list,
-        "xsltApplyXSLTTemplate: Bad arguments; @templ is mandatory.\n");
-    return;
+        xsltTransformError(ctxt, NULL, list,
+            "xsltApplyXSLTTemplate: Bad arguments; @templ is mandatory.\n");
+        return;
     }
 
 #ifdef WITH_DEBUGGER
     if (ctxt->debugStatus != XSLT_DEBUG_NONE) {
-    if (xsltDebuggerStartSequenceConstructor(ctxt, contextNode,
-        list, templ, &addCallResult) == NULL)
-        return;
+        if (xsltDebuggerStartSequenceConstructor(ctxt, contextNode,
+                list, templ, &addCallResult) == NULL)
+            return;
     }
 #endif
 
@@ -3145,17 +3104,17 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
     CHECK_STOPPED;
 
     if (ctxt->varsNr >= ctxt->maxTemplateVars)
-    {
+        {
         xsltTransformError(ctxt, NULL, list,
-        "xsltApplyXSLTTemplate: A potential infinite template recursion "
-        "was detected.\n"
-        "You can adjust maxTemplateVars (--maxvars) in order to "
-        "raise the maximum number of variables/params (currently set to %d).\n",
-        ctxt->maxTemplateVars);
+            "xsltApplyXSLTTemplate: A potential infinite template recursion "
+            "was detected.\n"
+            "You can adjust maxTemplateVars (--maxvars) in order to "
+            "raise the maximum number of variables/params (currently set to %d).\n",
+            ctxt->maxTemplateVars);
         xsltDebug(ctxt, contextNode, list, NULL);
-    ctxt->state = XSLT_STATE_STOPPED;
+        ctxt->state = XSLT_STATE_STOPPED;
         return;
-    }
+        }
 
     oldUserFragmentTop = ctxt->tmpRVT;
     ctxt->tmpRVT = NULL;
@@ -3170,10 +3129,10 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_PROFILER
     if (ctxt->profile) {
-    templ->nbCalls++;
-    start = xsltTimestamp();
-    profPush(ctxt, 0);
-    profCallgraphAdd(templ, ctxt->templ);
+        templ->nbCalls++;
+        start = xsltTimestamp();
+        profPush(ctxt, 0);
+        profCallgraphAdd(templ, ctxt->templ);
     }
 #endif
 
@@ -3184,8 +3143,8 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (templ->name != NULL)
-    XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-    "applying xsl:template '%s'\n", templ->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
+        "applying xsl:template '%s'\n", templ->name));
 #endif
     /*
     * Process xsl:param instructions and skip those elements for
@@ -3193,62 +3152,62 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
     */
     cur = list;
     do {
-    if (cur->type == XML_TEXT_NODE) {
-        cur = cur->next;
-        continue;
-    }
-    if ((cur->type != XML_ELEMENT_NODE) ||
-        (cur->name[0] != 'p') ||
-        (cur->psvi == NULL) ||
-        (! xmlStrEqual(cur->name, BAD_CAST "param")) ||
-        (! IS_XSLT_ELEM(cur)))
-    {
-        break;
-    }
-
-    list = cur->next;
-
-#ifdef XSLT_REFACTORED
-    iparam = (xsltStyleItemParamPtr) cur->psvi;
-#else
-    iparam = (xsltStylePreCompPtr) cur->psvi;
-#endif
-
-    /*
-    * Substitute xsl:param for a given xsl:with-param.
-    * Since the XPath expression will reference the params/vars
-    * by index, we need to slot the xsl:with-params in the
-    * order of encountered xsl:params to keep the sequence of
-    * params/variables in the stack exactly as it was at
-    * compile time,
-    */
-    tmpParam = NULL;
-    if (withParams) {
-        tmpParam = withParams;
-        do {
-        if ((tmpParam->name == (iparam->name)) &&
-            (tmpParam->nameURI == (iparam->ns)))
+        if (cur->type == XML_TEXT_NODE) {
+            cur = cur->next;
+            continue;
+        }
+        if ((cur->type != XML_ELEMENT_NODE) ||
+            (cur->name[0] != 'p') ||
+            (cur->psvi == NULL) ||
+            (! xmlStrEqual(cur->name, BAD_CAST "param")) ||
+            (! IS_XSLT_ELEM(cur)))
         {
-            /*
-            * Push the caller-parameter.
-            */
-            xsltLocalVariablePush(ctxt, tmpParam, -1);
             break;
         }
-        tmpParam = tmpParam->next;
-        } while (tmpParam != NULL);
-    }
-    /*
-    * Push the xsl:param.
-    */
-    if (tmpParam == NULL) {
+
+        list = cur->next;
+
+#ifdef XSLT_REFACTORED
+        iparam = (xsltStyleItemParamPtr) cur->psvi;
+#else
+        iparam = (xsltStylePreCompPtr) cur->psvi;
+#endif
+
         /*
-        * Note that we must assume that the added parameter
-        * has a @depth of 0.
+        * Substitute xsl:param for a given xsl:with-param.
+        * Since the XPath expression will reference the params/vars
+        * by index, we need to slot the xsl:with-params in the
+        * order of encountered xsl:params to keep the sequence of
+        * params/variables in the stack exactly as it was at
+        * compile time,
         */
-        xsltParseStylesheetParam(ctxt, cur);
-    }
-    cur = cur->next;
+        tmpParam = NULL;
+        if (withParams) {
+            tmpParam = withParams;
+            do {
+                if ((tmpParam->name == (iparam->name)) &&
+                    (tmpParam->nameURI == (iparam->ns)))
+                {
+                    /*
+                    * Push the caller-parameter.
+                    */
+                    xsltLocalVariablePush(ctxt, tmpParam, -1);
+                    break;
+                }
+                tmpParam = tmpParam->next;
+            } while (tmpParam != NULL);
+        }
+        /*
+        * Push the xsl:param.
+        */
+        if (tmpParam == NULL) {
+            /*
+            * Note that we must assume that the added parameter
+            * has a @depth of 0.
+            */
+            xsltParseStylesheetParam(ctxt, cur);
+        }
+        cur = cur->next;
     } while (cur != NULL);
     /*
     * Process the sequence constructor.
@@ -3260,7 +3219,7 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
     * the stack. Don't free xsl:with-param items.
     */
     if (ctxt->varsNr > ctxt->varsBase)
-    xsltTemplateParamsCleanup(ctxt);
+        xsltTemplateParamsCleanup(ctxt);
     ctxt->varsBase = oldVarsBase;
 
     /*
@@ -3270,13 +3229,13 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
     * of the obsolete xsltRegisterTmpRVT().
     */
     if (ctxt->tmpRVT) {
-    xmlDocPtr curdoc = ctxt->tmpRVT, tmp;
+        xmlDocPtr curdoc = ctxt->tmpRVT, tmp;
 
-    while (curdoc != NULL) {
-        tmp = curdoc;
-        curdoc = (xmlDocPtr) curdoc->next;
-        xsltReleaseRVT(ctxt, tmp);
-    }
+        while (curdoc != NULL) {
+            tmp = curdoc;
+            curdoc = (xmlDocPtr) curdoc->next;
+            xsltReleaseRVT(ctxt, tmp);
+        }
     }
     ctxt->tmpRVT = oldUserFragmentTop;
 
@@ -3287,24 +3246,24 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_PROFILER
     if (ctxt->profile) {
-    long spent, child, total, end;
+        long spent, child, total, end;
 
-    end = xsltTimestamp();
-    child = profPop(ctxt);
-    total = end - start;
-    spent = total - child;
-    if (spent <= 0) {
-        /*
-        * Not possible unless the original calibration failed
-        * we can try to correct it on the fly.
-        */
-        xsltCalibrateAdjust(spent);
-        spent = 0;
-    }
+        end = xsltTimestamp();
+        child = profPop(ctxt);
+        total = end - start;
+        spent = total - child;
+        if (spent <= 0) {
+            /*
+            * Not possible unless the original calibration failed
+            * we can try to correct it on the fly.
+            */
+            xsltCalibrateAdjust(spent);
+            spent = 0;
+        }
 
-    templ->time += spent;
-    if (ctxt->profNr > 0)
-        ctxt->profTab[ctxt->profNr - 1] += total;
+        templ->time += spent;
+        if (ctxt->profNr > 0)
+            ctxt->profTab[ctxt->profNr - 1] += total;
     }
 #endif
 
@@ -3348,43 +3307,43 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
  */
 void
 xsltApplyOneTemplate(xsltTransformContextPtr ctxt,
-             xmlNodePtr contextNode,
+                     xmlNodePtr contextNode,
                      xmlNodePtr list,
-             xsltTemplatePtr templ ATTRIBUTE_UNUSED,
+                     xsltTemplatePtr templ ATTRIBUTE_UNUSED,
                      xsltStackElemPtr params)
 {
     if ((ctxt == NULL) || (list == NULL))
-    return;
+        return;
     CHECK_STOPPED;
 
     if (params) {
-    /*
-     * This code should be obsolete - was previously used
-     * by libexslt/functions.c, but due to bug 381319 the
-     * logic there was changed.
-     */
-    int oldVarsNr = ctxt->varsNr;
+        /*
+         * This code should be obsolete - was previously used
+         * by libexslt/functions.c, but due to bug 381319 the
+         * logic there was changed.
+         */
+        int oldVarsNr = ctxt->varsNr;
 
-    /*
-    * Push the given xsl:param(s) onto the variable stack.
-    */
-    while (params != NULL) {
-        xsltLocalVariablePush(ctxt, params, -1);
-        params = params->next;
-    }
-    xsltApplySequenceConstructor(ctxt, contextNode, list, templ);
-    /*
-    * Pop the given xsl:param(s) from the stack but don't free them.
-    */
-    xsltLocalVariablePop(ctxt, oldVarsNr, -2);
+        /*
+        * Push the given xsl:param(s) onto the variable stack.
+        */
+        while (params != NULL) {
+            xsltLocalVariablePush(ctxt, params, -1);
+            params = params->next;
+        }
+        xsltApplySequenceConstructor(ctxt, contextNode, list, templ);
+        /*
+        * Pop the given xsl:param(s) from the stack but don't free them.
+        */
+        xsltLocalVariablePop(ctxt, oldVarsNr, -2);
     } else
-    xsltApplySequenceConstructor(ctxt, contextNode, list, templ);
+        xsltApplySequenceConstructor(ctxt, contextNode, list, templ);
 }
 
 /************************************************************************
- *                                  *
- *          XSLT-1.1 extensions                 *
- *                                  *
+ *                                                                      *
+ *                  XSLT-1.1 extensions                                 *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -3428,11 +3387,11 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
     if (comp->filename == NULL) {
 
         if (xmlStrEqual(inst->name, (const xmlChar *) "output")) {
-        /*
-        * The element "output" is in the namespace XSLT_SAXON_NAMESPACE
-        *   (http://icl.com/saxon)
-        * The @file is in no namespace.
-        */
+            /*
+            * The element "output" is in the namespace XSLT_SAXON_NAMESPACE
+            *   (http://icl.com/saxon)
+            * The @file is in no namespace.
+            */
 #ifdef WITH_XSLT_DEBUG_EXTRA
             xsltGenericDebug(xsltGenericDebugContext,
                              "Found saxon:output extension\n");
@@ -3441,8 +3400,8 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
                                                  (const xmlChar *) "file",
                                                  XSLT_SAXON_NAMESPACE);
 
-        if (URL == NULL)
-        URL = xsltEvalAttrValueTemplate(ctxt, inst,
+            if (URL == NULL)
+                URL = xsltEvalAttrValueTemplate(ctxt, inst,
                                                  (const xmlChar *) "href",
                                                  XSLT_SAXON_NAMESPACE);
         } else if (xmlStrEqual(inst->name, (const xmlChar *) "write")) {
@@ -3454,32 +3413,32 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
                                                  (const xmlChar *)
                                                  "select",
                                                  XSLT_XALAN_NAMESPACE);
-        if (URL != NULL) {
-        xmlXPathCompExprPtr cmp;
-        xmlChar *val;
+            if (URL != NULL) {
+                xmlXPathCompExprPtr cmp;
+                xmlChar *val;
 
-        /*
-         * Trying to handle bug #59212
-         * The value of the "select" attribute is an
-         * XPath expression.
-         * (see http://xml.apache.org/xalan-j/extensionslib.html#redirect)
-         */
-        cmp = xmlXPathCtxtCompile(ctxt->xpathCtxt, URL);
+                /*
+                 * Trying to handle bug #59212
+                 * The value of the "select" attribute is an
+                 * XPath expression.
+                 * (see http://xml.apache.org/xalan-j/extensionslib.html#redirect)
+                 */
+                cmp = xmlXPathCtxtCompile(ctxt->xpathCtxt, URL);
                 val = xsltEvalXPathString(ctxt, cmp);
-        xmlXPathFreeCompExpr(cmp);
-        xmlFree(URL);
-        URL = val;
-        }
-        if (URL == NULL)
-        URL = xsltEvalAttrValueTemplate(ctxt, inst,
-                             (const xmlChar *)
-                             "file",
-                             XSLT_XALAN_NAMESPACE);
-        if (URL == NULL)
-        URL = xsltEvalAttrValueTemplate(ctxt, inst,
-                             (const xmlChar *)
-                             "href",
-                             XSLT_XALAN_NAMESPACE);
+                xmlXPathFreeCompExpr(cmp);
+                xmlFree(URL);
+                URL = val;
+            }
+            if (URL == NULL)
+                URL = xsltEvalAttrValueTemplate(ctxt, inst,
+                                                     (const xmlChar *)
+                                                     "file",
+                                                     XSLT_XALAN_NAMESPACE);
+            if (URL == NULL)
+                URL = xsltEvalAttrValueTemplate(ctxt, inst,
+                                                     (const xmlChar *)
+                                                     "href",
+                                                     XSLT_XALAN_NAMESPACE);
         } else if (xmlStrEqual(inst->name, (const xmlChar *) "document")) {
             URL = xsltEvalAttrValueTemplate(ctxt, inst,
                                                  (const xmlChar *) "href",
@@ -3491,9 +3450,9 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
     }
 
     if (URL == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-                 "xsltDocumentElem: href/URI-Reference not found\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+                         "xsltDocumentElem: href/URI-Reference not found\n");
+        return;
     }
 
     /*
@@ -3501,37 +3460,37 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
      */
     filename = xmlBuildURI(URL, (const xmlChar *) ctxt->outputFile);
     if (filename == NULL) {
-    xmlChar *escURL;
+        xmlChar *escURL;
 
-    escURL=xmlURIEscapeStr(URL, BAD_CAST ":/.?,");
-    if (escURL != NULL) {
-        filename = xmlBuildURI(escURL, (const xmlChar *) ctxt->outputFile);
-        xmlFree(escURL);
-    }
+        escURL=xmlURIEscapeStr(URL, BAD_CAST ":/.?,");
+        if (escURL != NULL) {
+            filename = xmlBuildURI(escURL, (const xmlChar *) ctxt->outputFile);
+            xmlFree(escURL);
+        }
     }
 
     if (filename == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-                 "xsltDocumentElem: URL computation failed for %s\n",
-             URL);
-    xmlFree(URL);
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+                         "xsltDocumentElem: URL computation failed for %s\n",
+                         URL);
+        xmlFree(URL);
+        return;
     }
 
     /*
      * Security checking: can we write to this resource
      */
     if (ctxt->sec != NULL) {
-    ret = xsltCheckWrite(ctxt->sec, ctxt, filename);
-    if (ret <= 0) {
+        ret = xsltCheckWrite(ctxt->sec, ctxt, filename);
+        if (ret <= 0) {
             if (ret == 0)
                 xsltTransformError(ctxt, NULL, inst,
                      "xsltDocumentElem: write rights for %s denied\n",
                                  filename);
-        xmlFree(URL);
-        xmlFree(filename);
-        return;
-    }
+            xmlFree(URL);
+            xmlFree(filename);
+            return;
+        }
     }
 
     oldOutputFile = ctxt->outputFile;
@@ -3542,7 +3501,7 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
     style = xsltNewStylesheet();
     if (style == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
+        xsltTransformError(ctxt, NULL, inst,
                          "xsltDocumentElem: out of memory\n");
         goto error;
     }
@@ -3552,156 +3511,158 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
      * of the output.
      */
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *) "version",
-                     NULL);
+                                     (const xmlChar *) "version",
+                                     NULL);
     if (prop != NULL) {
-    if (style->version != NULL)
-        xmlFree(style->version);
-    style->version = prop;
+        if (style->version != NULL)
+            xmlFree(style->version);
+        style->version = prop;
     }
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *) "encoding",
-                     NULL);
+                                     (const xmlChar *) "encoding",
+                                     NULL);
     if (prop != NULL) {
-    if (style->encoding != NULL)
-        xmlFree(style->encoding);
-    style->encoding = prop;
+        if (style->encoding != NULL)
+            xmlFree(style->encoding);
+        style->encoding = prop;
     }
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *) "method",
-                     NULL);
+                                     (const xmlChar *) "method",
+                                     NULL);
     if (prop != NULL) {
-    const xmlChar *URI;
+        const xmlChar *URI;
 
-    if (style->method != NULL)
-        xmlFree(style->method);
-    style->method = NULL;
-    if (style->methodURI != NULL)
-        xmlFree(style->methodURI);
-    style->methodURI = NULL;
+        if (style->method != NULL)
+            xmlFree(style->method);
+        style->method = NULL;
+        if (style->methodURI != NULL)
+            xmlFree(style->methodURI);
+        style->methodURI = NULL;
 
-    URI = xsltGetQNameURI(inst, &prop);
-    if (prop == NULL) {
-        if (style != NULL) style->errors++;
-    } else if (URI == NULL) {
-        if ((xmlStrEqual(prop, (const xmlChar *) "xml")) ||
-        (xmlStrEqual(prop, (const xmlChar *) "html")) ||
-        (xmlStrEqual(prop, (const xmlChar *) "text"))) {
-        style->method = prop;
+        URI = xsltGetQNameURI(inst, &prop);
+        if (prop == NULL) {
+            if (style != NULL) style->errors++;
+        } else if (URI == NULL) {
+            if ((xmlStrEqual(prop, (const xmlChar *) "xml")) ||
+                (xmlStrEqual(prop, (const xmlChar *) "html")) ||
+                (xmlStrEqual(prop, (const xmlChar *) "text"))) {
+                style->method = prop;
+            } else {
+                xsltTransformError(ctxt, NULL, inst,
+                                 "invalid value for method: %s\n", prop);
+                if (style != NULL) style->warnings++;
+            }
         } else {
-        xsltTransformError(ctxt, NULL, inst,
-                 "invalid value for method: %s\n", prop);
-        if (style != NULL) style->warnings++;
+            style->method = prop;
+            style->methodURI = xmlStrdup(URI);
         }
-    } else {
-        style->method = prop;
-        style->methodURI = xmlStrdup(URI);
-    }
     }
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *)
-                     "doctype-system", NULL);
+                                     (const xmlChar *)
+                                     "doctype-system", NULL);
     if (prop != NULL) {
-    if (style->doctypeSystem != NULL)
-        xmlFree(style->doctypeSystem);
-    style->doctypeSystem = prop;
+        if (style->doctypeSystem != NULL)
+            xmlFree(style->doctypeSystem);
+        style->doctypeSystem = prop;
     }
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *)
-                     "doctype-public", NULL);
+                                     (const xmlChar *)
+                                     "doctype-public", NULL);
     if (prop != NULL) {
-    if (style->doctypePublic != NULL)
-        xmlFree(style->doctypePublic);
-    style->doctypePublic = prop;
+        if (style->doctypePublic != NULL)
+            xmlFree(style->doctypePublic);
+        style->doctypePublic = prop;
     }
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *) "standalone",
-                     NULL);
+                                     (const xmlChar *) "standalone",
+                                     NULL);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
-        style->standalone = 1;
-    } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
-        style->standalone = 0;
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-                 "invalid value for standalone: %s\n",
-                 prop);
-        if (style != NULL) style->warnings++;
-    }
-    xmlFree(prop);
+        if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
+            style->standalone = 1;
+        } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
+            style->standalone = 0;
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                             "invalid value for standalone: %s\n",
+                             prop);
+            if (style != NULL) style->warnings++;
+        }
+        xmlFree(prop);
     }
 
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *) "indent",
-                     NULL);
+                                     (const xmlChar *) "indent",
+                                     NULL);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
-        style->indent = 1;
-    } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
-        style->indent = 0;
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-                 "invalid value for indent: %s\n", prop);
-        if (style != NULL) style->warnings++;
-    }
-    xmlFree(prop);
+        if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
+            style->indent = 1;
+        } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
+            style->indent = 0;
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                             "invalid value for indent: %s\n", prop);
+            if (style != NULL) style->warnings++;
+        }
+        xmlFree(prop);
     }
 
     prop = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *)
-                     "omit-xml-declaration",
-                     NULL);
+                                     (const xmlChar *)
+                                     "omit-xml-declaration",
+                                     NULL);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
-        style->omitXmlDeclaration = 1;
-    } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
-        style->omitXmlDeclaration = 0;
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-                 "invalid value for omit-xml-declaration: %s\n",
-                 prop);
-        if (style != NULL) style->warnings++;
-    }
-    xmlFree(prop);
+        if (xmlStrEqual(prop, (const xmlChar *) "yes")) {
+            style->omitXmlDeclaration = 1;
+        } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
+            style->omitXmlDeclaration = 0;
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                             "invalid value for omit-xml-declaration: %s\n",
+                             prop);
+            if (style != NULL) style->warnings++;
+        }
+        xmlFree(prop);
     }
 
     elements = xsltEvalAttrValueTemplate(ctxt, inst,
-                     (const xmlChar *)
-                     "cdata-section-elements",
-                     NULL);
+                                         (const xmlChar *)
+                                         "cdata-section-elements",
+                                         NULL);
     if (elements != NULL) {
-    if (style->stripSpaces == NULL)
-        style->stripSpaces = xmlHashCreate(10);
-    if (style->stripSpaces == NULL)
-        return;
+        if (style->stripSpaces == NULL)
+            style->stripSpaces = xmlHashCreate(10);
+        if (style->stripSpaces == NULL) {
+            xmlFree(elements);
+            return;
+        }
 
-    element = elements;
-    while (*element != 0) {
-        while (IS_BLANK_CH(*element))
-        element++;
-        if (*element == 0)
-        break;
-        end = element;
-        while ((*end != 0) && (!IS_BLANK_CH(*end)))
-        end++;
-        element = xmlStrndup(element, end - element);
-        if (element) {
-        const xmlChar *URI;
+        element = elements;
+        while (*element != 0) {
+            while (IS_BLANK_CH(*element))
+                element++;
+            if (*element == 0)
+                break;
+            end = element;
+            while ((*end != 0) && (!IS_BLANK_CH(*end)))
+                end++;
+            element = xmlStrndup(element, end - element);
+            if (element) {
+                const xmlChar *URI;
 
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-                 "add cdata section output element %s\n",
-                 element);
+                xsltGenericDebug(xsltGenericDebugContext,
+                                 "add cdata section output element %s\n",
+                                 element);
 #endif
                 URI = xsltGetQNameURI(inst, &element);
 
-        xmlHashAddEntry2(style->stripSpaces, element, URI,
-                    (xmlChar *) "cdata");
-        xmlFree(element);
+                xmlHashAddEntry2(style->stripSpaces, element, URI,
+                                (xmlChar *) "cdata");
+                xmlFree(element);
+            }
+            element = end;
         }
-        element = end;
-    }
-    xmlFree(elements);
+        xmlFree(elements);
     }
 
     /*
@@ -3714,64 +3675,64 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
 
     if ((method != NULL) &&
-    (!xmlStrEqual(method, (const xmlChar *) "xml"))) {
-    if (xmlStrEqual(method, (const xmlChar *) "html")) {
-        ctxt->type = XSLT_OUTPUT_HTML;
-        if (((doctypePublic != NULL) || (doctypeSystem != NULL)))
-        res = htmlNewDoc(doctypeSystem, doctypePublic);
-        else {
-        if (version != NULL) {
+        (!xmlStrEqual(method, (const xmlChar *) "xml"))) {
+        if (xmlStrEqual(method, (const xmlChar *) "html")) {
+            ctxt->type = XSLT_OUTPUT_HTML;
+            if (((doctypePublic != NULL) || (doctypeSystem != NULL)))
+                res = htmlNewDoc(doctypeSystem, doctypePublic);
+            else {
+                if (version != NULL) {
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
-            xsltGetHTMLIDs(version, &doctypePublic, &doctypeSystem);
+                    xsltGetHTMLIDs(version, &doctypePublic, &doctypeSystem);
 #endif
                 }
-        res = htmlNewDocNoDtD(doctypeSystem, doctypePublic);
+                res = htmlNewDocNoDtD(doctypeSystem, doctypePublic);
+            }
+            if (res == NULL)
+                goto error;
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
+        } else if (xmlStrEqual(method, (const xmlChar *) "xhtml")) {
+            xsltTransformError(ctxt, NULL, inst,
+             "xsltDocumentElem: unsupported method xhtml\n");
+            ctxt->type = XSLT_OUTPUT_HTML;
+            res = htmlNewDocNoDtD(doctypeSystem, doctypePublic);
+            if (res == NULL)
+                goto error;
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
+        } else if (xmlStrEqual(method, (const xmlChar *) "text")) {
+            ctxt->type = XSLT_OUTPUT_TEXT;
+            res = xmlNewDoc(style->version);
+            if (res == NULL)
+                goto error;
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
+#ifdef WITH_XSLT_DEBUG
+            xsltGenericDebug(xsltGenericDebugContext,
+                     "reusing transformation dict for output\n");
+#endif
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                             "xsltDocumentElem: unsupported method (%s)\n",
+                             method);
+            goto error;
         }
-        if (res == NULL)
-        goto error;
-        res->dict = ctxt->dict;
-        xmlDictReference(res->dict);
-    } else if (xmlStrEqual(method, (const xmlChar *) "xhtml")) {
-        xsltTransformError(ctxt, NULL, inst,
-         "xsltDocumentElem: unsupported method xhtml\n");
-        ctxt->type = XSLT_OUTPUT_HTML;
-        res = htmlNewDocNoDtD(doctypeSystem, doctypePublic);
-        if (res == NULL)
-        goto error;
-        res->dict = ctxt->dict;
-        xmlDictReference(res->dict);
-    } else if (xmlStrEqual(method, (const xmlChar *) "text")) {
-        ctxt->type = XSLT_OUTPUT_TEXT;
+    } else {
+        ctxt->type = XSLT_OUTPUT_XML;
         res = xmlNewDoc(style->version);
         if (res == NULL)
-        goto error;
+            goto error;
         res->dict = ctxt->dict;
         xmlDictReference(res->dict);
 #ifdef WITH_XSLT_DEBUG
         xsltGenericDebug(xsltGenericDebugContext,
                      "reusing transformation dict for output\n");
 #endif
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-                 "xsltDocumentElem: unsupported method (%s)\n",
-                     method);
-        goto error;
-    }
-    } else {
-    ctxt->type = XSLT_OUTPUT_XML;
-    res = xmlNewDoc(style->version);
-    if (res == NULL)
-        goto error;
-    res->dict = ctxt->dict;
-    xmlDictReference(res->dict);
-#ifdef WITH_XSLT_DEBUG
-    xsltGenericDebug(xsltGenericDebugContext,
-                     "reusing transformation dict for output\n");
-#endif
     }
     res->charset = XML_CHAR_ENCODING_UTF8;
     if (encoding != NULL)
-    res->encoding = xmlStrdup(encoding);
+        res->encoding = xmlStrdup(encoding);
     ctxt->output = res;
     ctxt->insert = (xmlNodePtr) res;
     xsltApplySequenceConstructor(ctxt, node, inst->children, NULL);
@@ -3784,9 +3745,9 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
         const xmlChar *doctype = NULL;
 
         if ((root->ns != NULL) && (root->ns->prefix != NULL))
-        doctype = xmlDictQLookup(ctxt->dict, root->ns->prefix, root->name);
-    if (doctype == NULL)
-        doctype = root->name;
+            doctype = xmlDictQLookup(ctxt->dict, root->ns->prefix, root->name);
+        if (doctype == NULL)
+            doctype = root->name;
 
         /*
          * Apply the default selection of the method
@@ -3802,7 +3763,7 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
                     break;
                 if ((tmp->type == XML_TEXT_NODE) && (!xmlIsBlankNode(tmp)))
                     break;
-        tmp = tmp->next;
+                tmp = tmp->next;
             }
             if (tmp == root) {
                 ctxt->type = XSLT_OUTPUT_HTML;
@@ -3812,7 +3773,7 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
                                                         doctypePublic,
                                                         doctypeSystem);
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
-        } else if (version != NULL) {
+                } else if (version != NULL) {
                     xsltGetHTMLIDs(version, &doctypePublic,
                                    &doctypeSystem);
                     if (((doctypePublic != NULL) || (doctypeSystem != NULL)))
@@ -3844,32 +3805,32 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
      * Note that append use will forbid use of remote URI target.
      */
     prop = xsltEvalAttrValueTemplate(ctxt, inst, (const xmlChar *)"append",
-                     NULL);
+                                     NULL);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *) "true") ||
-        xmlStrEqual(prop, (const xmlChar *) "yes")) {
-        style->omitXmlDeclaration = 1;
-        redirect_write_append = 1;
-    } else
-        style->omitXmlDeclaration = 0;
-    xmlFree(prop);
+        if (xmlStrEqual(prop, (const xmlChar *) "true") ||
+            xmlStrEqual(prop, (const xmlChar *) "yes")) {
+            style->omitXmlDeclaration = 1;
+            redirect_write_append = 1;
+        } else
+            style->omitXmlDeclaration = 0;
+        xmlFree(prop);
     }
 
     if (redirect_write_append) {
         FILE *f;
 
-    f = fopen((const char *) filename, "ab");
-    if (f == NULL) {
-        ret = -1;
+        f = fopen((const char *) filename, "ab");
+        if (f == NULL) {
+            ret = -1;
+        } else {
+            ret = xsltSaveResultToFile(f, res, style);
+            fclose(f);
+        }
     } else {
-        ret = xsltSaveResultToFile(f, res, style);
-        fclose(f);
-    }
-    } else {
-    ret = xsltSaveResultToFilename((const char *) filename, res, style, 0);
+        ret = xsltSaveResultToFilename((const char *) filename, res, style, 0);
     }
     if (ret < 0) {
-    xsltTransformError(ctxt, NULL, inst,
+        xsltTransformError(ctxt, NULL, inst,
                          "xsltDocumentElem: unable to save to %s\n",
                          filename);
 #ifdef WITH_XSLT_DEBUG_EXTRA
@@ -3895,9 +3856,9 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
 }
 
 /************************************************************************
- *                                  *
- *      Most of the XSLT-1.0 transformations            *
- *                                  *
+ *                                                                      *
+ *              Most of the XSLT-1.0 transformations                    *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -3912,15 +3873,15 @@ xsltDocumentElem(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltSort(xsltTransformContextPtr ctxt,
-    xmlNodePtr node ATTRIBUTE_UNUSED, xmlNodePtr inst,
-    xsltElemPreCompPtr comp) {
+        xmlNodePtr node ATTRIBUTE_UNUSED, xmlNodePtr inst,
+        xsltElemPreCompPtr comp) {
     if (comp == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:sort : compilation failed\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:sort : compilation failed\n");
+        return;
     }
     xsltTransformError(ctxt, NULL, inst,
-     "xsl:sort : improper use this should not be reached\n");
+         "xsl:sort : improper use this should not be reached\n");
 }
 
 /**
@@ -3934,7 +3895,7 @@ xsltSort(xsltTransformContextPtr ctxt,
  */
 void
 xsltCopy(xsltTransformContextPtr ctxt, xmlNodePtr node,
-     xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+         xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemCopyPtr comp = (xsltStyleItemCopyPtr) castedComp;
@@ -3945,99 +3906,99 @@ xsltCopy(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
     oldInsert = ctxt->insert;
     if (ctxt->insert != NULL) {
-    switch (node->type) {
-        case XML_TEXT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        /*
-         * This text comes from the stylesheet
-         * For stylesheets, the set of whitespace-preserving
-         * element names consists of just xsl:text.
-         */
+        switch (node->type) {
+            case XML_TEXT_NODE:
+            case XML_CDATA_SECTION_NODE:
+                /*
+                 * This text comes from the stylesheet
+                 * For stylesheets, the set of whitespace-preserving
+                 * element names consists of just xsl:text.
+                 */
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        if (node->type == XML_CDATA_SECTION_NODE) {
-            XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopy: CDATA text %s\n", node->content));
-        } else {
-            XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltCopy: text %s\n", node->content));
+                if (node->type == XML_CDATA_SECTION_NODE) {
+                    XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltCopy: CDATA text %s\n", node->content));
+                } else {
+                    XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                         "xsltCopy: text %s\n", node->content));
                 }
 #endif
-        xsltCopyText(ctxt, ctxt->insert, node, 0);
-        break;
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-        break;
-        case XML_ELEMENT_NODE:
-        /*
-        * REVISIT NOTE: The "fake" is a doc-node, not an element node.
-        * REMOVED:
-        *   if (xmlStrEqual(node->name, BAD_CAST " fake node libxslt"))
-        *    return;
-        */
+                xsltCopyText(ctxt, ctxt->insert, node, 0);
+                break;
+            case XML_DOCUMENT_NODE:
+            case XML_HTML_DOCUMENT_NODE:
+                break;
+            case XML_ELEMENT_NODE:
+                /*
+                * REVISIT NOTE: The "fake" is a doc-node, not an element node.
+                * REMOVED:
+                *   if (xmlStrEqual(node->name, BAD_CAST " fake node libxslt"))
+                *    return;
+                */
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-                 "xsltCopy: node %s\n", node->name));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                                 "xsltCopy: node %s\n", node->name));
 #endif
-        copy = xsltShallowCopyElem(ctxt, node, ctxt->insert, 0);
-        ctxt->insert = copy;
-        if (comp->use != NULL) {
-            xsltApplyAttributeSet(ctxt, node, inst, comp->use);
-        }
-        break;
-        case XML_ATTRIBUTE_NODE: {
+                copy = xsltShallowCopyElem(ctxt, node, ctxt->insert, 0);
+                ctxt->insert = copy;
+                if (comp->use != NULL) {
+                    xsltApplyAttributeSet(ctxt, node, inst, comp->use);
+                }
+                break;
+            case XML_ATTRIBUTE_NODE: {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-                 "xsltCopy: attribute %s\n", node->name));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                                 "xsltCopy: attribute %s\n", node->name));
 #endif
-        /*
-        * REVISIT: We could also raise an error if the parent is not
-        * an element node.
-        * OPTIMIZE TODO: Can we set the value/children of the
-        * attribute without an intermediate copy of the string value?
-        */
-        xsltShallowCopyAttr(ctxt, inst, ctxt->insert, (xmlAttrPtr) node);
-        break;
-        }
-        case XML_PI_NODE:
+                /*
+                * REVISIT: We could also raise an error if the parent is not
+                * an element node.
+                * OPTIMIZE TODO: Can we set the value/children of the
+                * attribute without an intermediate copy of the string value?
+                */
+                xsltShallowCopyAttr(ctxt, inst, ctxt->insert, (xmlAttrPtr) node);
+                break;
+            }
+            case XML_PI_NODE:
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-                 "xsltCopy: PI %s\n", node->name));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                                 "xsltCopy: PI %s\n", node->name));
 #endif
-        copy = xmlNewDocPI(ctxt->insert->doc, node->name,
-                           node->content);
-        copy = xsltAddChild(ctxt->insert, copy);
-        break;
-        case XML_COMMENT_NODE:
+                copy = xmlNewDocPI(ctxt->insert->doc, node->name,
+                                   node->content);
+                copy = xsltAddChild(ctxt->insert, copy);
+                break;
+            case XML_COMMENT_NODE:
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-                 "xsltCopy: comment\n"));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                                 "xsltCopy: comment\n"));
 #endif
-        copy = xmlNewComment(node->content);
-        copy = xsltAddChild(ctxt->insert, copy);
-        break;
-        case XML_NAMESPACE_DECL:
+                copy = xmlNewComment(node->content);
+                copy = xsltAddChild(ctxt->insert, copy);
+                break;
+            case XML_NAMESPACE_DECL:
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
-                 "xsltCopy: namespace declaration\n"));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY,xsltGenericDebug(xsltGenericDebugContext,
+                                 "xsltCopy: namespace declaration\n"));
 #endif
-        xsltShallowCopyNsNode(ctxt, inst, ctxt->insert, (xmlNsPtr)node);
-        break;
-        default:
-        break;
+                xsltShallowCopyNsNode(ctxt, inst, ctxt->insert, (xmlNsPtr)node);
+                break;
+            default:
+                break;
 
-    }
+        }
     }
 
     switch (node->type) {
-    case XML_DOCUMENT_NODE:
-    case XML_HTML_DOCUMENT_NODE:
-    case XML_ELEMENT_NODE:
-        xsltApplySequenceConstructor(ctxt, ctxt->node, inst->children,
-        NULL);
-        break;
-    default:
-        break;
+        case XML_DOCUMENT_NODE:
+        case XML_HTML_DOCUMENT_NODE:
+        case XML_ELEMENT_NODE:
+            xsltApplySequenceConstructor(ctxt, ctxt->node, inst->children,
+                NULL);
+            break;
+        default:
+            break;
     }
     ctxt->insert = oldInsert;
 }
@@ -4053,29 +4014,29 @@ xsltCopy(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltText(xsltTransformContextPtr ctxt, xmlNodePtr node ATTRIBUTE_UNUSED,
-        xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED) {
+            xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED) {
     if ((inst->children != NULL) && (comp != NULL)) {
-    xmlNodePtr text = inst->children;
-    xmlNodePtr copy;
+        xmlNodePtr text = inst->children;
+        xmlNodePtr copy;
 
-    while (text != NULL) {
-        if ((text->type != XML_TEXT_NODE) &&
-             (text->type != XML_CDATA_SECTION_NODE)) {
-        xsltTransformError(ctxt, NULL, inst,
-                 "xsl:text content problem\n");
-        break;
-        }
-        copy = xmlNewDocText(ctxt->output, text->content);
-        if (text->type != XML_CDATA_SECTION_NODE) {
+        while (text != NULL) {
+            if ((text->type != XML_TEXT_NODE) &&
+                 (text->type != XML_CDATA_SECTION_NODE)) {
+                xsltTransformError(ctxt, NULL, inst,
+                                 "xsl:text content problem\n");
+                break;
+            }
+            copy = xmlNewDocText(ctxt->output, text->content);
+            if (text->type != XML_CDATA_SECTION_NODE) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-             "Disable escaping: %s\n", text->content);
+                xsltGenericDebug(xsltGenericDebugContext,
+                     "Disable escaping: %s\n", text->content);
 #endif
-        copy->name = xmlStringTextNoenc;
+                copy->name = xmlStringTextNoenc;
+            }
+            copy = xsltAddChild(ctxt->insert, copy);
+            text = text->next;
         }
-        copy = xsltAddChild(ctxt->insert, copy);
-        text = text->next;
-    }
     }
 }
 
@@ -4090,7 +4051,7 @@ xsltText(xsltTransformContextPtr ctxt, xmlNodePtr node ATTRIBUTE_UNUSED,
  */
 void
 xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
-        xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
+            xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemElementPtr comp = (xsltStyleItemElementPtr) castedComp;
 #else
@@ -4102,7 +4063,7 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
     xmlNodePtr oldInsert;
 
     if (ctxt->insert == NULL)
-    return;
+        return;
 
     /*
     * A comp->has_name == 0 indicates that we need to skip this instruction,
@@ -4117,31 +4078,31 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
     oldInsert = ctxt->insert;
 
     if (comp->name == NULL) {
-    /* TODO: fix attr acquisition wrt to the XSLT namespace */
+        /* TODO: fix attr acquisition wrt to the XSLT namespace */
         prop = xsltEvalAttrValueTemplate(ctxt, inst,
-        (const xmlChar *) "name", XSLT_NAMESPACE);
+            (const xmlChar *) "name", XSLT_NAMESPACE);
         if (prop == NULL) {
             xsltTransformError(ctxt, NULL, inst,
-        "xsl:element: The attribute 'name' is missing.\n");
+                "xsl:element: The attribute 'name' is missing.\n");
             goto error;
         }
-    if (xmlValidateQName(prop, 0)) {
-        xsltTransformError(ctxt, NULL, inst,
-        "xsl:element: The effective name '%s' is not a "
-        "valid QName.\n", prop);
-        /* we fall through to catch any further errors, if possible */
-    }
-    name = xsltSplitQName(ctxt->dict, prop, &prefix);
-    xmlFree(prop);
+        if (xmlValidateQName(prop, 0)) {
+            xsltTransformError(ctxt, NULL, inst,
+                "xsl:element: The effective name '%s' is not a "
+                "valid QName.\n", prop);
+            /* we fall through to catch any further errors, if possible */
+        }
+        name = xsltSplitQName(ctxt->dict, prop, &prefix);
+        xmlFree(prop);
     } else {
-    /*
-    * The "name" value was static.
-    */
+        /*
+        * The "name" value was static.
+        */
 #ifdef XSLT_REFACTORED
-    prefix = comp->nsPrefix;
-    name = comp->name;
+        prefix = comp->nsPrefix;
+        name = comp->name;
 #else
-    name = xsltSplitQName(ctxt->dict, comp->name, &prefix);
+        name = xsltSplitQName(ctxt->dict, comp->name, &prefix);
 #endif
     }
 
@@ -4149,14 +4110,14 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
      * Create the new element
      */
     if (ctxt->output->dict == ctxt->dict) {
-    copy = xmlNewDocNodeEatName(ctxt->output, NULL, (xmlChar *)name, NULL);
+        copy = xmlNewDocNodeEatName(ctxt->output, NULL, (xmlChar *)name, NULL);
     } else {
-    copy = xmlNewDocNode(ctxt->output, NULL, (xmlChar *)name, NULL);
+        copy = xmlNewDocNode(ctxt->output, NULL, (xmlChar *)name, NULL);
     }
     if (copy == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-        "xsl:element : creation of %s failed\n", name);
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "xsl:element : creation of %s failed\n", name);
+        return;
     }
     copy = xsltAddChild(ctxt->insert, copy);
     if (copy == NULL) {
@@ -4170,29 +4131,29 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
     * ---------
     */
     if (comp->has_ns) {
-    if (comp->ns != NULL) {
-        /*
-        * No AVT; just plain text for the namespace name.
-        */
-        if (comp->ns[0] != 0)
-        nsName = comp->ns;
-    } else {
-        xmlChar *tmpNsName;
-        /*
-        * Eval the AVT.
-        */
-        /* TODO: check attr acquisition wrt to the XSLT namespace */
-        tmpNsName = xsltEvalAttrValueTemplate(ctxt, inst,
-        (const xmlChar *) "namespace", XSLT_NAMESPACE);
-        /*
-        * SPEC XSLT 1.0:
-        *  "If the string is empty, then the expanded-name of the
-        *  attribute has a null namespace URI."
-        */
-        if ((tmpNsName != NULL) && (tmpNsName[0] != 0))
-        nsName = xmlDictLookup(ctxt->dict, BAD_CAST tmpNsName, -1);
-        xmlFree(tmpNsName);
-    }
+        if (comp->ns != NULL) {
+            /*
+            * No AVT; just plain text for the namespace name.
+            */
+            if (comp->ns[0] != 0)
+                nsName = comp->ns;
+        } else {
+            xmlChar *tmpNsName;
+            /*
+            * Eval the AVT.
+            */
+            /* TODO: check attr acquisition wrt to the XSLT namespace */
+            tmpNsName = xsltEvalAttrValueTemplate(ctxt, inst,
+                (const xmlChar *) "namespace", XSLT_NAMESPACE);
+            /*
+            * SPEC XSLT 1.0:
+            *  "If the string is empty, then the expanded-name of the
+            *  attribute has a null namespace URI."
+            */
+            if ((tmpNsName != NULL) && (tmpNsName[0] != 0))
+                nsName = xmlDictLookup(ctxt->dict, BAD_CAST tmpNsName, -1);
+            xmlFree(tmpNsName);
+        }
 
         if (xmlStrEqual(nsName, BAD_CAST "http://www.w3.org/2000/xmlns/")) {
             xsltTransformError(ctxt, NULL, inst,
@@ -4206,20 +4167,20 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
             prefix = NULL;
         }
     } else {
-    xmlNsPtr ns;
-    /*
-    * SPEC XSLT 1.0:
-    *  "If the namespace attribute is not present, then the QName is
-    *  expanded into an expanded-name using the namespace declarations
-    *  in effect for the xsl:element element, including any default
-    *  namespace declaration.
-    */
-    ns = xmlSearchNs(inst->doc, inst, prefix);
-    if (ns == NULL) {
+        xmlNsPtr ns;
         /*
-        * TODO: Check this in the compilation layer in case it's a
-        * static value.
+        * SPEC XSLT 1.0:
+        *  "If the namespace attribute is not present, then the QName is
+        *  expanded into an expanded-name using the namespace declarations
+        *  in effect for the xsl:element element, including any default
+        *  namespace declaration.
         */
+        ns = xmlSearchNs(inst->doc, inst, prefix);
+        if (ns == NULL) {
+            /*
+            * TODO: Check this in the compilation layer in case it's a
+            * static value.
+            */
             if (prefix != NULL) {
                 xsltTransformError(ctxt, NULL, inst,
                     "xsl:element: The QName '%s:%s' has no "
@@ -4227,59 +4188,59 @@ xsltElement(xsltTransformContextPtr ctxt, xmlNodePtr node,
                     "this is an error, since the namespace was not "
                     "specified by the instruction itself.\n", prefix, name);
             }
-    } else
-        nsName = ns->href;
+        } else
+            nsName = ns->href;
     }
     /*
     * Find/create a matching ns-decl in the result tree.
     */
     if (nsName != NULL) {
-    if (xmlStrEqual(prefix, BAD_CAST "xmlns")) {
+        if (xmlStrEqual(prefix, BAD_CAST "xmlns")) {
             /* Don't use a prefix of "xmlns" */
-        xmlChar *pref = xmlStrdup(BAD_CAST "ns_1");
+            xmlChar *pref = xmlStrdup(BAD_CAST "ns_1");
 
-        copy->ns = xsltGetSpecialNamespace(ctxt, inst, nsName, pref, copy);
+            copy->ns = xsltGetSpecialNamespace(ctxt, inst, nsName, pref, copy);
 
-        xmlFree(pref);
-    } else {
-        copy->ns = xsltGetSpecialNamespace(ctxt, inst, nsName, prefix,
-        copy);
-    }
+            xmlFree(pref);
+        } else {
+            copy->ns = xsltGetSpecialNamespace(ctxt, inst, nsName, prefix,
+                copy);
+        }
     } else if ((copy->parent != NULL) &&
-    (copy->parent->type == XML_ELEMENT_NODE) &&
-    (copy->parent->ns != NULL))
+        (copy->parent->type == XML_ELEMENT_NODE) &&
+        (copy->parent->ns != NULL))
     {
-    /*
-    * "Undeclare" the default namespace.
-    */
-    xsltGetSpecialNamespace(ctxt, inst, NULL, NULL, copy);
+        /*
+        * "Undeclare" the default namespace.
+        */
+        xsltGetSpecialNamespace(ctxt, inst, NULL, NULL, copy);
     }
 
     ctxt->insert = copy;
 
     if (comp->has_use) {
-    if (comp->use != NULL) {
-        xsltApplyAttributeSet(ctxt, node, inst, comp->use);
-    } else {
-        xmlChar *attrSets = NULL;
-        /*
-        * BUG TODO: use-attribute-sets is not a value template.
-        *  use-attribute-sets = qnames
-        */
-        attrSets = xsltEvalAttrValueTemplate(ctxt, inst,
-        (const xmlChar *)"use-attribute-sets", NULL);
-        if (attrSets != NULL) {
-        xsltApplyAttributeSet(ctxt, node, inst, attrSets);
-        xmlFree(attrSets);
+        if (comp->use != NULL) {
+            xsltApplyAttributeSet(ctxt, node, inst, comp->use);
+        } else {
+            xmlChar *attrSets = NULL;
+            /*
+            * BUG TODO: use-attribute-sets is not a value template.
+            *  use-attribute-sets = qnames
+            */
+            attrSets = xsltEvalAttrValueTemplate(ctxt, inst,
+                (const xmlChar *)"use-attribute-sets", NULL);
+            if (attrSets != NULL) {
+                xsltApplyAttributeSet(ctxt, node, inst, attrSets);
+                xmlFree(attrSets);
+            }
         }
-    }
     }
     /*
     * Instantiate the sequence constructor.
     */
     if (inst->children != NULL)
-    xsltApplySequenceConstructor(ctxt, ctxt->node, inst->children,
-        NULL);
+        xsltApplySequenceConstructor(ctxt, ctxt->node, inst->children,
+            NULL);
 
 error:
     ctxt->insert = oldInsert;
@@ -4298,7 +4259,7 @@ error:
  */
 void
 xsltComment(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED) {
+                   xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED) {
     xmlChar *value = NULL;
     xmlNodePtr commentNode;
     int len;
@@ -4308,19 +4269,19 @@ xsltComment(xsltTransformContextPtr ctxt, xmlNodePtr node,
     len = xmlStrlen(value);
     if (len > 0) {
         if ((value[len-1] == '-') ||
-        (xmlStrstr(value, BAD_CAST "--"))) {
-        xsltTransformError(ctxt, NULL, inst,
-            "xsl:comment : '--' or ending '-' not allowed in comment\n");
-        /* fall through to try to catch further errors */
-    }
+            (xmlStrstr(value, BAD_CAST "--"))) {
+            xsltTransformError(ctxt, NULL, inst,
+                    "xsl:comment : '--' or ending '-' not allowed in comment\n");
+            /* fall through to try to catch further errors */
+        }
     }
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (value == NULL) {
-    XSLT_TRACE(ctxt,XSLT_TRACE_COMMENT,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltComment: empty\n"));
+        XSLT_TRACE(ctxt,XSLT_TRACE_COMMENT,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltComment: empty\n"));
     } else {
-    XSLT_TRACE(ctxt,XSLT_TRACE_COMMENT,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltComment: content %s\n", value));
+        XSLT_TRACE(ctxt,XSLT_TRACE_COMMENT,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltComment: content %s\n", value));
     }
 #endif
 
@@ -4328,7 +4289,7 @@ xsltComment(xsltTransformContextPtr ctxt, xmlNodePtr node,
     commentNode = xsltAddChild(ctxt->insert, commentNode);
 
     if (value != NULL)
-    xmlFree(value);
+        xmlFree(value);
 }
 
 /**
@@ -4342,7 +4303,7 @@ xsltComment(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltProcessingInstruction(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemPIPtr comp = (xsltStyleItemPIPtr) castedComp;
 #else
@@ -4354,36 +4315,36 @@ xsltProcessingInstruction(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
 
     if (ctxt->insert == NULL)
-    return;
+        return;
     if (comp->has_name == 0)
-    return;
+        return;
     if (comp->name == NULL) {
-    name = xsltEvalAttrValueTemplate(ctxt, inst,
-                (const xmlChar *)"name", NULL);
-    if (name == NULL) {
-        xsltTransformError(ctxt, NULL, inst,
-         "xsl:processing-instruction : name is missing\n");
-        goto error;
-    }
+        name = xsltEvalAttrValueTemplate(ctxt, inst,
+                            (const xmlChar *)"name", NULL);
+        if (name == NULL) {
+            xsltTransformError(ctxt, NULL, inst,
+                 "xsl:processing-instruction : name is missing\n");
+            goto error;
+        }
     } else {
-    name = comp->name;
+        name = comp->name;
     }
     /* TODO: check that it's both an an NCName and a PITarget. */
 
 
     value = xsltEvalTemplateString(ctxt, node, inst);
     if (xmlStrstr(value, BAD_CAST "?>") != NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:processing-instruction: '?>' not allowed within PI content\n");
-    goto error;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:processing-instruction: '?>' not allowed within PI content\n");
+        goto error;
     }
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (value == NULL) {
-    XSLT_TRACE(ctxt,XSLT_TRACE_PI,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessingInstruction: %s empty\n", name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_PI,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessingInstruction: %s empty\n", name));
     } else {
-    XSLT_TRACE(ctxt,XSLT_TRACE_PI,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltProcessingInstruction: %s content %s\n", name, value));
+        XSLT_TRACE(ctxt,XSLT_TRACE_PI,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltProcessingInstruction: %s content %s\n", name, value));
     }
 #endif
 
@@ -4394,7 +4355,7 @@ error:
     if ((name != NULL) && (name != comp->name))
         xmlFree((xmlChar *) name);
     if (value != NULL)
-    xmlFree(value);
+        xmlFree(value);
 }
 
 /**
@@ -4408,7 +4369,7 @@ error:
  */
 void
 xsltCopyOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemCopyOfPtr comp = (xsltStyleItemCopyOfPtr) castedComp;
 #else
@@ -4419,11 +4380,11 @@ xsltCopyOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
     int i;
 
     if ((ctxt == NULL) || (node == NULL) || (inst == NULL))
-    return;
+        return;
     if ((comp == NULL) || (comp->select == NULL) || (comp->comp == NULL)) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:copy-of : compilation failed\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:copy-of : compilation failed\n");
+        return;
     }
 
      /*
@@ -4446,7 +4407,7 @@ xsltCopyOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltCopyOf: select %s\n", comp->select));
+         "xsltCopyOf: select %s\n", comp->select));
 #endif
 
     /*
@@ -4455,90 +4416,90 @@ xsltCopyOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
     res = xsltPreCompEval(ctxt, node, comp);
 
     if (res != NULL) {
-    if (res->type == XPATH_NODESET) {
-        /*
-        * Node-set
-        * --------
-        */
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltCopyOf: result is a node set\n"));
-#endif
-        list = res->nodesetval;
-        if (list != NULL) {
-        xmlNodePtr cur;
-        /*
-        * The list is already sorted in document order by XPath.
-        * Append everything in this order under ctxt->insert.
-        */
-        for (i = 0;i < list->nodeNr;i++) {
-            cur = list->nodeTab[i];
-            if (cur == NULL)
-            continue;
-            if ((cur->type == XML_DOCUMENT_NODE) ||
-            (cur->type == XML_HTML_DOCUMENT_NODE))
-            {
-            xsltCopyTreeList(ctxt, inst,
-                cur->children, ctxt->insert, 0, 0);
-            } else if (cur->type == XML_ATTRIBUTE_NODE) {
-            xsltShallowCopyAttr(ctxt, inst,
-                ctxt->insert, (xmlAttrPtr) cur);
-            } else {
-            xsltCopyTree(ctxt, inst, cur, ctxt->insert, 0, 0);
-            }
-        }
-        }
-    } else if (res->type == XPATH_XSLT_TREE) {
-        /*
-        * Result tree fragment
-        * --------------------
-        * E.g. via <xsl:variable ...><foo/></xsl:variable>
-        * Note that the root node of such trees is an xmlDocPtr in Libxslt.
-        */
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltCopyOf: result is a result tree fragment\n"));
-#endif
-        list = res->nodesetval;
-        if ((list != NULL) && (list->nodeTab != NULL) &&
-        (list->nodeTab[0] != NULL) &&
-        (IS_XSLT_REAL_NODE(list->nodeTab[0])))
-        {
-        xsltCopyTreeList(ctxt, inst,
-            list->nodeTab[0]->children, ctxt->insert, 0, 0);
-        }
-    } else {
-        xmlChar *value = NULL;
-        /*
-        * Convert to a string.
-        */
-        value = xmlXPathCastToString(res);
-        if (value == NULL) {
-        xsltTransformError(ctxt, NULL, inst,
-            "Internal error in xsltCopyOf(): "
-            "failed to cast an XPath object to string.\n");
-        ctxt->state = XSLT_STATE_STOPPED;
-        } else {
-        if (value[0] != 0) {
+        if (res->type == XPATH_NODESET) {
             /*
-            * Append content as text node.
+            * Node-set
+            * --------
             */
-            xsltCopyTextString(ctxt, ctxt->insert, value, 0);
-        }
-        xmlFree(value);
+#ifdef WITH_XSLT_DEBUG_PROCESS
+            XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltCopyOf: result is a node set\n"));
+#endif
+            list = res->nodesetval;
+            if (list != NULL) {
+                xmlNodePtr cur;
+                /*
+                * The list is already sorted in document order by XPath.
+                * Append everything in this order under ctxt->insert.
+                */
+                for (i = 0;i < list->nodeNr;i++) {
+                    cur = list->nodeTab[i];
+                    if (cur == NULL)
+                        continue;
+                    if ((cur->type == XML_DOCUMENT_NODE) ||
+                        (cur->type == XML_HTML_DOCUMENT_NODE))
+                    {
+                        xsltCopyTreeList(ctxt, inst,
+                            cur->children, ctxt->insert, 0, 0);
+                    } else if (cur->type == XML_ATTRIBUTE_NODE) {
+                        xsltShallowCopyAttr(ctxt, inst,
+                            ctxt->insert, (xmlAttrPtr) cur);
+                    } else {
+                        xsltCopyTree(ctxt, inst, cur, ctxt->insert, 0, 0);
+                    }
+                }
+            }
+        } else if (res->type == XPATH_XSLT_TREE) {
+            /*
+            * Result tree fragment
+            * --------------------
+            * E.g. via <xsl:variable ...><foo/></xsl:variable>
+            * Note that the root node of such trees is an xmlDocPtr in Libxslt.
+            */
+#ifdef WITH_XSLT_DEBUG_PROCESS
+            XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
+                 "xsltCopyOf: result is a result tree fragment\n"));
+#endif
+            list = res->nodesetval;
+            if ((list != NULL) && (list->nodeTab != NULL) &&
+                (list->nodeTab[0] != NULL) &&
+                (IS_XSLT_REAL_NODE(list->nodeTab[0])))
+            {
+                xsltCopyTreeList(ctxt, inst,
+                    list->nodeTab[0]->children, ctxt->insert, 0, 0);
+            }
+        } else {
+            xmlChar *value = NULL;
+            /*
+            * Convert to a string.
+            */
+            value = xmlXPathCastToString(res);
+            if (value == NULL) {
+                xsltTransformError(ctxt, NULL, inst,
+                    "Internal error in xsltCopyOf(): "
+                    "failed to cast an XPath object to string.\n");
+                ctxt->state = XSLT_STATE_STOPPED;
+            } else {
+                if (value[0] != 0) {
+                    /*
+                    * Append content as text node.
+                    */
+                    xsltCopyTextString(ctxt, ctxt->insert, value, 0);
+                }
+                xmlFree(value);
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltCopyOf: result %s\n", res->stringval));
+                XSLT_TRACE(ctxt,XSLT_TRACE_COPY_OF,xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltCopyOf: result %s\n", res->stringval));
 #endif
+            }
         }
-    }
     } else {
-    ctxt->state = XSLT_STATE_STOPPED;
+        ctxt->state = XSLT_STATE_STOPPED;
     }
 
     if (res != NULL)
-    xmlXPathFreeObject(res);
+        xmlXPathFreeObject(res);
 }
 
 /**
@@ -4552,7 +4513,7 @@ xsltCopyOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltValueOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemValueOfPtr comp = (xsltStyleItemValueOfPtr) castedComp;
@@ -4563,18 +4524,18 @@ xsltValueOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
     xmlChar *value = NULL;
 
     if ((ctxt == NULL) || (node == NULL) || (inst == NULL))
-    return;
+        return;
 
     if ((comp == NULL) || (comp->select == NULL) || (comp->comp == NULL)) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltValueOf(): "
-        "The XSLT 'value-of' instruction was not compiled.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltValueOf(): "
+            "The XSLT 'value-of' instruction was not compiled.\n");
+        return;
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_VALUE_OF,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltValueOf: select %s\n", comp->select));
+         "xsltValueOf: select %s\n", comp->select));
 #endif
 
     res = xsltPreCompEval(ctxt, node, comp);
@@ -4583,36 +4544,36 @@ xsltValueOf(xsltTransformContextPtr ctxt, xmlNodePtr node,
     * Cast the XPath object to string.
     */
     if (res != NULL) {
-    value = xmlXPathCastToString(res);
-    if (value == NULL) {
+        value = xmlXPathCastToString(res);
+        if (value == NULL) {
+            xsltTransformError(ctxt, NULL, inst,
+                "Internal error in xsltValueOf(): "
+                "failed to cast an XPath object to string.\n");
+            ctxt->state = XSLT_STATE_STOPPED;
+            goto error;
+        }
+        if (value[0] != 0) {
+            xsltCopyTextString(ctxt, ctxt->insert, value, comp->noescape);
+        }
+    } else {
         xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltValueOf(): "
-        "failed to cast an XPath object to string.\n");
+            "XPath evaluation returned no result.\n");
         ctxt->state = XSLT_STATE_STOPPED;
         goto error;
-    }
-    if (value[0] != 0) {
-        xsltCopyTextString(ctxt, ctxt->insert, value, comp->noescape);
-    }
-    } else {
-    xsltTransformError(ctxt, NULL, inst,
-        "XPath evaluation returned no result.\n");
-    ctxt->state = XSLT_STATE_STOPPED;
-    goto error;
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (value) {
-    XSLT_TRACE(ctxt,XSLT_TRACE_VALUE_OF,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltValueOf: result '%s'\n", value));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VALUE_OF,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltValueOf: result '%s'\n", value));
     }
 #endif
 
 error:
     if (value != NULL)
-    xmlFree(value);
+        xmlFree(value);
     if (res != NULL)
-    xmlXPathFreeObject(res);
+        xmlXPathFreeObject(res);
 }
 
 /**
@@ -4626,7 +4587,7 @@ error:
  */
 void
 xsltNumber(xsltTransformContextPtr ctxt, xmlNodePtr node,
-       xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+           xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemNumberPtr comp = (xsltStyleItemNumberPtr) castedComp;
@@ -4638,13 +4599,13 @@ xsltNumber(xsltTransformContextPtr ctxt, xmlNodePtr node,
     int oldXPNsNr;
 
     if (comp == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:number : compilation failed\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:number : compilation failed\n");
+        return;
     }
 
     if ((ctxt == NULL) || (node == NULL) || (inst == NULL) || (comp == NULL))
-    return;
+        return;
 
     comp->numdata.doc = inst->doc;
     comp->numdata.node = inst;
@@ -4683,19 +4644,19 @@ xsltNumber(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltApplyImports(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
-             xmlNodePtr inst,
-         xsltElemPreCompPtr comp ATTRIBUTE_UNUSED)
+                 xmlNodePtr inst,
+                 xsltElemPreCompPtr comp ATTRIBUTE_UNUSED)
 {
     xsltTemplatePtr templ;
 
     if ((ctxt == NULL) || (inst == NULL))
-    return;
+        return;
 
     if (comp == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltApplyImports(): "
-        "The XSLT 'apply-imports' instruction was not compiled.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltApplyImports(): "
+            "The XSLT 'apply-imports' instruction was not compiled.\n");
+        return;
     }
     /*
     * NOTE that ctxt->currentTemplateRule and ctxt->templ is not the
@@ -4704,36 +4665,36 @@ xsltApplyImports(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     * currently processed.
     */
     if (ctxt->currentTemplateRule == NULL) {
-    /*
-    * SPEC XSLT 2.0:
-    * "[ERR XTDE0560] It is a non-recoverable dynamic error if
-    *  xsl:apply-imports or xsl:next-match is evaluated when the
-    *  current template rule is null."
-    */
-    xsltTransformError(ctxt, NULL, inst,
-         "It is an error to call 'apply-imports' "
-         "when there's no current template rule.\n");
-    return;
+        /*
+        * SPEC XSLT 2.0:
+        * "[ERR XTDE0560] It is a non-recoverable dynamic error if
+        *  xsl:apply-imports or xsl:next-match is evaluated when the
+        *  current template rule is null."
+        */
+        xsltTransformError(ctxt, NULL, inst,
+             "It is an error to call 'apply-imports' "
+             "when there's no current template rule.\n");
+        return;
     }
     /*
     * TODO: Check if this is correct.
     */
     templ = xsltGetTemplate(ctxt, contextNode,
-    ctxt->currentTemplateRule->style);
+        ctxt->currentTemplateRule->style);
 
     if (templ != NULL) {
-    xsltTemplatePtr oldCurTemplRule = ctxt->currentTemplateRule;
-    /*
-    * Set the current template rule.
-    */
-    ctxt->currentTemplateRule = templ;
-    /*
-    * URGENT TODO: Need xsl:with-param be handled somehow here?
-    */
-    xsltApplyXSLTTemplate(ctxt, contextNode, templ->content,
-        templ, NULL);
+        xsltTemplatePtr oldCurTemplRule = ctxt->currentTemplateRule;
+        /*
+        * Set the current template rule.
+        */
+        ctxt->currentTemplateRule = templ;
+        /*
+        * URGENT TODO: Need xsl:with-param be handled somehow here?
+        */
+        xsltApplyXSLTTemplate(ctxt, contextNode, templ->content,
+            templ, NULL);
 
-    ctxt->currentTemplateRule = oldCurTemplRule;
+        ctxt->currentTemplateRule = oldCurTemplRule;
     }
     else {
         /* Use built-in templates. */
@@ -4752,95 +4713,95 @@ xsltApplyImports(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
  */
 void
 xsltCallTemplate(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemCallTemplatePtr comp =
-    (xsltStyleItemCallTemplatePtr) castedComp;
+        (xsltStyleItemCallTemplatePtr) castedComp;
 #else
     xsltStylePreCompPtr comp = (xsltStylePreCompPtr) castedComp;
 #endif
     xsltStackElemPtr withParams = NULL;
 
     if (ctxt->insert == NULL)
-    return;
+        return;
     if (comp == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-         "The XSLT 'call-template' instruction was not compiled.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "The XSLT 'call-template' instruction was not compiled.\n");
+        return;
     }
 
     /*
      * The template must have been precomputed
      */
     if (comp->templ == NULL) {
-    comp->templ = xsltFindTemplate(ctxt, comp->name, comp->ns);
-    if (comp->templ == NULL) {
-        if (comp->ns != NULL) {
-            xsltTransformError(ctxt, NULL, inst,
-            "The called template '{%s}%s' was not found.\n",
-            comp->ns, comp->name);
-        } else {
-            xsltTransformError(ctxt, NULL, inst,
-            "The called template '%s' was not found.\n",
-            comp->name);
+        comp->templ = xsltFindTemplate(ctxt, comp->name, comp->ns);
+        if (comp->templ == NULL) {
+            if (comp->ns != NULL) {
+                xsltTransformError(ctxt, NULL, inst,
+                        "The called template '{%s}%s' was not found.\n",
+                        comp->ns, comp->name);
+            } else {
+                xsltTransformError(ctxt, NULL, inst,
+                        "The called template '%s' was not found.\n",
+                        comp->name);
+            }
+            return;
         }
-        return;
-    }
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if ((comp != NULL) && (comp->name != NULL))
-    XSLT_TRACE(ctxt,XSLT_TRACE_CALL_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-             "call-template: name %s\n", comp->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_CALL_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
+                         "call-template: name %s\n", comp->name));
 #endif
 
     if (inst->children) {
-    xmlNodePtr cur;
-    xsltStackElemPtr param;
+        xmlNodePtr cur;
+        xsltStackElemPtr param;
 
-    cur = inst->children;
-    while (cur != NULL) {
+        cur = inst->children;
+        while (cur != NULL) {
 #ifdef WITH_DEBUGGER
-        if (ctxt->debugStatus != XSLT_DEBUG_NONE)
-        xslHandleDebugger(cur, node, comp->templ, ctxt);
+            if (ctxt->debugStatus != XSLT_DEBUG_NONE)
+                xslHandleDebugger(cur, node, comp->templ, ctxt);
 #endif
-        if (ctxt->state == XSLT_STATE_STOPPED) break;
-        /*
-        * TODO: The "with-param"s could be part of the "call-template"
-        *   structure. Avoid to "search" for params dynamically
-        *   in the XML tree every time.
-        */
-        if (IS_XSLT_ELEM(cur)) {
-        if (IS_XSLT_NAME(cur, "with-param")) {
-            param = xsltParseStylesheetCallerParam(ctxt, cur);
-            if (param != NULL) {
-            param->next = withParams;
-            withParams = param;
+            if (ctxt->state == XSLT_STATE_STOPPED) break;
+            /*
+            * TODO: The "with-param"s could be part of the "call-template"
+            *   structure. Avoid to "search" for params dynamically
+            *   in the XML tree every time.
+            */
+            if (IS_XSLT_ELEM(cur)) {
+                if (IS_XSLT_NAME(cur, "with-param")) {
+                    param = xsltParseStylesheetCallerParam(ctxt, cur);
+                    if (param != NULL) {
+                        param->next = withParams;
+                        withParams = param;
+                    }
+                } else {
+                    xsltGenericError(xsltGenericErrorContext,
+                        "xsl:call-template: misplaced xsl:%s\n", cur->name);
+                }
+            } else {
+                xsltGenericError(xsltGenericErrorContext,
+                    "xsl:call-template: misplaced %s element\n", cur->name);
             }
-        } else {
-            xsltGenericError(xsltGenericErrorContext,
-            "xsl:call-template: misplaced xsl:%s\n", cur->name);
+            cur = cur->next;
         }
-        } else {
-        xsltGenericError(xsltGenericErrorContext,
-            "xsl:call-template: misplaced %s element\n", cur->name);
-        }
-        cur = cur->next;
-    }
     }
     /*
      * Create a new frame using the params first
      */
     xsltApplyXSLTTemplate(ctxt, node, comp->templ->content, comp->templ,
-    withParams);
+        withParams);
     if (withParams != NULL)
-    xsltFreeStackElemList(withParams);
+        xsltFreeStackElemList(withParams);
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if ((comp != NULL) && (comp->name != NULL))
-    XSLT_TRACE(ctxt,XSLT_TRACE_CALL_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
-             "call-template returned: name %s\n", comp->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_CALL_TEMPLATE,xsltGenericDebug(xsltGenericDebugContext,
+                         "call-template returned: name %s\n", comp->name));
 #endif
 }
 
@@ -4855,16 +4816,16 @@ xsltCallTemplate(xsltTransformContextPtr ctxt, xmlNodePtr node,
  */
 void
 xsltApplyTemplates(xsltTransformContextPtr ctxt, xmlNodePtr node,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemApplyTemplatesPtr comp =
-    (xsltStyleItemApplyTemplatesPtr) castedComp;
+        (xsltStyleItemApplyTemplatesPtr) castedComp;
 #else
     xsltStylePreCompPtr comp = (xsltStylePreCompPtr) castedComp;
 #endif
     int i;
-    xmlNodePtr cur, delNode = NULL, oldContextNode;
+    xmlNodePtr cur, oldContextNode;
     xmlNodeSetPtr list = NULL, oldList;
     xsltStackElemPtr withParams = NULL;
     int oldXPProximityPosition, oldXPContextSize;
@@ -4874,17 +4835,17 @@ xsltApplyTemplates(xsltTransformContextPtr ctxt, xmlNodePtr node,
     xmlXPathContextPtr xpctxt;
 
     if (comp == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:apply-templates : compilation failed\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:apply-templates : compilation failed\n");
+        return;
     }
     if ((ctxt == NULL) || (node == NULL) || (inst == NULL) || (comp == NULL))
-    return;
+        return;
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if ((node != NULL) && (node->name != NULL))
-    XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltApplyTemplates: node: '%s'\n", node->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
+             "xsltApplyTemplates: node: '%s'\n", node->name));
 #endif
 
     xpctxt = ctxt->xpathCtxt;
@@ -4913,169 +4874,105 @@ xsltApplyTemplates(xsltTransformContextPtr ctxt, xmlNodePtr node,
     ctxt->modeURI = comp->modeURI;
 
     if (comp->select != NULL) {
-    xmlXPathObjectPtr res = NULL;
+        xmlXPathObjectPtr res = NULL;
 
-    if (comp->comp == NULL) {
-        xsltTransformError(ctxt, NULL, inst,
-         "xsl:apply-templates : compilation failed\n");
-        goto error;
-    }
-#ifdef WITH_XSLT_DEBUG_PROCESS
-    XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltApplyTemplates: select %s\n", comp->select));
-#endif
-
-    res = xsltPreCompEval(ctxt, node, comp);
-
-    if (res != NULL) {
-        if (res->type == XPATH_NODESET) {
-        list = res->nodesetval; /* consume the node set */
-        res->nodesetval = NULL;
-        } else {
-        xsltTransformError(ctxt, NULL, inst,
-            "The 'select' expression did not evaluate to a "
-            "node set.\n");
-        ctxt->state = XSLT_STATE_STOPPED;
-        xmlXPathFreeObject(res);
-        goto error;
+        if (comp->comp == NULL) {
+            xsltTransformError(ctxt, NULL, inst,
+                 "xsl:apply-templates : compilation failed\n");
+            goto error;
         }
-        xmlXPathFreeObject(res);
-        /*
-        * Note: An xsl:apply-templates with a 'select' attribute,
-        * can change the current source doc.
-        */
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-        "Failed to evaluate the 'select' expression.\n");
-        ctxt->state = XSLT_STATE_STOPPED;
-        goto error;
-    }
-    if (list == NULL) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
         XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltApplyTemplates: select didn't evaluate to a node list\n"));
+             "xsltApplyTemplates: select %s\n", comp->select));
 #endif
-        goto exit;
-    }
-    /*
-    *
-    * NOTE: Previously a document info (xsltDocument) was
-    * created and attached to the Result Tree Fragment.
-    * But such a document info is created on demand in
-    * xsltKeyFunction() (functions.c), so we need to create
-    * it here beforehand.
-    * In order to take care of potential keys we need to
-    * do some extra work for the case when a Result Tree Fragment
-    * is converted into a nodeset (e.g. exslt:node-set()) :
-    * We attach a "pseudo-doc" (xsltDocument) to _private.
-    * This xsltDocument, together with the keyset, will be freed
-    * when the Result Tree Fragment is freed.
-    *
-    */
-#if 0
-    if ((ctxt->nbKeys > 0) &&
-        (list->nodeNr != 0) &&
-        (list->nodeTab[0]->doc != NULL) &&
-        XSLT_IS_RES_TREE_FRAG(list->nodeTab[0]->doc))
-    {
-        /*
-        * NOTE that it's also OK if @effectiveDocInfo will be
-        * set to NULL.
-        */
-        isRTF = 1;
-        effectiveDocInfo = list->nodeTab[0]->doc->_private;
-    }
-#endif
-    } else {
-    /*
-     * Build an XPath node set with the children
-     */
-    list = xmlXPathNodeSetCreate(NULL);
-    if (list == NULL)
-        goto error;
-    if (node->type != XML_NAMESPACE_DECL)
-        cur = node->children;
-    else
-        cur = NULL;
-    while (cur != NULL) {
-        switch (cur->type) {
-        case XML_TEXT_NODE:
-            if ((IS_BLANK_NODE(cur)) &&
-            (cur->parent != NULL) &&
-            (cur->parent->type == XML_ELEMENT_NODE) &&
-            (ctxt->style->stripSpaces != NULL)) {
-            const xmlChar *val;
 
-            if (cur->parent->ns != NULL) {
-                val = (const xmlChar *)
-                  xmlHashLookup2(ctxt->style->stripSpaces,
-                         cur->parent->name,
-                         cur->parent->ns->href);
-                if (val == NULL) {
-                val = (const xmlChar *)
-                  xmlHashLookup2(ctxt->style->stripSpaces,
-                         BAD_CAST "*",
-                         cur->parent->ns->href);
-                }
+        res = xsltPreCompEval(ctxt, node, comp);
+
+        if (res != NULL) {
+            if (res->type == XPATH_NODESET) {
+                list = res->nodesetval; /* consume the node set */
+                res->nodesetval = NULL;
             } else {
-                val = (const xmlChar *)
-                  xmlHashLookup2(ctxt->style->stripSpaces,
-                         cur->parent->name, NULL);
+                xsltTransformError(ctxt, NULL, inst,
+                    "The 'select' expression did not evaluate to a "
+                    "node set.\n");
+                ctxt->state = XSLT_STATE_STOPPED;
+                xmlXPathFreeObject(res);
+                goto error;
             }
-            if ((val != NULL) &&
-                (xmlStrEqual(val, (xmlChar *) "strip"))) {
-                delNode = cur;
-                break;
-            }
-            }
-            /* Intentional fall-through */
-        case XML_ELEMENT_NODE:
-        case XML_DOCUMENT_NODE:
-        case XML_HTML_DOCUMENT_NODE:
-        case XML_CDATA_SECTION_NODE:
-        case XML_PI_NODE:
-        case XML_COMMENT_NODE:
-            xmlXPathNodeSetAddUnique(list, cur);
-            break;
-        case XML_DTD_NODE:
-            /* Unlink the DTD, it's still reachable
-             * using doc->intSubset */
-            if (cur->next != NULL)
-            cur->next->prev = cur->prev;
-            if (cur->prev != NULL)
-            cur->prev->next = cur->next;
-            break;
-        case XML_NAMESPACE_DECL:
-            break;
-        default:
+            xmlXPathFreeObject(res);
+            /*
+            * Note: An xsl:apply-templates with a 'select' attribute,
+            * can change the current source doc.
+            */
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                "Failed to evaluate the 'select' expression.\n");
+            ctxt->state = XSLT_STATE_STOPPED;
+            goto error;
+        }
+        if (list == NULL) {
 #ifdef WITH_XSLT_DEBUG_PROCESS
             XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltApplyTemplates: skipping cur type %d\n",
-                     cur->type));
+                "xsltApplyTemplates: select didn't evaluate to a node list\n"));
 #endif
-            delNode = cur;
+            goto exit;
         }
-        cur = cur->next;
-        if (delNode != NULL) {
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-             "xsltApplyTemplates: removing ignorable blank cur\n"));
+        /*
+        *
+        * NOTE: Previously a document info (xsltDocument) was
+        * created and attached to the Result Tree Fragment.
+        * But such a document info is created on demand in
+        * xsltKeyFunction() (functions.c), so we need to create
+        * it here beforehand.
+        * In order to take care of potential keys we need to
+        * do some extra work for the case when a Result Tree Fragment
+        * is converted into a nodeset (e.g. exslt:node-set()) :
+        * We attach a "pseudo-doc" (xsltDocument) to _private.
+        * This xsltDocument, together with the keyset, will be freed
+        * when the Result Tree Fragment is freed.
+        *
+        */
+#if 0
+        if ((ctxt->nbKeys > 0) &&
+            (list->nodeNr != 0) &&
+            (list->nodeTab[0]->doc != NULL) &&
+            XSLT_IS_RES_TREE_FRAG(list->nodeTab[0]->doc))
+        {
+            /*
+            * NOTE that it's also OK if @effectiveDocInfo will be
+            * set to NULL.
+            */
+            isRTF = 1;
+            effectiveDocInfo = list->nodeTab[0]->doc->_private;
+        }
 #endif
-        xmlUnlinkNode(delNode);
-        xmlFreeNode(delNode);
-        delNode = NULL;
+    } else {
+        /*
+         * Build an XPath node set with the children
+         */
+        list = xmlXPathNodeSetCreate(NULL);
+        if (list == NULL)
+            goto error;
+        if (node->type != XML_NAMESPACE_DECL)
+            cur = node->children;
+        else
+            cur = NULL;
+        while (cur != NULL) {
+            if (IS_XSLT_REAL_NODE(cur))
+                xmlXPathNodeSetAddUnique(list, cur);
+            cur = cur->next;
         }
-    }
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     if (list != NULL)
     XSLT_TRACE(ctxt,XSLT_TRACE_APPLY_TEMPLATES,xsltGenericDebug(xsltGenericDebugContext,
-    "xsltApplyTemplates: list of %d nodes\n", list->nodeNr));
+        "xsltApplyTemplates: list of %d nodes\n", list->nodeNr));
 #endif
 
     if ((list == NULL) || (list->nodeNr == 0))
-    goto exit;
+        goto exit;
 
     /*
     * Set the context's node set and size; this is also needed for
@@ -5090,111 +4987,112 @@ xsltApplyTemplates(xsltTransformContextPtr ctxt, xmlNodePtr node,
     * xsl:sort or xsl:with-param elements; XPath expression might fail.
     */
     if (inst->children) {
-    xsltStackElemPtr param;
+        xsltStackElemPtr param;
 
-    cur = inst->children;
-    while (cur) {
-
-#ifdef WITH_DEBUGGER
-        if (ctxt->debugStatus != XSLT_DEBUG_NONE)
-        xslHandleDebugger(cur, node, NULL, ctxt);
-#endif
-        if (ctxt->state == XSLT_STATE_STOPPED)
-        break;
-        if (cur->type == XML_TEXT_NODE) {
-        cur = cur->next;
-        continue;
-        }
-        if (! IS_XSLT_ELEM(cur))
-        break;
-        if (IS_XSLT_NAME(cur, "with-param")) {
-        param = xsltParseStylesheetCallerParam(ctxt, cur);
-        if (param != NULL) {
-            param->next = withParams;
-            withParams = param;
-        }
-        }
-        if (IS_XSLT_NAME(cur, "sort")) {
-        xsltTemplatePtr oldCurTempRule =
-            ctxt->currentTemplateRule;
-        int nbsorts = 0;
-        xmlNodePtr sorts[XSLT_MAX_SORT];
-
-        sorts[nbsorts++] = cur;
-
+        cur = inst->children;
         while (cur) {
 
 #ifdef WITH_DEBUGGER
             if (ctxt->debugStatus != XSLT_DEBUG_NONE)
-            xslHandleDebugger(cur, node, NULL, ctxt);
+                xslHandleDebugger(cur, node, NULL, ctxt);
 #endif
             if (ctxt->state == XSLT_STATE_STOPPED)
-            break;
-
+                break;
             if (cur->type == XML_TEXT_NODE) {
-            cur = cur->next;
-            continue;
+                cur = cur->next;
+                continue;
             }
-
             if (! IS_XSLT_ELEM(cur))
-            break;
+                break;
             if (IS_XSLT_NAME(cur, "with-param")) {
-            param = xsltParseStylesheetCallerParam(ctxt, cur);
-            if (param != NULL) {
-                param->next = withParams;
-                withParams = param;
-            }
+                param = xsltParseStylesheetCallerParam(ctxt, cur);
+                if (param != NULL) {
+                    param->next = withParams;
+                    withParams = param;
+                }
             }
             if (IS_XSLT_NAME(cur, "sort")) {
-            if (nbsorts >= XSLT_MAX_SORT) {
-                xsltTransformError(ctxt, NULL, cur,
-                "The number (%d) of xsl:sort instructions exceeds the "
-                "maximum allowed by this processor's settings.\n",
-                nbsorts);
-                ctxt->state = XSLT_STATE_STOPPED;
-                break;
-            } else {
+                xsltTemplatePtr oldCurTempRule =
+                    ctxt->currentTemplateRule;
+                int nbsorts = 0;
+                xmlNodePtr sorts[XSLT_MAX_SORT];
+
                 sorts[nbsorts++] = cur;
-            }
+                cur = cur->next;
+
+                while (cur) {
+
+#ifdef WITH_DEBUGGER
+                    if (ctxt->debugStatus != XSLT_DEBUG_NONE)
+                        xslHandleDebugger(cur, node, NULL, ctxt);
+#endif
+                    if (ctxt->state == XSLT_STATE_STOPPED)
+                        break;
+
+                    if (cur->type == XML_TEXT_NODE) {
+                        cur = cur->next;
+                        continue;
+                    }
+
+                    if (! IS_XSLT_ELEM(cur))
+                        break;
+                    if (IS_XSLT_NAME(cur, "with-param")) {
+                        param = xsltParseStylesheetCallerParam(ctxt, cur);
+                        if (param != NULL) {
+                            param->next = withParams;
+                            withParams = param;
+                        }
+                    }
+                    if (IS_XSLT_NAME(cur, "sort")) {
+                        if (nbsorts >= XSLT_MAX_SORT) {
+                            xsltTransformError(ctxt, NULL, cur,
+                                "The number (%d) of xsl:sort instructions exceeds the "
+                                "maximum allowed by this processor's settings.\n",
+                                nbsorts);
+                            ctxt->state = XSLT_STATE_STOPPED;
+                            break;
+                        } else {
+                            sorts[nbsorts++] = cur;
+                        }
+                    }
+                    cur = cur->next;
+                }
+                /*
+                * The "current template rule" is cleared for xsl:sort.
+                */
+                ctxt->currentTemplateRule = NULL;
+                /*
+                * Sort.
+                */
+                xsltDoSortFunction(ctxt, sorts, nbsorts);
+                ctxt->currentTemplateRule = oldCurTempRule;
+                break;
             }
             cur = cur->next;
         }
-        /*
-        * The "current template rule" is cleared for xsl:sort.
-        */
-        ctxt->currentTemplateRule = NULL;
-        /*
-        * Sort.
-        */
-        xsltDoSortFunction(ctxt, sorts, nbsorts);
-        ctxt->currentTemplateRule = oldCurTempRule;
-        break;
-        }
-        cur = cur->next;
-    }
     }
     xpctxt->contextSize = list->nodeNr;
     /*
     * Apply templates for all selected source nodes.
     */
     for (i = 0; i < list->nodeNr; i++) {
-    cur = list->nodeTab[i];
-    /*
-    * The node becomes the "current node".
-    */
-    ctxt->node = cur;
-    /*
-    * An xsl:apply-templates can change the current context doc.
-    * OPTIMIZE TODO: Get rid of the need to set the context doc.
-    */
-    if ((cur->type != XML_NAMESPACE_DECL) && (cur->doc != NULL))
-        xpctxt->doc = cur->doc;
+        cur = list->nodeTab[i];
+        /*
+        * The node becomes the "current node".
+        */
+        ctxt->node = cur;
+        /*
+        * An xsl:apply-templates can change the current context doc.
+        * OPTIMIZE TODO: Get rid of the need to set the context doc.
+        */
+        if ((cur->type != XML_NAMESPACE_DECL) && (cur->doc != NULL))
+            xpctxt->doc = cur->doc;
 
-    xpctxt->proximityPosition = i + 1;
-    /*
-    * Find and apply a template for this node.
-    */
-    xsltProcessOneNode(ctxt, cur, withParams);
+        xpctxt->proximityPosition = i + 1;
+        /*
+        * Find and apply a template for this node.
+        */
+        xsltProcessOneNode(ctxt, cur, withParams);
     }
 
 exit:
@@ -5203,9 +5101,9 @@ error:
     * Free the parameter list.
     */
     if (withParams != NULL)
-    xsltFreeStackElemList(withParams);
+        xsltFreeStackElemList(withParams);
     if (list != NULL)
-    xmlXPathFreeNodeSet(list);
+        xmlXPathFreeNodeSet(list);
     /*
     * Restore context states.
     */
@@ -5232,12 +5130,12 @@ error:
  */
 void
 xsltChoose(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
-       xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED)
+           xmlNodePtr inst, xsltElemPreCompPtr comp ATTRIBUTE_UNUSED)
 {
     xmlNodePtr cur;
 
     if ((ctxt == NULL) || (contextNode == NULL) || (inst == NULL))
-    return;
+        return;
 
     /*
     * TODO: Content model checks should be done only at compilation
@@ -5245,9 +5143,9 @@ xsltChoose(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     */
     cur = inst->children;
     if (cur == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-        "xsl:choose: The instruction has no content.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "xsl:choose: The instruction has no content.\n");
+        return;
     }
 
 #ifdef XSLT_REFACTORED
@@ -5256,115 +5154,115 @@ xsltChoose(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     */
 #else
     if ((! IS_XSLT_ELEM(cur)) || (! IS_XSLT_NAME(cur, "when"))) {
-    xsltTransformError(ctxt, NULL, inst,
-         "xsl:choose: xsl:when expected first\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+             "xsl:choose: xsl:when expected first\n");
+        return;
     }
 #endif
 
     {
-    int testRes = 0, res = 0;
+        int testRes = 0, res = 0;
 
 #ifdef XSLT_REFACTORED
-    xsltStyleItemWhenPtr wcomp = NULL;
+        xsltStyleItemWhenPtr wcomp = NULL;
 #else
-    xsltStylePreCompPtr wcomp = NULL;
+        xsltStylePreCompPtr wcomp = NULL;
 #endif
 
-    /*
-    * Process xsl:when ---------------------------------------------------
-    */
-    while (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "when")) {
-        wcomp = cur->psvi;
+        /*
+        * Process xsl:when ---------------------------------------------------
+        */
+        while (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "when")) {
+            wcomp = cur->psvi;
 
-        if ((wcomp == NULL) || (wcomp->test == NULL) ||
-        (wcomp->comp == NULL))
-        {
-        xsltTransformError(ctxt, NULL, cur,
-            "Internal error in xsltChoose(): "
-            "The XSLT 'when' instruction was not compiled.\n");
-        goto error;
-        }
+            if ((wcomp == NULL) || (wcomp->test == NULL) ||
+                (wcomp->comp == NULL))
+            {
+                xsltTransformError(ctxt, NULL, cur,
+                    "Internal error in xsltChoose(): "
+                    "The XSLT 'when' instruction was not compiled.\n");
+                goto error;
+            }
 
 
 #ifdef WITH_DEBUGGER
-        if (xslDebugStatus != XSLT_DEBUG_NONE) {
-        /*
-        * TODO: Isn't comp->templ always NULL for xsl:choose?
-        */
-        xslHandleDebugger(cur, contextNode, NULL, ctxt);
-        }
+            if (xslDebugStatus != XSLT_DEBUG_NONE) {
+                /*
+                * TODO: Isn't comp->templ always NULL for xsl:choose?
+                */
+                xslHandleDebugger(cur, contextNode, NULL, ctxt);
+            }
 #endif
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltChoose: test %s\n", wcomp->test));
+            XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
+                "xsltChoose: test %s\n", wcomp->test));
 #endif
 
 #ifdef XSLT_FAST_IF
-        res = xsltPreCompEvalToBoolean(ctxt, contextNode, wcomp);
+            res = xsltPreCompEvalToBoolean(ctxt, contextNode, wcomp);
 
-        if (res == -1) {
-        ctxt->state = XSLT_STATE_STOPPED;
-        goto error;
-        }
-        testRes = (res == 1) ? 1 : 0;
+            if (res == -1) {
+                ctxt->state = XSLT_STATE_STOPPED;
+                goto error;
+            }
+            testRes = (res == 1) ? 1 : 0;
 
 #else /* XSLT_FAST_IF */
 
-        res = xsltPreCompEval(ctxt, cotextNode, wcomp);
+            res = xsltPreCompEval(ctxt, cotextNode, wcomp);
 
-        if (res != NULL) {
-        if (res->type != XPATH_BOOLEAN)
-            res = xmlXPathConvertBoolean(res);
-        if (res->type == XPATH_BOOLEAN)
-            testRes = res->boolval;
-        else {
+            if (res != NULL) {
+                if (res->type != XPATH_BOOLEAN)
+                    res = xmlXPathConvertBoolean(res);
+                if (res->type == XPATH_BOOLEAN)
+                    testRes = res->boolval;
+                else {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltChoose: test didn't evaluate to a boolean\n"));
+                    XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltChoose: test didn't evaluate to a boolean\n"));
 #endif
-            goto error;
-        }
-        xmlXPathFreeObject(res);
-        res = NULL;
-        } else {
-        ctxt->state = XSLT_STATE_STOPPED;
-        goto error;
-        }
+                    goto error;
+                }
+                xmlXPathFreeObject(res);
+                res = NULL;
+            } else {
+                ctxt->state = XSLT_STATE_STOPPED;
+                goto error;
+            }
 
 #endif /* else of XSLT_FAST_IF */
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltChoose: test evaluate to %d\n", testRes));
+            XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
+                "xsltChoose: test evaluate to %d\n", testRes));
 #endif
-        if (testRes)
-        goto test_is_true;
+            if (testRes)
+                goto test_is_true;
 
-        cur = cur->next;
-    }
+            cur = cur->next;
+        }
 
-    /*
-    * Process xsl:otherwise ----------------------------------------------
-    */
-    if (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "otherwise")) {
+        /*
+        * Process xsl:otherwise ----------------------------------------------
+        */
+        if (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "otherwise")) {
 
 #ifdef WITH_DEBUGGER
-        if (xslDebugStatus != XSLT_DEBUG_NONE)
-        xslHandleDebugger(cur, contextNode, NULL, ctxt);
+            if (xslDebugStatus != XSLT_DEBUG_NONE)
+                xslHandleDebugger(cur, contextNode, NULL, ctxt);
 #endif
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
-        "evaluating xsl:otherwise\n"));
+            XSLT_TRACE(ctxt,XSLT_TRACE_CHOOSE,xsltGenericDebug(xsltGenericDebugContext,
+                "evaluating xsl:otherwise\n"));
 #endif
-        goto test_is_true;
-    }
-    goto exit;
+            goto test_is_true;
+        }
+        goto exit;
 
 test_is_true:
 
-    goto process_sequence;
+        goto process_sequence;
     }
 
 process_sequence:
@@ -5373,7 +5271,7 @@ process_sequence:
     * Instantiate the sequence constructor.
     */
     xsltApplySequenceConstructor(ctxt, ctxt->node, cur->children,
-    NULL);
+        NULL);
 
 exit:
 error:
@@ -5391,7 +5289,7 @@ error:
  */
 void
 xsltIf(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
-               xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+                   xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
     int res = 0;
 
@@ -5402,83 +5300,83 @@ xsltIf(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
 #endif
 
     if ((ctxt == NULL) || (contextNode == NULL) || (inst == NULL))
-    return;
+        return;
     if ((comp == NULL) || (comp->test == NULL) || (comp->comp == NULL)) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltIf(): "
-        "The XSLT 'if' instruction was not compiled.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltIf(): "
+            "The XSLT 'if' instruction was not compiled.\n");
+        return;
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_IF,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltIf: test %s\n", comp->test));
+         "xsltIf: test %s\n", comp->test));
 #endif
 
 #ifdef XSLT_FAST_IF
     {
-    xmlDocPtr oldLocalFragmentTop = ctxt->localRVT;
+        xmlDocPtr oldLocalFragmentTop = ctxt->localRVT;
 
-    res = xsltPreCompEvalToBoolean(ctxt, contextNode, comp);
+        res = xsltPreCompEvalToBoolean(ctxt, contextNode, comp);
 
-    /*
-    * Cleanup fragments created during evaluation of the
-    * "select" expression.
-    */
-    if (oldLocalFragmentTop != ctxt->localRVT)
-        xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+        /*
+        * Cleanup fragments created during evaluation of the
+        * "select" expression.
+        */
+        if (oldLocalFragmentTop != ctxt->localRVT)
+            xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
     }
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_IF,xsltGenericDebug(xsltGenericDebugContext,
-    "xsltIf: test evaluate to %d\n", res));
+        "xsltIf: test evaluate to %d\n", res));
 #endif
 
     if (res == -1) {
-    ctxt->state = XSLT_STATE_STOPPED;
-    goto error;
+        ctxt->state = XSLT_STATE_STOPPED;
+        goto error;
     }
     if (res == 1) {
-    /*
-    * Instantiate the sequence constructor of xsl:if.
-    */
-    xsltApplySequenceConstructor(ctxt,
-        contextNode, inst->children, NULL);
+        /*
+        * Instantiate the sequence constructor of xsl:if.
+        */
+        xsltApplySequenceConstructor(ctxt,
+            contextNode, inst->children, NULL);
     }
 
 #else /* XSLT_FAST_IF */
     {
-    /*
-    * OLD CODE:
-    */
-    xmlXPathObjectPtr xpobj = xsltPreCompEval(ctxt, contextNode, comp);
-    if (xpobj != NULL) {
-        if (xpobj->type != XPATH_BOOLEAN)
-        xpobj = xmlXPathConvertBoolean(xpobj);
-        if (xpobj->type == XPATH_BOOLEAN) {
-        res = xpobj->boolval;
+        /*
+        * OLD CODE:
+        */
+        xmlXPathObjectPtr xpobj = xsltPreCompEval(ctxt, contextNode, comp);
+        if (xpobj != NULL) {
+            if (xpobj->type != XPATH_BOOLEAN)
+                xpobj = xmlXPathConvertBoolean(xpobj);
+            if (xpobj->type == XPATH_BOOLEAN) {
+                res = xpobj->boolval;
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_IF,xsltGenericDebug(xsltGenericDebugContext,
-            "xsltIf: test evaluate to %d\n", res));
+                XSLT_TRACE(ctxt,XSLT_TRACE_IF,xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltIf: test evaluate to %d\n", res));
 #endif
-        if (res) {
-            xsltApplySequenceConstructor(ctxt,
-            contextNode, inst->children, NULL);
-        }
+                if (res) {
+                    xsltApplySequenceConstructor(ctxt,
+                        contextNode, inst->children, NULL);
+                }
+            } else {
+
+#ifdef WITH_XSLT_DEBUG_PROCESS
+                XSLT_TRACE(ctxt, XSLT_TRACE_IF,
+                    xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltIf: test didn't evaluate to a boolean\n"));
+#endif
+                ctxt->state = XSLT_STATE_STOPPED;
+            }
+            xmlXPathFreeObject(xpobj);
         } else {
-
-#ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt, XSLT_TRACE_IF,
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltIf: test didn't evaluate to a boolean\n"));
-#endif
-        ctxt->state = XSLT_STATE_STOPPED;
+            ctxt->state = XSLT_STATE_STOPPED;
         }
-        xmlXPathFreeObject(xpobj);
-    } else {
-        ctxt->state = XSLT_STATE_STOPPED;
-    }
     }
 #endif /* else of XSLT_FAST_IF */
 
@@ -5497,7 +5395,7 @@ error:
  */
 void
 xsltForEach(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
-        xmlNodePtr inst, xsltElemPreCompPtr castedComp)
+            xmlNodePtr inst, xsltElemPreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemForEachPtr comp = (xsltStyleItemForEachPtr) castedComp;
@@ -5517,29 +5415,29 @@ xsltForEach(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     xmlXPathContextPtr xpctxt;
 
     if ((ctxt == NULL) || (contextNode == NULL) || (inst == NULL)) {
-    xsltGenericError(xsltGenericErrorContext,
-        "xsltForEach(): Bad arguments.\n");
-    return;
+        xsltGenericError(xsltGenericErrorContext,
+            "xsltForEach(): Bad arguments.\n");
+        return;
     }
 
     if (comp == NULL) {
         xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltForEach(): "
-        "The XSLT 'for-each' instruction was not compiled.\n");
+            "Internal error in xsltForEach(): "
+            "The XSLT 'for-each' instruction was not compiled.\n");
         return;
     }
     if ((comp->select == NULL) || (comp->comp == NULL)) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltForEach(): "
-        "The selecting expression of the XSLT 'for-each' "
-        "instruction was not compiled correctly.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltForEach(): "
+            "The selecting expression of the XSLT 'for-each' "
+            "instruction was not compiled correctly.\n");
+        return;
     }
     xpctxt = ctxt->xpathCtxt;
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_FOR_EACH,xsltGenericDebug(xsltGenericDebugContext,
-     "xsltForEach: select %s\n", comp->select));
+         "xsltForEach: select %s\n", comp->select));
 #endif
 
     /*
@@ -5565,31 +5463,31 @@ xsltForEach(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     res = xsltPreCompEval(ctxt, contextNode, comp);
 
     if (res != NULL) {
-    if (res->type == XPATH_NODESET)
-        list = res->nodesetval;
-    else {
-        xsltTransformError(ctxt, NULL, inst,
-        "The 'select' expression does not evaluate to a node set.\n");
+        if (res->type == XPATH_NODESET)
+            list = res->nodesetval;
+        else {
+            xsltTransformError(ctxt, NULL, inst,
+                "The 'select' expression does not evaluate to a node set.\n");
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
-        XSLT_TRACE(ctxt,XSLT_TRACE_FOR_EACH,xsltGenericDebug(xsltGenericDebugContext,
-        "xsltForEach: select didn't evaluate to a node list\n"));
+            XSLT_TRACE(ctxt,XSLT_TRACE_FOR_EACH,xsltGenericDebug(xsltGenericDebugContext,
+                "xsltForEach: select didn't evaluate to a node list\n"));
 #endif
-        goto error;
-    }
+            goto error;
+        }
     } else {
-    xsltTransformError(ctxt, NULL, inst,
-        "Failed to evaluate the 'select' expression.\n");
-    ctxt->state = XSLT_STATE_STOPPED;
-    goto error;
+        xsltTransformError(ctxt, NULL, inst,
+            "Failed to evaluate the 'select' expression.\n");
+        ctxt->state = XSLT_STATE_STOPPED;
+        goto error;
     }
 
     if ((list == NULL) || (list->nodeNr <= 0))
-    goto exit;
+        goto exit;
 
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_FOR_EACH,xsltGenericDebug(xsltGenericDebugContext,
-    "xsltForEach: select evaluates to %d nodes\n", list->nodeNr));
+        "xsltForEach: select evaluates to %d nodes\n", list->nodeNr));
 #endif
 
     /*
@@ -5603,62 +5501,62 @@ xsltForEach(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
     */
     curInst = inst->children;
     if (IS_XSLT_ELEM(curInst) && IS_XSLT_NAME(curInst, "sort")) {
-    int nbsorts = 0;
-    xmlNodePtr sorts[XSLT_MAX_SORT];
+        int nbsorts = 0;
+        xmlNodePtr sorts[XSLT_MAX_SORT];
 
-    sorts[nbsorts++] = curInst;
-
-#ifdef WITH_DEBUGGER
-    if (xslDebugStatus != XSLT_DEBUG_NONE)
-        xslHandleDebugger(curInst, contextNode, NULL, ctxt);
-#endif
-
-    curInst = curInst->next;
-    while (IS_XSLT_ELEM(curInst) && IS_XSLT_NAME(curInst, "sort")) {
-        if (nbsorts >= XSLT_MAX_SORT) {
-        xsltTransformError(ctxt, NULL, curInst,
-            "The number of xsl:sort instructions exceeds the "
-            "maximum (%d) allowed by this processor.\n",
-            XSLT_MAX_SORT);
-        goto error;
-        } else {
         sorts[nbsorts++] = curInst;
-        }
 
 #ifdef WITH_DEBUGGER
         if (xslDebugStatus != XSLT_DEBUG_NONE)
-        xslHandleDebugger(curInst, contextNode, NULL, ctxt);
+            xslHandleDebugger(curInst, contextNode, NULL, ctxt);
 #endif
+
         curInst = curInst->next;
-    }
-    xsltDoSortFunction(ctxt, sorts, nbsorts);
+        while (IS_XSLT_ELEM(curInst) && IS_XSLT_NAME(curInst, "sort")) {
+            if (nbsorts >= XSLT_MAX_SORT) {
+                xsltTransformError(ctxt, NULL, curInst,
+                    "The number of xsl:sort instructions exceeds the "
+                    "maximum (%d) allowed by this processor.\n",
+                    XSLT_MAX_SORT);
+                goto error;
+            } else {
+                sorts[nbsorts++] = curInst;
+            }
+
+#ifdef WITH_DEBUGGER
+            if (xslDebugStatus != XSLT_DEBUG_NONE)
+                xslHandleDebugger(curInst, contextNode, NULL, ctxt);
+#endif
+            curInst = curInst->next;
+        }
+        xsltDoSortFunction(ctxt, sorts, nbsorts);
     }
     xpctxt->contextSize = list->nodeNr;
     /*
     * Instantiate the sequence constructor for each selected node.
     */
     for (i = 0; i < list->nodeNr; i++) {
-    cur = list->nodeTab[i];
-    /*
-    * The selected node becomes the "current node".
-    */
-    ctxt->node = cur;
-    /*
-    * An xsl:for-each can change the current context doc.
-    * OPTIMIZE TODO: Get rid of the need to set the context doc.
-    */
-    if ((cur->type != XML_NAMESPACE_DECL) && (cur->doc != NULL))
-        xpctxt->doc = cur->doc;
+        cur = list->nodeTab[i];
+        /*
+        * The selected node becomes the "current node".
+        */
+        ctxt->node = cur;
+        /*
+        * An xsl:for-each can change the current context doc.
+        * OPTIMIZE TODO: Get rid of the need to set the context doc.
+        */
+        if ((cur->type != XML_NAMESPACE_DECL) && (cur->doc != NULL))
+            xpctxt->doc = cur->doc;
 
-    xpctxt->proximityPosition = i + 1;
+        xpctxt->proximityPosition = i + 1;
 
-    xsltApplySequenceConstructor(ctxt, cur, curInst, NULL);
+        xsltApplySequenceConstructor(ctxt, cur, curInst, NULL);
     }
 
 exit:
 error:
     if (res != NULL)
-    xmlXPathFreeObject(res);
+        xmlXPathFreeObject(res);
     /*
     * Restore old states.
     */
@@ -5673,9 +5571,9 @@ error:
 }
 
 /************************************************************************
- *                                  *
- *          Generic interface               *
- *                                  *
+ *                                                                      *
+ *                      Generic interface                               *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
@@ -5717,20 +5615,20 @@ static xsltHTMLVersion xsltHTMLVersions[] = {
  */
 static int
 xsltGetHTMLIDs(const xmlChar *version, const xmlChar **publicID,
-                const xmlChar **systemID) {
+                    const xmlChar **systemID) {
     unsigned int i;
     if (version == NULL)
-    return(-1);
+        return(-1);
     for (i = 0;i < (sizeof(xsltHTMLVersions)/sizeof(xsltHTMLVersions[1]));
-     i++) {
-    if (!xmlStrcasecmp(version,
-                   (const xmlChar *) xsltHTMLVersions[i].version)) {
-        if (publicID != NULL)
-        *publicID = (const xmlChar *) xsltHTMLVersions[i].public;
-        if (systemID != NULL)
-        *systemID = (const xmlChar *) xsltHTMLVersions[i].system;
-        return(0);
-    }
+         i++) {
+        if (!xmlStrcasecmp(version,
+                           (const xmlChar *) xsltHTMLVersions[i].version)) {
+            if (publicID != NULL)
+                *publicID = (const xmlChar *) xsltHTMLVersions[i].public;
+            if (systemID != NULL)
+                *systemID = (const xmlChar *) xsltHTMLVersions[i].system;
+            return(0);
+        }
     }
     return(-1);
 }
@@ -5753,61 +5651,61 @@ xsltApplyStripSpaces(xsltTransformContextPtr ctxt, xmlNodePtr node) {
 
     current = node;
     while (current != NULL) {
-    /*
-     * Cleanup children empty nodes if asked for
-     */
-    if ((IS_XSLT_REAL_NODE(current)) &&
-        (current->children != NULL) &&
-        (xsltFindElemSpaceHandling(ctxt, current))) {
-        xmlNodePtr delete = NULL, cur = current->children;
+        /*
+         * Cleanup children empty nodes if asked for
+         */
+        if ((IS_XSLT_REAL_NODE(current)) &&
+            (current->children != NULL) &&
+            (xsltFindElemSpaceHandling(ctxt, current))) {
+            xmlNodePtr delete = NULL, cur = current->children;
 
-        while (cur != NULL) {
-        if (IS_BLANK_NODE(cur))
-            delete = cur;
+            while (cur != NULL) {
+                if (IS_BLANK_NODE(cur))
+                    delete = cur;
 
-        cur = cur->next;
-        if (delete != NULL) {
-            xmlUnlinkNode(delete);
-            xmlFreeNode(delete);
-            delete = NULL;
+                cur = cur->next;
+                if (delete != NULL) {
+                    xmlUnlinkNode(delete);
+                    xmlFreeNode(delete);
+                    delete = NULL;
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            nb++;
+                    nb++;
 #endif
+                }
+            }
         }
-        }
-    }
 
-    /*
-     * Skip to next node in document order.
-     */
-    if (node->type == XML_ENTITY_REF_NODE) {
-        /* process deep in entities */
-        xsltApplyStripSpaces(ctxt, node->children);
-    }
-    if ((current->children != NULL) &&
-            (current->type != XML_ENTITY_REF_NODE)) {
-        current = current->children;
-    } else if (current->next != NULL) {
-        current = current->next;
-    } else {
-        do {
-        current = current->parent;
-        if (current == NULL)
-            break;
-        if (current == node)
-            goto done;
-        if (current->next != NULL) {
-            current = current->next;
-            break;
+        /*
+         * Skip to next node in document order.
+         */
+        if (node->type == XML_ENTITY_REF_NODE) {
+            /* process deep in entities */
+            xsltApplyStripSpaces(ctxt, node->children);
         }
-        } while (current != NULL);
-    }
+        if ((current->children != NULL) &&
+            (current->type != XML_ENTITY_REF_NODE)) {
+            current = current->children;
+        } else if (current->next != NULL) {
+            current = current->next;
+        } else {
+            do {
+                current = current->parent;
+                if (current == NULL)
+                    break;
+                if (current == node)
+                    goto done;
+                if (current->next != NULL) {
+                    current = current->next;
+                    break;
+                }
+            } while (current != NULL);
+        }
     }
 
 done:
 #ifdef WITH_XSLT_DEBUG_PROCESS
     XSLT_TRACE(ctxt,XSLT_TRACE_STRIP_SPACES,xsltGenericDebug(xsltGenericDebugContext,
-         "xsltApplyStripSpaces: removed %d ignorable blank node\n", nb));
+             "xsltApplyStripSpaces: removed %d ignorable blank node\n", nb));
 #endif
     return;
 }
@@ -5819,7 +5717,7 @@ xsltCountKeys(xsltTransformContextPtr ctxt)
     xsltKeyDefPtr keyd;
 
     if (ctxt == NULL)
-    return(-1);
+        return(-1);
 
     /*
     * Do we have those nastly templates with a key() in the match pattern?
@@ -5827,11 +5725,11 @@ xsltCountKeys(xsltTransformContextPtr ctxt)
     ctxt->hasTemplKeyPatterns = 0;
     style = ctxt->style;
     while (style != NULL) {
-    if (style->keyMatch != NULL) {
-        ctxt->hasTemplKeyPatterns = 1;
-        break;
-    }
-    style = xsltNextImport(style);
+        if (style->keyMatch != NULL) {
+            ctxt->hasTemplKeyPatterns = 1;
+            break;
+        }
+        style = xsltNextImport(style);
     }
     /*
     * Count number of key declarations.
@@ -5839,12 +5737,12 @@ xsltCountKeys(xsltTransformContextPtr ctxt)
     ctxt->nbKeys = 0;
     style = ctxt->style;
     while (style != NULL) {
-    keyd = style->keys;
-    while (keyd) {
-        ctxt->nbKeys++;
-        keyd = keyd->next;
-    }
-    style = xsltNextImport(style);
+        keyd = style->keys;
+        while (keyd) {
+            ctxt->nbKeys++;
+            keyd = keyd->next;
+        }
+        style = xsltNextImport(style);
     }
     return(ctxt->nbKeys);
 }
@@ -5886,25 +5784,25 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
 
     if (style->internalized == 0) {
 #ifdef WITH_XSLT_DEBUG
-    xsltGenericDebug(xsltGenericDebugContext,
-             "Stylesheet was not fully internalized !\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+                         "Stylesheet was not fully internalized !\n");
 #endif
     }
     if (doc->intSubset != NULL) {
-    /*
-     * Avoid hitting the DTD when scanning nodes
-     * but keep it linked as doc->intSubset
-     */
-    xmlNodePtr cur = (xmlNodePtr) doc->intSubset;
-    if (cur->next != NULL)
-        cur->next->prev = cur->prev;
-    if (cur->prev != NULL)
-        cur->prev->next = cur->next;
-    if (doc->children == cur)
-        doc->children = cur->next;
-    if (doc->last == cur)
-        doc->last = cur->prev;
-    cur->prev = cur->next = NULL;
+        /*
+         * Avoid hitting the DTD when scanning nodes
+         * but keep it linked as doc->intSubset
+         */
+        xmlNodePtr cur = (xmlNodePtr) doc->intSubset;
+        if (cur->next != NULL)
+            cur->next->prev = cur->prev;
+        if (cur->prev != NULL)
+            cur->prev->next = cur->next;
+        if (doc->children == cur)
+            doc->children = cur->next;
+        if (doc->last == cur)
+            doc->last = cur->prev;
+        cur->prev = cur->next = NULL;
     }
 
     /*
@@ -5912,15 +5810,15 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
      */
     root = xmlDocGetRootElement(doc);
     if (root != NULL) {
-    if (((ptrdiff_t) root->content >= 0) &&
+        if (((ptrdiff_t) root->content >= 0) &&
             (xslDebugStatus == XSLT_DEBUG_NONE))
-        xmlXPathOrderDocElems(doc);
+            xmlXPathOrderDocElems(doc);
     }
 
     if (userCtxt != NULL)
-    ctxt = userCtxt;
+        ctxt = userCtxt;
     else
-    ctxt = xsltNewTransformContext(style, doc);
+        ctxt = xsltNewTransformContext(style, doc);
 
     if (ctxt == NULL)
         return (NULL);
@@ -5949,9 +5847,9 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
      */
     if (ctxt->dict != NULL) {
         if (ctxt->mode != NULL)
-        ctxt->mode = xmlDictLookup(ctxt->dict, ctxt->mode, -1);
+            ctxt->mode = xmlDictLookup(ctxt->dict, ctxt->mode, -1);
         if (ctxt->modeURI != NULL)
-        ctxt->modeURI = xmlDictLookup(ctxt->dict, ctxt->modeURI, -1);
+            ctxt->modeURI = xmlDictLookup(ctxt->dict, ctxt->modeURI, -1);
     }
 
     XSLT_GET_IMPORT_PTR(method, style, method)
@@ -5961,76 +5859,76 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
 
     if ((method != NULL) &&
-    (!xmlStrEqual(method, (const xmlChar *) "xml")))
+        (!xmlStrEqual(method, (const xmlChar *) "xml")))
     {
         if (xmlStrEqual(method, (const xmlChar *) "html")) {
             ctxt->type = XSLT_OUTPUT_HTML;
             if (((doctypePublic != NULL) || (doctypeSystem != NULL))) {
                 res = htmlNewDoc(doctypeSystem, doctypePublic);
-        } else {
+            } else {
                 if (version == NULL) {
-            xmlDtdPtr dtd;
+                    xmlDtdPtr dtd;
 
-            res = htmlNewDoc(NULL, NULL);
-            /*
-            * Make sure no DTD node is generated in this case
-            */
-            if (res != NULL) {
-            dtd = xmlGetIntSubset(res);
-            if (dtd != NULL) {
-                xmlUnlinkNode((xmlNodePtr) dtd);
-                xmlFreeDtd(dtd);
-            }
-            res->intSubset = NULL;
-            res->extSubset = NULL;
-            }
-        } else {
+                    res = htmlNewDoc(NULL, NULL);
+                    /*
+                    * Make sure no DTD node is generated in this case
+                    */
+                    if (res != NULL) {
+                        dtd = xmlGetIntSubset(res);
+                        if (dtd != NULL) {
+                            xmlUnlinkNode((xmlNodePtr) dtd);
+                            xmlFreeDtd(dtd);
+                        }
+                        res->intSubset = NULL;
+                        res->extSubset = NULL;
+                    }
+                } else {
 
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
-            xsltGetHTMLIDs(version, &doctypePublic, &doctypeSystem);
+                    xsltGetHTMLIDs(version, &doctypePublic, &doctypeSystem);
 #endif
-            res = htmlNewDoc(doctypeSystem, doctypePublic);
-        }
+                    res = htmlNewDoc(doctypeSystem, doctypePublic);
+                }
             }
             if (res == NULL)
                 goto error;
-        res->dict = ctxt->dict;
-        xmlDictReference(res->dict);
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
 
 #ifdef WITH_XSLT_DEBUG
-        xsltGenericDebug(xsltGenericDebugContext,
-        "reusing transformation dict for output\n");
+            xsltGenericDebug(xsltGenericDebugContext,
+                "reusing transformation dict for output\n");
 #endif
         } else if (xmlStrEqual(method, (const xmlChar *) "xhtml")) {
-        xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
-        "xsltApplyStylesheetInternal: unsupported method xhtml, using html\n");
+            xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
+                "xsltApplyStylesheetInternal: unsupported method xhtml, using html\n");
             ctxt->type = XSLT_OUTPUT_HTML;
             res = htmlNewDoc(doctypeSystem, doctypePublic);
             if (res == NULL)
                 goto error;
-        res->dict = ctxt->dict;
-        xmlDictReference(res->dict);
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
 
 #ifdef WITH_XSLT_DEBUG
-        xsltGenericDebug(xsltGenericDebugContext,
-        "reusing transformation dict for output\n");
+            xsltGenericDebug(xsltGenericDebugContext,
+                "reusing transformation dict for output\n");
 #endif
         } else if (xmlStrEqual(method, (const xmlChar *) "text")) {
             ctxt->type = XSLT_OUTPUT_TEXT;
             res = xmlNewDoc(style->version);
             if (res == NULL)
                 goto error;
-        res->dict = ctxt->dict;
-        xmlDictReference(res->dict);
+            res->dict = ctxt->dict;
+            xmlDictReference(res->dict);
 
 #ifdef WITH_XSLT_DEBUG
-        xsltGenericDebug(xsltGenericDebugContext,
-        "reusing transformation dict for output\n");
+            xsltGenericDebug(xsltGenericDebugContext,
+                "reusing transformation dict for output\n");
 #endif
         } else {
-        xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
-        "xsltApplyStylesheetInternal: unsupported method (%s)\n",
-        method);
+            xsltTransformError(ctxt, NULL, (xmlNodePtr) doc,
+                "xsltApplyStylesheetInternal: unsupported method (%s)\n",
+                method);
             goto error;
         }
     } else {
@@ -6038,11 +5936,11 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
         res = xmlNewDoc(style->version);
         if (res == NULL)
             goto error;
-    res->dict = ctxt->dict;
-    xmlDictReference(ctxt->dict);
+        res->dict = ctxt->dict;
+        xmlDictReference(ctxt->dict);
 #ifdef WITH_XSLT_DEBUG
-    xsltGenericDebug(xsltGenericDebugContext,
-             "reusing transformation dict for output\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+                         "reusing transformation dict for output\n");
 #endif
     }
     res->charset = XML_CHAR_ENCODING_UTF8;
@@ -6062,12 +5960,12 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
      * and start by processing the top node.
      */
     if (xsltNeedElemSpaceHandling(ctxt))
-    xsltApplyStripSpaces(ctxt, xmlDocGetRootElement(doc));
+        xsltApplyStripSpaces(ctxt, xmlDocGetRootElement(doc));
     /*
     * Evaluate global params and user-provided params.
     */
     if (ctxt->globalVars == NULL)
-    ctxt->globalVars = xmlHashCreate(20);
+        ctxt->globalVars = xmlHashCreate(20);
     if (params != NULL) {
         xsltEvalUserParams(ctxt, params);
     }
@@ -6141,9 +6039,9 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
         const xmlChar *doctype = NULL;
 
         if ((root->ns != NULL) && (root->ns->prefix != NULL))
-        doctype = xmlDictQLookup(ctxt->dict, root->ns->prefix, root->name);
-    if (doctype == NULL)
-        doctype = root->name;
+            doctype = xmlDictQLookup(ctxt->dict, root->ns->prefix, root->name);
+        if (doctype == NULL)
+            doctype = root->name;
 
         /*
          * Apply the default selection of the method
@@ -6159,21 +6057,21 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
                     break;
                 if ((tmp->type == XML_TEXT_NODE) && (!xmlIsBlankNode(tmp)))
                     break;
-        tmp = tmp->next;
+                tmp = tmp->next;
             }
             if (tmp == root) {
                 ctxt->type = XSLT_OUTPUT_HTML;
-        /*
-        * REVISIT TODO: XML_HTML_DOCUMENT_NODE is set after the
-        *  transformation on the doc, but functions like
-        */
+                /*
+                * REVISIT TODO: XML_HTML_DOCUMENT_NODE is set after the
+                *  transformation on the doc, but functions like
+                */
                 res->type = XML_HTML_DOCUMENT_NODE;
                 if (((doctypePublic != NULL) || (doctypeSystem != NULL))) {
                     res->intSubset = xmlCreateIntSubset(res, doctype,
                                                         doctypePublic,
                                                         doctypeSystem);
 #ifdef XSLT_GENERATE_HTML_DOCTYPE
-        } else if (version != NULL) {
+                } else if (version != NULL) {
                     xsltGetHTMLIDs(version, &doctypePublic,
                                    &doctypeSystem);
                     if (((doctypePublic != NULL) || (doctypeSystem != NULL)))
@@ -6190,25 +6088,25 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
             XSLT_GET_IMPORT_PTR(doctypePublic, style, doctypePublic)
             XSLT_GET_IMPORT_PTR(doctypeSystem, style, doctypeSystem)
             if (((doctypePublic != NULL) || (doctypeSystem != NULL))) {
-            xmlNodePtr last;
-        /* Need a small "hack" here to assure DTD comes before
-           possible comment nodes */
-        node = res->children;
-        last = res->last;
-        res->children = NULL;
-        res->last = NULL;
+                xmlNodePtr last;
+                /* Need a small "hack" here to assure DTD comes before
+                   possible comment nodes */
+                node = res->children;
+                last = res->last;
+                res->children = NULL;
+                res->last = NULL;
                 res->intSubset = xmlCreateIntSubset(res, doctype,
                                                     doctypePublic,
                                                     doctypeSystem);
-        if (res->children != NULL) {
-            res->children->next = node;
-            node->prev = res->children;
-            res->last = last;
-        } else {
-            res->children = node;
-            res->last = last;
-        }
-        }
+                if (res->children != NULL) {
+                    res->children->next = node;
+                    node->prev = res->children;
+                    res->last = last;
+                } else {
+                    res->children = node;
+                    res->last = last;
+                }
+            }
         }
     }
     xmlXPathFreeNodeSet(ctxt->nodeList);
@@ -6223,22 +6121,22 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
      * Be pedantic.
      */
     if ((ctxt != NULL) && (ctxt->state != XSLT_STATE_OK)) {
-    xmlFreeDoc(res);
-    res = NULL;
+        xmlFreeDoc(res);
+        res = NULL;
     }
     if ((res != NULL) && (ctxt != NULL) && (output != NULL)) {
-    int ret;
+        int ret;
 
-    ret = xsltCheckWrite(ctxt->sec, ctxt, (const xmlChar *) output);
-    if (ret == 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-             "xsltApplyStylesheet: forbidden to save to %s\n",
-                   output);
-    } else if (ret < 0) {
-        xsltTransformError(ctxt, NULL, NULL,
-             "xsltApplyStylesheet: saving to %s may not be possible\n",
-                   output);
-    }
+        ret = xsltCheckWrite(ctxt->sec, ctxt, (const xmlChar *) output);
+        if (ret == 0) {
+            xsltTransformError(ctxt, NULL, NULL,
+                     "xsltApplyStylesheet: forbidden to save to %s\n",
+                               output);
+        } else if (ret < 0) {
+            xsltTransformError(ctxt, NULL, NULL,
+                     "xsltApplyStylesheet: saving to %s may not be possible\n",
+                               output);
+        }
     }
 
 #ifdef XSLT_DEBUG_PROFILE_CACHE
@@ -6248,7 +6146,7 @@ xsltApplyStylesheetInternal(xsltStylesheetPtr style, xmlDocPtr doc,
 #endif
 
     if ((ctxt != NULL) && (userCtxt == NULL))
-    xsltFreeTransformContext(ctxt);
+        xsltFreeTransformContext(ctxt);
 
     return (res);
 
@@ -6329,7 +6227,7 @@ xsltApplyStylesheetUser(xsltStylesheetPtr style, xmlDocPtr doc,
     xmlDocPtr res;
 
     res = xsltApplyStylesheetInternal(style, doc, params, output,
-                                  profile, userCtxt);
+                                      profile, userCtxt);
     return (res);
 }
 
@@ -6363,7 +6261,7 @@ int
 xsltRunStylesheetUser(xsltStylesheetPtr style, xmlDocPtr doc,
                   const char **params, const char *output,
                   xmlSAXHandlerPtr SAX, xmlOutputBufferPtr IObuf,
-          FILE * profile, xsltTransformContextPtr userCtxt)
+                  FILE * profile, xsltTransformContextPtr userCtxt)
 {
     xmlDocPtr tmp;
     int ret;
@@ -6376,13 +6274,13 @@ xsltRunStylesheetUser(xsltStylesheetPtr style, xmlDocPtr doc,
     /* unsupported yet */
     if (SAX != NULL) {
         XSLT_TODO   /* xsltRunStylesheet xmlSAXHandlerPtr SAX */
-    return (-1);
+        return (-1);
     }
 
     tmp = xsltApplyStylesheetInternal(style, doc, params, output, profile,
-                                  userCtxt);
+                                      userCtxt);
     if (tmp == NULL) {
-    xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
+        xsltTransformError(NULL, NULL, (xmlNodePtr) doc,
                          "xsltRunStylesheet : run failed\n");
         return (-1);
     }
@@ -6426,7 +6324,7 @@ xsltRunStylesheet(xsltStylesheetPtr style, xmlDocPtr doc,
                   xmlSAXHandlerPtr SAX, xmlOutputBufferPtr IObuf)
 {
     return(xsltRunStylesheetUser(style, doc, params, output, SAX, IObuf,
-                         NULL, NULL));
+                                 NULL, NULL));
 }
 
 static void
@@ -6446,79 +6344,79 @@ xsltRegisterAllElement(xsltTransformContextPtr ctxt)
 {
     xsltRegisterExtElement(ctxt, (const xmlChar *) "apply-templates",
                            XSLT_NAMESPACE,
-               xsltApplyTemplates);
+                           xsltApplyTemplates);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "apply-imports",
                            XSLT_NAMESPACE,
-               xsltApplyImports);
+                           xsltApplyImports);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "call-template",
                            XSLT_NAMESPACE,
-               xsltCallTemplate);
+                           xsltCallTemplate);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "element",
                            XSLT_NAMESPACE,
-               xsltElement);
+                           xsltElement);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "attribute",
                            XSLT_NAMESPACE,
-               xsltAttribute);
+                           xsltAttribute);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "text",
                            XSLT_NAMESPACE,
-               xsltText);
+                           xsltText);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "processing-instruction",
                            XSLT_NAMESPACE,
-               xsltProcessingInstruction);
+                           xsltProcessingInstruction);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "comment",
                            XSLT_NAMESPACE,
-               xsltComment);
+                           xsltComment);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "copy",
                            XSLT_NAMESPACE,
-               xsltCopy);
+                           xsltCopy);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "value-of",
                            XSLT_NAMESPACE,
-               xsltValueOf);
+                           xsltValueOf);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "number",
                            XSLT_NAMESPACE,
-               xsltNumber);
+                           xsltNumber);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "for-each",
                            XSLT_NAMESPACE,
-               xsltForEach);
+                           xsltForEach);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "if",
                            XSLT_NAMESPACE,
-               xsltIf);
+                           xsltIf);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "choose",
                            XSLT_NAMESPACE,
-               xsltChoose);
+                           xsltChoose);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "sort",
                            XSLT_NAMESPACE,
-               xsltSort);
+                           xsltSort);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "copy-of",
                            XSLT_NAMESPACE,
-               xsltCopyOf);
+                           xsltCopyOf);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "message",
                            XSLT_NAMESPACE,
-               xsltMessageWrapper);
+                           xsltMessageWrapper);
 
     /*
      * Those don't have callable entry points but are registered anyway
      */
     xsltRegisterExtElement(ctxt, (const xmlChar *) "variable",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "param",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "with-param",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "decimal-format",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "when",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "otherwise",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
     xsltRegisterExtElement(ctxt, (const xmlChar *) "fallback",
                            XSLT_NAMESPACE,
-               xsltDebug);
+                           xsltDebug);
 
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/transform.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/transform.h
@@ -25,27 +25,27 @@ extern "C" {
  * XInclude default processing.
  */
 XSLTPUBFUN void XSLTCALL
-        xsltSetXIncludeDefault  (int xinclude);
+                xsltSetXIncludeDefault  (int xinclude);
 XSLTPUBFUN int XSLTCALL
-        xsltGetXIncludeDefault  (void);
+                xsltGetXIncludeDefault  (void);
 
 /**
  * Export context to users.
  */
 XSLTPUBFUN xsltTransformContextPtr XSLTCALL
-        xsltNewTransformContext (xsltStylesheetPtr style,
-                     xmlDocPtr doc);
+                xsltNewTransformContext (xsltStylesheetPtr style,
+                                         xmlDocPtr doc);
 
 XSLTPUBFUN void XSLTCALL
-        xsltFreeTransformContext(xsltTransformContextPtr ctxt);
+                xsltFreeTransformContext(xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN xmlDocPtr XSLTCALL
-        xsltApplyStylesheetUser (xsltStylesheetPtr style,
-                     xmlDocPtr doc,
-                     const char **params,
-                     const char *output,
-                     FILE * profile,
-                     xsltTransformContextPtr userCtxt);
+                xsltApplyStylesheetUser (xsltStylesheetPtr style,
+                                         xmlDocPtr doc,
+                                         const char **params,
+                                         const char *output,
+                                         FILE * profile,
+                                         xsltTransformContextPtr userCtxt);
 XSLTPUBFUN void XSLTCALL
                 xsltProcessOneNode      (xsltTransformContextPtr ctxt,
                                          xmlNodePtr node,
@@ -54,150 +54,150 @@ XSLTPUBFUN void XSLTCALL
  * Private Interfaces.
  */
 XSLTPUBFUN void XSLTCALL
-        xsltApplyStripSpaces    (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node);
+                xsltApplyStripSpaces    (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node);
 XSLTPUBFUN xmlDocPtr XSLTCALL
-        xsltApplyStylesheet (xsltStylesheetPtr style,
-                     xmlDocPtr doc,
-                     const char **params);
+                xsltApplyStylesheet     (xsltStylesheetPtr style,
+                                         xmlDocPtr doc,
+                                         const char **params);
 XSLTPUBFUN xmlDocPtr XSLTCALL
-        xsltProfileStylesheet   (xsltStylesheetPtr style,
-                     xmlDocPtr doc,
-                     const char **params,
-                     FILE * output);
+                xsltProfileStylesheet   (xsltStylesheetPtr style,
+                                         xmlDocPtr doc,
+                                         const char **params,
+                                         FILE * output);
 XSLTPUBFUN int XSLTCALL
-        xsltRunStylesheet   (xsltStylesheetPtr style,
-                     xmlDocPtr doc,
-                     const char **params,
-                     const char *output,
-                     xmlSAXHandlerPtr SAX,
-                     xmlOutputBufferPtr IObuf);
+                xsltRunStylesheet       (xsltStylesheetPtr style,
+                                         xmlDocPtr doc,
+                                         const char **params,
+                                         const char *output,
+                                         xmlSAXHandlerPtr SAX,
+                                         xmlOutputBufferPtr IObuf);
 XSLTPUBFUN int XSLTCALL
-        xsltRunStylesheetUser   (xsltStylesheetPtr style,
-                     xmlDocPtr doc,
-                     const char **params,
-                     const char *output,
-                     xmlSAXHandlerPtr SAX,
-                     xmlOutputBufferPtr IObuf,
-                     FILE * profile,
-                     xsltTransformContextPtr userCtxt);
+                xsltRunStylesheetUser   (xsltStylesheetPtr style,
+                                         xmlDocPtr doc,
+                                         const char **params,
+                                         const char *output,
+                                         xmlSAXHandlerPtr SAX,
+                                         xmlOutputBufferPtr IObuf,
+                                         FILE * profile,
+                                         xsltTransformContextPtr userCtxt);
 XSLTPUBFUN void XSLTCALL
-        xsltApplyOneTemplate    (xsltTransformContextPtr ctxt,
-                     xmlNodePtr node,
-                     xmlNodePtr list,
-                     xsltTemplatePtr templ,
-                     xsltStackElemPtr params);
+                xsltApplyOneTemplate    (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr list,
+                                         xsltTemplatePtr templ,
+                                         xsltStackElemPtr params);
 XSLTPUBFUN void XSLTCALL
-        xsltDocumentElem    (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltDocumentElem        (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltSort        (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltSort                (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltCopy        (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltCopy                (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltText        (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltText                (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltElement     (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltElement             (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltComment     (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltComment             (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltAttribute       (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltAttribute           (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltProcessingInstruction(xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltProcessingInstruction(xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltCopyOf      (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltCopyOf              (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltValueOf     (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltValueOf             (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltNumber      (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltNumber              (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltApplyImports    (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltApplyImports        (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltCallTemplate    (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltCallTemplate        (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltApplyTemplates  (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltApplyTemplates      (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltChoose      (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltChoose              (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltIf          (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltIf                  (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltForEach     (xsltTransformContextPtr ctxt,
-                                     xmlNodePtr node,
-                     xmlNodePtr inst,
-                     xsltElemPreCompPtr comp);
+                xsltForEach             (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr node,
+                                         xmlNodePtr inst,
+                                         xsltElemPreCompPtr comp);
 XSLTPUBFUN void XSLTCALL
-        xsltRegisterAllElement  (xsltTransformContextPtr ctxt);
+                xsltRegisterAllElement  (xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN xmlNodePtr XSLTCALL
-        xsltCopyTextString  (xsltTransformContextPtr ctxt,
-                     xmlNodePtr target,
-                     const xmlChar *string,
-                     int noescape);
+                xsltCopyTextString      (xsltTransformContextPtr ctxt,
+                                         xmlNodePtr target,
+                                         const xmlChar *string,
+                                         int noescape);
 
 /* Following 2 functions needed for libexslt/functions.c */
 XSLTPUBFUN void XSLTCALL
-        xsltLocalVariablePop    (xsltTransformContextPtr ctxt,
-                     int limitNr,
-                     int level);
+                xsltLocalVariablePop    (xsltTransformContextPtr ctxt,
+                                         int limitNr,
+                                         int level);
 XSLTPUBFUN int XSLTCALL
-        xsltLocalVariablePush   (xsltTransformContextPtr ctxt,
-                     xsltStackElemPtr variable,
-                     int level);
+                xsltLocalVariablePush   (xsltTransformContextPtr ctxt,
+                                         xsltStackElemPtr variable,
+                                         int level);
 /*
  * Hook for the debugger if activated.
  */
 XSLTPUBFUN void XSLTCALL
-        xslHandleDebugger   (xmlNodePtr cur,
-                     xmlNodePtr node,
-                     xsltTemplatePtr templ,
-                     xsltTransformContextPtr ctxt);
+                xslHandleDebugger       (xmlNodePtr cur,
+                                         xmlNodePtr node,
+                                         xsltTemplatePtr templ,
+                                         xsltTransformContextPtr ctxt);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/trio.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/trio.h
@@ -90,11 +90,11 @@ int trio_vdprintf TRIO_PROTO((int fd, TRIO_CONST char *format, va_list args));
 int trio_dprintfv TRIO_PROTO((int fd, TRIO_CONST char *format, void **args));
 
 int trio_cprintf TRIO_PROTO((trio_outstream_t stream, trio_pointer_t closure,
-                 TRIO_CONST char *format, ...));
+                             TRIO_CONST char *format, ...));
 int trio_vcprintf TRIO_PROTO((trio_outstream_t stream, trio_pointer_t closure,
-                  TRIO_CONST char *format, va_list args));
+                              TRIO_CONST char *format, va_list args));
 int trio_cprintfv TRIO_PROTO((trio_outstream_t stream, trio_pointer_t closure,
-                  TRIO_CONST char *format, void **args));
+                              TRIO_CONST char *format, void **args));
 
 int trio_sprintf TRIO_PROTO((char *buffer, TRIO_CONST char *format, ...));
 int trio_vsprintf TRIO_PROTO((char *buffer, TRIO_CONST char *format, va_list args));
@@ -102,9 +102,9 @@ int trio_sprintfv TRIO_PROTO((char *buffer, TRIO_CONST char *format, void **args
 
 int trio_snprintf TRIO_PROTO((char *buffer, size_t max, TRIO_CONST char *format, ...));
 int trio_vsnprintf TRIO_PROTO((char *buffer, size_t bufferSize, TRIO_CONST char *format,
-           va_list args));
+                   va_list args));
 int trio_snprintfv TRIO_PROTO((char *buffer, size_t bufferSize, TRIO_CONST char *format,
-           void **args));
+                   void **args));
 
 int trio_snprintfcat TRIO_PROTO((char *buffer, size_t max, TRIO_CONST char *format, ...));
 int trio_vsnprintfcat TRIO_PROTO((char *buffer, size_t bufferSize, TRIO_CONST char *format,
@@ -132,11 +132,11 @@ int trio_vdscanf TRIO_PROTO((int fd, TRIO_CONST char *format, va_list args));
 int trio_dscanfv TRIO_PROTO((int fd, TRIO_CONST char *format, void **args));
 
 int trio_cscanf TRIO_PROTO((trio_instream_t stream, trio_pointer_t closure,
-                TRIO_CONST char *format, ...));
+                            TRIO_CONST char *format, ...));
 int trio_vcscanf TRIO_PROTO((trio_instream_t stream, trio_pointer_t closure,
-                 TRIO_CONST char *format, va_list args));
+                             TRIO_CONST char *format, va_list args));
 int trio_cscanfv TRIO_PROTO((trio_instream_t stream, trio_pointer_t closure,
-                 TRIO_CONST char *format, void **args));
+                             TRIO_CONST char *format, void **args));
 
 int trio_sscanf TRIO_PROTO((TRIO_CONST char *buffer, TRIO_CONST char *format, ...));
 int trio_vsscanf TRIO_PROTO((TRIO_CONST char *buffer, TRIO_CONST char *format, va_list args));

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/variables.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/variables.c
@@ -48,9 +48,9 @@ static const xmlChar *xsltComputingGlobalVarMarker =
 #define XSLT_TCTXT_VARIABLE(c) ((xsltStackElemPtr) (c)->contextVariable)
 
 /************************************************************************
- *                                  *
- *  Result Value Tree (Result Tree Fragment) interfaces         *
- *                                  *
+ *                                                                      *
+ *  Result Value Tree (Result Tree Fragment) interfaces                 *
+ *                                                                      *
  ************************************************************************/
 /**
  * xsltCreateRVT:
@@ -71,28 +71,28 @@ xsltCreateRVT(xsltTransformContextPtr ctxt)
     * Answer: It is called by the EXSLT module.
     */
     if (ctxt == NULL)
-    return(NULL);
+        return(NULL);
 
     /*
     * Reuse a RTF from the cache if available.
     */
     if (ctxt->cache->RVT) {
-    container = ctxt->cache->RVT;
-    ctxt->cache->RVT = (xmlDocPtr) container->next;
-    /* clear the internal pointers */
-    container->next = NULL;
-    container->prev = NULL;
-    if (ctxt->cache->nbRVT > 0)
-        ctxt->cache->nbRVT--;
+        container = ctxt->cache->RVT;
+        ctxt->cache->RVT = (xmlDocPtr) container->next;
+        /* clear the internal pointers */
+        container->next = NULL;
+        container->prev = NULL;
+        if (ctxt->cache->nbRVT > 0)
+            ctxt->cache->nbRVT--;
 #ifdef XSLT_DEBUG_PROFILE_CACHE
-    ctxt->cache->dbgReusedRVTs++;
+        ctxt->cache->dbgReusedRVTs++;
 #endif
-    return(container);
+        return(container);
     }
 
     container = xmlNewDoc(NULL);
     if (container == NULL)
-    return(NULL);
+        return(NULL);
     container->dict = ctxt->dict;
     xmlDictReference(container->dict);
     XSLT_MARK_RES_TREE_FRAG(container);
@@ -120,7 +120,7 @@ int
 xsltRegisterTmpRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
 {
     if ((ctxt == NULL) || (RVT == NULL))
-    return(-1);
+        return(-1);
 
     RVT->prev = NULL;
     RVT->psvi = XSLT_RVT_LOCAL;
@@ -131,14 +131,14 @@ xsltRegisterTmpRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
     * var/param itself.
     */
     if (ctxt->contextVariable != NULL) {
-    RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
-    XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
-    return(0);
+        RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
+        XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
+        return(0);
     }
 
     RVT->next = (xmlNodePtr) ctxt->tmpRVT;
     if (ctxt->tmpRVT != NULL)
-    ctxt->tmpRVT->prev = (xmlNodePtr) RVT;
+        ctxt->tmpRVT->prev = (xmlNodePtr) RVT;
     ctxt->tmpRVT = RVT;
     return(0);
 }
@@ -157,10 +157,10 @@ xsltRegisterTmpRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
  */
 int
 xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
-             xmlDocPtr RVT)
+                     xmlDocPtr RVT)
 {
     if ((ctxt == NULL) || (RVT == NULL))
-    return(-1);
+        return(-1);
 
     RVT->prev = NULL;
     RVT->psvi = XSLT_RVT_LOCAL;
@@ -172,11 +172,11 @@ xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
     * freed before we leave the scope of a var.
     */
     if ((ctxt->contextVariable != NULL) &&
-    (XSLT_TCTXT_VARIABLE(ctxt)->flags & XSLT_VAR_IN_SELECT))
+        (XSLT_TCTXT_VARIABLE(ctxt)->flags & XSLT_VAR_IN_SELECT))
     {
-    RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
-    XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
-    return(0);
+        RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
+        XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
+        return(0);
     }
     /*
     * Store the fragment in the scope of the current instruction.
@@ -185,7 +185,7 @@ xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
     */
     RVT->next = (xmlNodePtr) ctxt->localRVT;
     if (ctxt->localRVT != NULL)
-    ctxt->localRVT->prev = (xmlNodePtr) RVT;
+        ctxt->localRVT->prev = (xmlNodePtr) RVT;
     ctxt->localRVT = RVT;
     return(0);
 }
@@ -233,7 +233,7 @@ xsltExtensionInstructionResultFinalize(
 int
 xsltExtensionInstructionResultRegister(
         xsltTransformContextPtr ctxt ATTRIBUTE_UNUSED,
-    xmlXPathObjectPtr obj ATTRIBUTE_UNUSED)
+        xmlXPathObjectPtr obj ATTRIBUTE_UNUSED)
 {
     return(0);
 }
@@ -261,7 +261,7 @@ xsltFlagRVTs(xsltTransformContextPtr ctxt, xmlXPathObjectPtr obj, void *val) {
     xmlDocPtr doc;
 
     if ((ctxt == NULL) || (obj == NULL))
-    return(-1);
+        return(-1);
 
     /*
     * OPTIMIZE TODO: If no local variables/params and no local tree
@@ -270,45 +270,45 @@ xsltFlagRVTs(xsltTransformContextPtr ctxt, xmlXPathObjectPtr obj, void *val) {
     */
 
     if ((obj->type != XPATH_NODESET) && (obj->type != XPATH_XSLT_TREE))
-    return(0);
+        return(0);
     if ((obj->nodesetval == NULL) || (obj->nodesetval->nodeNr == 0))
-    return(0);
+        return(0);
 
     for (i = 0; i < obj->nodesetval->nodeNr; i++) {
-    cur = obj->nodesetval->nodeTab[i];
-    if (cur->type == XML_NAMESPACE_DECL) {
-        /*
-        * The XPath module sets the owner element of a ns-node on
-        * the ns->next field.
-        */
-        if ((((xmlNsPtr) cur)->next != NULL) &&
-        (((xmlNsPtr) cur)->next->type == XML_ELEMENT_NODE))
-        {
-        cur = (xmlNodePtr) ((xmlNsPtr) cur)->next;
-        doc = cur->doc;
+        cur = obj->nodesetval->nodeTab[i];
+        if (cur->type == XML_NAMESPACE_DECL) {
+            /*
+            * The XPath module sets the owner element of a ns-node on
+            * the ns->next field.
+            */
+            if ((((xmlNsPtr) cur)->next != NULL) &&
+                (((xmlNsPtr) cur)->next->type == XML_ELEMENT_NODE))
+            {
+                cur = (xmlNodePtr) ((xmlNsPtr) cur)->next;
+                doc = cur->doc;
+            } else {
+                xsltTransformError(ctxt, NULL, ctxt->inst,
+                    "Internal error in xsltFlagRVTs(): "
+                    "Cannot retrieve the doc of a namespace node.\n");
+                return(-1);
+            }
         } else {
-        xsltTransformError(ctxt, NULL, ctxt->inst,
-            "Internal error in xsltFlagRVTs(): "
-            "Cannot retrieve the doc of a namespace node.\n");
-        return(-1);
+            doc = cur->doc;
         }
-    } else {
-        doc = cur->doc;
-    }
-    if (doc == NULL) {
-        xsltTransformError(ctxt, NULL, ctxt->inst,
-        "Internal error in xsltFlagRVTs(): "
-        "Cannot retrieve the doc of a node.\n");
-        return(-1);
-    }
-    if (doc->name && (doc->name[0] == ' ') &&
+        if (doc == NULL) {
+            xsltTransformError(ctxt, NULL, ctxt->inst,
+                "Internal error in xsltFlagRVTs(): "
+                "Cannot retrieve the doc of a node.\n");
+            return(-1);
+        }
+        if (doc->name && (doc->name[0] == ' ') &&
             doc->psvi != XSLT_RVT_GLOBAL) {
-        /*
-        * This is a result tree fragment.
-        * We store ownership information in the @psvi field.
-        * TODO: How do we know if this is a doc acquired via the
-        *  document() function?
-        */
+            /*
+            * This is a result tree fragment.
+            * We store ownership information in the @psvi field.
+            * TODO: How do we know if this is a doc acquired via the
+            *  document() function?
+            */
 #ifdef WITH_XSLT_DEBUG_VARIABLE
             XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
                 "Flagging RVT %p: %p -> %p\n", doc, doc->psvi, val));
@@ -319,7 +319,7 @@ xsltFlagRVTs(xsltTransformContextPtr ctxt, xmlXPathObjectPtr obj, void *val) {
                     doc->psvi = XSLT_RVT_LOCAL;
             } else if (val == XSLT_RVT_GLOBAL) {
                 if (doc->psvi != XSLT_RVT_LOCAL) {
-            xmlGenericError(xmlGenericErrorContext,
+                    xmlGenericError(xmlGenericErrorContext,
                             "xsltFlagRVTs: Invalid transition %p => GLOBAL\n",
                             doc->psvi);
                     doc->psvi = XSLT_RVT_GLOBAL;
@@ -329,9 +329,9 @@ xsltFlagRVTs(xsltTransformContextPtr ctxt, xmlXPathObjectPtr obj, void *val) {
                 /* Will be registered as persistant in xsltReleaseLocalRVTs. */
                 doc->psvi = XSLT_RVT_GLOBAL;
             } else if (val == XSLT_RVT_FUNC_RESULT) {
-            doc->psvi = val;
+                doc->psvi = val;
             }
-    }
+        }
     }
 
     return(0);
@@ -349,57 +349,57 @@ void
 xsltReleaseRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
 {
     if (RVT == NULL)
-    return;
+        return;
 
     if (ctxt && (ctxt->cache->nbRVT < 40)) {
-    /*
-    * Store the Result Tree Fragment.
-    * Free the document info.
-    */
-    if (RVT->_private != NULL) {
-        xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
-        xmlFree(RVT->_private);
-        RVT->_private = NULL;
-    }
-    /*
-    * Clear the document tree.
-    * REVISIT TODO: Do we expect ID/IDREF tables to be existent?
-    */
-    if (RVT->children != NULL) {
-        xmlFreeNodeList(RVT->children);
-        RVT->children = NULL;
-        RVT->last = NULL;
-    }
-    if (RVT->ids != NULL) {
-        xmlFreeIDTable((xmlIDTablePtr) RVT->ids);
-        RVT->ids = NULL;
-    }
-    if (RVT->refs != NULL) {
-        xmlFreeRefTable((xmlRefTablePtr) RVT->refs);
-        RVT->refs = NULL;
-    }
+        /*
+        * Store the Result Tree Fragment.
+        * Free the document info.
+        */
+        if (RVT->_private != NULL) {
+            xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
+            xmlFree(RVT->_private);
+            RVT->_private = NULL;
+        }
+        /*
+        * Clear the document tree.
+        * REVISIT TODO: Do we expect ID/IDREF tables to be existent?
+        */
+        if (RVT->children != NULL) {
+            xmlFreeNodeList(RVT->children);
+            RVT->children = NULL;
+            RVT->last = NULL;
+        }
+        if (RVT->ids != NULL) {
+            xmlFreeIDTable((xmlIDTablePtr) RVT->ids);
+            RVT->ids = NULL;
+        }
+        if (RVT->refs != NULL) {
+            xmlFreeRefTable((xmlRefTablePtr) RVT->refs);
+            RVT->refs = NULL;
+        }
 
-    /*
-    * Reset the ownership information.
-    */
-    RVT->psvi = NULL;
+        /*
+        * Reset the ownership information.
+        */
+        RVT->psvi = NULL;
 
-    RVT->next = (xmlNodePtr) ctxt->cache->RVT;
-    ctxt->cache->RVT = RVT;
+        RVT->next = (xmlNodePtr) ctxt->cache->RVT;
+        ctxt->cache->RVT = RVT;
 
-    ctxt->cache->nbRVT++;
+        ctxt->cache->nbRVT++;
 
 #ifdef XSLT_DEBUG_PROFILE_CACHE
-    ctxt->cache->dbgCachedRVTs++;
+        ctxt->cache->dbgCachedRVTs++;
 #endif
-    return;
+        return;
     }
     /*
     * Free it.
     */
     if (RVT->_private != NULL) {
-    xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
-    xmlFree(RVT->_private);
+        xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
+        xmlFree(RVT->_private);
     }
     xmlFreeDoc(RVT);
 }
@@ -425,7 +425,7 @@ xsltRegisterPersistRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
     RVT->prev = NULL;
     RVT->next = (xmlNodePtr) ctxt->persistRVT;
     if (ctxt->persistRVT != NULL)
-    ctxt->persistRVT->prev = (xmlNodePtr) RVT;
+        ctxt->persistRVT->prev = (xmlNodePtr) RVT;
     ctxt->persistRVT = RVT;
     return(0);
 }
@@ -444,19 +444,19 @@ xsltFreeRVTs(xsltTransformContextPtr ctxt)
     xmlDocPtr cur, next;
 
     if (ctxt == NULL)
-    return;
+        return;
     /*
     * Local fragments.
     */
     cur = ctxt->localRVT;
     while (cur != NULL) {
         next = (xmlDocPtr) cur->next;
-    if (cur->_private != NULL) {
-        xsltFreeDocumentKeys(cur->_private);
-        xmlFree(cur->_private);
-    }
-    xmlFreeDoc(cur);
-    cur = next;
+        if (cur->_private != NULL) {
+            xsltFreeDocumentKeys(cur->_private);
+            xmlFree(cur->_private);
+        }
+        xmlFreeDoc(cur);
+        cur = next;
     }
     ctxt->localRVT = NULL;
     /*
@@ -465,12 +465,12 @@ xsltFreeRVTs(xsltTransformContextPtr ctxt)
     cur = ctxt->tmpRVT;
     while (cur != NULL) {
         next = (xmlDocPtr) cur->next;
-    if (cur->_private != NULL) {
-        xsltFreeDocumentKeys(cur->_private);
-        xmlFree(cur->_private);
-    }
-    xmlFreeDoc(cur);
-    cur = next;
+        if (cur->_private != NULL) {
+            xsltFreeDocumentKeys(cur->_private);
+            xmlFree(cur->_private);
+        }
+        xmlFreeDoc(cur);
+        cur = next;
     }
     ctxt->tmpRVT = NULL;
     /*
@@ -479,20 +479,20 @@ xsltFreeRVTs(xsltTransformContextPtr ctxt)
     cur = ctxt->persistRVT;
     while (cur != NULL) {
         next = (xmlDocPtr) cur->next;
-    if (cur->_private != NULL) {
-        xsltFreeDocumentKeys(cur->_private);
-        xmlFree(cur->_private);
-    }
-    xmlFreeDoc(cur);
-    cur = next;
+        if (cur->_private != NULL) {
+            xsltFreeDocumentKeys(cur->_private);
+            xmlFree(cur->_private);
+        }
+        xmlFreeDoc(cur);
+        cur = next;
     }
     ctxt->persistRVT = NULL;
 }
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -510,20 +510,20 @@ xsltNewStackElem(xsltTransformContextPtr ctxt)
     * Reuse a stack item from the cache if available.
     */
     if (ctxt && ctxt->cache->stackItems) {
-    ret = ctxt->cache->stackItems;
-    ctxt->cache->stackItems = ret->next;
-    ret->next = NULL;
-    ctxt->cache->nbStackItems--;
+        ret = ctxt->cache->stackItems;
+        ctxt->cache->stackItems = ret->next;
+        ret->next = NULL;
+        ctxt->cache->nbStackItems--;
 #ifdef XSLT_DEBUG_PROFILE_CACHE
-    ctxt->cache->dbgReusedVars++;
+        ctxt->cache->dbgReusedVars++;
 #endif
-    return(ret);
+        return(ret);
     }
     ret = (xsltStackElemPtr) xmlMalloc(sizeof(xsltStackElem));
     if (ret == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewStackElem : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewStackElem : malloc failed\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltStackElem));
     ret->context = ctxt;
@@ -544,9 +544,9 @@ xsltCopyStackElem(xsltStackElemPtr elem) {
 
     cur = (xsltStackElemPtr) xmlMalloc(sizeof(xsltStackElem));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltCopyStackElem : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltCopyStackElem : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltStackElem));
     cur->context = elem->context;
@@ -567,21 +567,21 @@ xsltCopyStackElem(xsltStackElemPtr elem) {
 static void
 xsltFreeStackElem(xsltStackElemPtr elem) {
     if (elem == NULL)
-    return;
+        return;
     if (elem->value != NULL)
-    xmlXPathFreeObject(elem->value);
+        xmlXPathFreeObject(elem->value);
     /*
     * Release the list of temporary Result Tree Fragments.
     */
     if (elem->context) {
-    xmlDocPtr cur;
+        xmlDocPtr cur;
 
-    while (elem->fragment != NULL) {
-        cur = elem->fragment;
-        elem->fragment = (xmlDocPtr) cur->next;
+        while (elem->fragment != NULL) {
+            cur = elem->fragment;
+            elem->fragment = (xmlDocPtr) cur->next;
 
             if (cur->psvi == XSLT_RVT_LOCAL) {
-        xsltReleaseRVT(elem->context, cur);
+                xsltReleaseRVT(elem->context, cur);
             } else if (cur->psvi == XSLT_RVT_FUNC_RESULT) {
                 xsltRegisterLocalRVT(elem->context, cur);
                 cur->psvi = XSLT_RVT_FUNC_RESULT;
@@ -590,25 +590,25 @@ xsltFreeStackElem(xsltStackElemPtr elem) {
                         "xsltFreeStackElem: Unexpected RVT flag %p\n",
                         cur->psvi);
             }
-    }
+        }
     }
     /*
     * Cache or free the variable structure.
     */
     if (elem->context && (elem->context->cache->nbStackItems < 50)) {
-    /*
-    * Store the item in the cache.
-    */
-    xsltTransformContextPtr ctxt = elem->context;
-    memset(elem, 0, sizeof(xsltStackElem));
-    elem->context = ctxt;
-    elem->next = ctxt->cache->stackItems;
-    ctxt->cache->stackItems = elem;
-    ctxt->cache->nbStackItems++;
+        /*
+        * Store the item in the cache.
+        */
+        xsltTransformContextPtr ctxt = elem->context;
+        memset(elem, 0, sizeof(xsltStackElem));
+        elem->context = ctxt;
+        elem->next = ctxt->cache->stackItems;
+        ctxt->cache->stackItems = elem;
+        ctxt->cache->nbStackItems++;
 #ifdef XSLT_DEBUG_PROFILE_CACHE
-    ctxt->cache->dbgCachedVars++;
+        ctxt->cache->dbgCachedVars++;
 #endif
-    return;
+        return;
     }
     xmlFree(elem);
 }
@@ -630,9 +630,9 @@ xsltFreeStackElemList(xsltStackElemPtr elem) {
     xsltStackElemPtr next;
 
     while (elem != NULL) {
-    next = elem->next;
-    xsltFreeStackElem(elem);
-    elem = next;
+        next = elem->next;
+        xsltFreeStackElem(elem);
+        elem = next;
     }
 }
 
@@ -651,12 +651,12 @@ static int stack_cmp = 0;
 
 static xsltStackElemPtr
 xsltStackLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
-            const xmlChar *nameURI) {
+                const xmlChar *nameURI) {
     int i;
     xsltStackElemPtr cur;
 
     if ((ctxt == NULL) || (name == NULL) || (ctxt->varsNr == 0))
-    return(NULL);
+        return(NULL);
 
     /*
      * Do the lookup from the top of the stack, but
@@ -665,16 +665,16 @@ xsltStackLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
      * come from the disctionnary and hence pointer comparison.
      */
     for (i = ctxt->varsNr; i > ctxt->varsBase; i--) {
-    cur = ctxt->varsTab[i-1];
-    while (cur != NULL) {
-        if ((cur->name == name) && (cur->nameURI == nameURI)) {
+        cur = ctxt->varsTab[i-1];
+        while (cur != NULL) {
+            if ((cur->name == name) && (cur->nameURI == nameURI)) {
 #if 0
-        stack_addr++;
+                stack_addr++;
 #endif
-        return(cur);
+                return(cur);
+            }
+            cur = cur->next;
         }
-        cur = cur->next;
-    }
     }
 
     /*
@@ -686,16 +686,16 @@ xsltStackLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
         nameURI = xmlDictLookup(ctxt->dict, nameURI, -1);
 
     for (i = ctxt->varsNr; i > ctxt->varsBase; i--) {
-    cur = ctxt->varsTab[i-1];
-    while (cur != NULL) {
-        if ((cur->name == name) && (cur->nameURI == nameURI)) {
+        cur = ctxt->varsTab[i-1];
+        while (cur != NULL) {
+            if ((cur->name == name) && (cur->nameURI == nameURI)) {
 #if 0
-        stack_cmp++;
+                stack_cmp++;
 #endif
-        return(cur);
+                return(cur);
+            }
+            cur = cur->next;
         }
-        cur = cur->next;
-    }
     }
 
     return(NULL);
@@ -720,20 +720,20 @@ xsltStackLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
  */
 static int
 xsltCheckStackElem(xsltTransformContextPtr ctxt, const xmlChar *name,
-               const xmlChar *nameURI) {
+                   const xmlChar *nameURI) {
     xsltStackElemPtr cur;
 
     if ((ctxt == NULL) || (name == NULL))
-    return(-1);
+        return(-1);
 
     cur = xsltStackLookup(ctxt, name, nameURI);
     if (cur == NULL)
         return(0);
     if (cur->comp != NULL) {
         if (cur->comp->type == XSLT_FUNC_WITHPARAM)
-        return(3);
-    else if (cur->comp->type == XSLT_FUNC_PARAM)
-        return(2);
+            return(3);
+        else if (cur->comp->type == XSLT_FUNC_PARAM)
+            return(2);
     }
 
     return(1);
@@ -757,34 +757,34 @@ static int
 xsltAddStackElem(xsltTransformContextPtr ctxt, xsltStackElemPtr elem)
 {
     if ((ctxt == NULL) || (elem == NULL))
-    return(-1);
+        return(-1);
 
     do {
-    if (ctxt->varsMax == 0) {
-        ctxt->varsMax = 10;
-        ctxt->varsTab =
-        (xsltStackElemPtr *) xmlMalloc(ctxt->varsMax *
-        sizeof(ctxt->varsTab[0]));
-        if (ctxt->varsTab == NULL) {
-        xmlGenericError(xmlGenericErrorContext, "malloc failed !\n");
-        return (-1);
+        if (ctxt->varsMax == 0) {
+            ctxt->varsMax = 10;
+            ctxt->varsTab =
+                (xsltStackElemPtr *) xmlMalloc(ctxt->varsMax *
+                sizeof(ctxt->varsTab[0]));
+            if (ctxt->varsTab == NULL) {
+                xmlGenericError(xmlGenericErrorContext, "malloc failed !\n");
+                return (-1);
+            }
         }
-    }
-    if (ctxt->varsNr >= ctxt->varsMax) {
-        ctxt->varsMax *= 2;
-        ctxt->varsTab =
-        (xsltStackElemPtr *) xmlRealloc(ctxt->varsTab,
-        ctxt->varsMax *
-        sizeof(ctxt->varsTab[0]));
-        if (ctxt->varsTab == NULL) {
-        xmlGenericError(xmlGenericErrorContext, "realloc failed !\n");
-        return (-1);
+        if (ctxt->varsNr >= ctxt->varsMax) {
+            ctxt->varsMax *= 2;
+            ctxt->varsTab =
+                (xsltStackElemPtr *) xmlRealloc(ctxt->varsTab,
+                ctxt->varsMax *
+                sizeof(ctxt->varsTab[0]));
+            if (ctxt->varsTab == NULL) {
+                xmlGenericError(xmlGenericErrorContext, "realloc failed !\n");
+                return (-1);
+            }
         }
-    }
-    ctxt->varsTab[ctxt->varsNr++] = elem;
-    ctxt->vars = elem;
+        ctxt->varsTab[ctxt->varsNr++] = elem;
+        ctxt->vars = elem;
 
-    elem = elem->next;
+        elem = elem->next;
     } while (elem != NULL);
 
     return(0);
@@ -806,9 +806,9 @@ xsltAddStackElemList(xsltTransformContextPtr ctxt, xsltStackElemPtr elems)
 }
 
 /************************************************************************
- *                                  *
- *          Module interfaces               *
- *                                  *
+ *                                                                      *
+ *                      Module interfaces                               *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -823,11 +823,11 @@ xsltAddStackElemList(xsltTransformContextPtr ctxt, xsltStackElemPtr elems)
  */
 static xmlXPathObjectPtr
 xsltEvalVariable(xsltTransformContextPtr ctxt, xsltStackElemPtr variable,
-             xsltStylePreCompPtr castedComp)
+                 xsltStylePreCompPtr castedComp)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleItemVariablePtr comp =
-    (xsltStyleItemVariablePtr) castedComp;
+        (xsltStyleItemVariablePtr) castedComp;
 #else
     xsltStylePreCompPtr comp = castedComp;
 #endif
@@ -835,7 +835,7 @@ xsltEvalVariable(xsltTransformContextPtr ctxt, xsltStackElemPtr variable,
     xmlNodePtr oldInst;
 
     if ((ctxt == NULL) || (variable == NULL))
-    return(NULL);
+        return(NULL);
 
     /*
     * A variable or parameter are evaluated on demand; thus the
@@ -846,189 +846,189 @@ xsltEvalVariable(xsltTransformContextPtr ctxt, xsltStackElemPtr variable,
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-    "Evaluating variable '%s'\n", variable->name));
+        "Evaluating variable '%s'\n", variable->name));
 #endif
     if (variable->select != NULL) {
-    xmlXPathCompExprPtr xpExpr = NULL;
-    xmlDocPtr oldXPDoc;
-    xmlNodePtr oldXPContextNode;
-    int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
-    xmlNsPtr *oldXPNamespaces;
-    xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
-    xsltStackElemPtr oldVar = ctxt->contextVariable;
-
-    if ((comp != NULL) && (comp->comp != NULL)) {
-        xpExpr = comp->comp;
-    } else {
-        xpExpr = xmlXPathCtxtCompile(ctxt->xpathCtxt, variable->select);
-    }
-    if (xpExpr == NULL)
-        return(NULL);
-    /*
-    * Save context states.
-    */
-    oldXPDoc = xpctxt->doc;
-    oldXPContextNode = xpctxt->node;
-    oldXPProximityPosition = xpctxt->proximityPosition;
-    oldXPContextSize = xpctxt->contextSize;
-    oldXPNamespaces = xpctxt->namespaces;
-    oldXPNsNr = xpctxt->nsNr;
-
-    xpctxt->node = ctxt->node;
-    /*
-    * OPTIMIZE TODO: Lame try to set the context doc.
-    *   Get rid of this somehow in xpath.c.
-    */
-    if ((ctxt->node->type != XML_NAMESPACE_DECL) &&
-        ctxt->node->doc)
-        xpctxt->doc = ctxt->node->doc;
-    /*
-    * BUG TODO: The proximity position and the context size will
-    *  potentially be wrong.
-    *  Example:
-    *  <xsl:template select="foo">
-    *    <xsl:variable name="pos" select="position()"/>
-    *    <xsl:for-each select="bar">
-    *      <xsl:value-of select="$pos"/>
-    *    </xsl:for-each>
-    *  </xsl:template>
-    *  Here the proximity position and context size are changed
-    *  to the context of <xsl:for-each select="bar">, but
-    *  the variable needs to be evaluated in the context of
-    *  <xsl:template select="foo">.
-    */
-    if (comp != NULL) {
-
-#ifdef XSLT_REFACTORED
-        if (comp->inScopeNs != NULL) {
-        xpctxt->namespaces = comp->inScopeNs->list;
-        xpctxt->nsNr = comp->inScopeNs->xpathNumber;
-        } else {
-        xpctxt->namespaces = NULL;
-        xpctxt->nsNr = 0;
-        }
-#else
-        xpctxt->namespaces = comp->nsList;
-        xpctxt->nsNr = comp->nsNr;
-#endif
-    } else {
-        xpctxt->namespaces = NULL;
-        xpctxt->nsNr = 0;
-    }
-
-    /*
-    * We need to mark that we are "selecting" a var's value;
-    * if any tree fragments are created inside the expression,
-    * then those need to be stored inside the variable; otherwise
-    * we'll eventually free still referenced fragments, before
-    * we leave the scope of the variable.
-    */
-    ctxt->contextVariable = variable;
-    variable->flags |= XSLT_VAR_IN_SELECT;
-
-    result = xmlXPathCompiledEval(xpExpr, xpctxt);
-
-    variable->flags ^= XSLT_VAR_IN_SELECT;
-    /*
-    * Restore Context states.
-    */
-    ctxt->contextVariable = oldVar;
-
-    xpctxt->doc = oldXPDoc;
-    xpctxt->node = oldXPContextNode;
-    xpctxt->contextSize = oldXPContextSize;
-    xpctxt->proximityPosition = oldXPProximityPosition;
-    xpctxt->namespaces = oldXPNamespaces;
-    xpctxt->nsNr = oldXPNsNr;
-
-    if ((comp == NULL) || (comp->comp == NULL))
-        xmlXPathFreeCompExpr(xpExpr);
-    if (result == NULL) {
-        xsltTransformError(ctxt, NULL,
-        (comp != NULL) ? comp->inst : NULL,
-        "Failed to evaluate the expression of variable '%s'.\n",
-        variable->name);
-        ctxt->state = XSLT_STATE_STOPPED;
-
-#ifdef WITH_XSLT_DEBUG_VARIABLE
-#ifdef LIBXML_DEBUG_ENABLED
-    } else {
-        if ((xsltGenericDebugContext == stdout) ||
-        (xsltGenericDebugContext == stderr))
-        xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
-                    result, 0);
-#endif
-#endif
-    }
-    } else {
-    if (variable->tree == NULL) {
-        result = xmlXPathNewCString("");
-    } else {
-        if (variable->tree) {
-        xmlDocPtr container;
-        xmlNodePtr oldInsert;
-        xmlDocPtr  oldOutput;
+        xmlXPathCompExprPtr xpExpr = NULL;
+        xmlDocPtr oldXPDoc;
+        xmlNodePtr oldXPContextNode;
+        int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
+        xmlNsPtr *oldXPNamespaces;
+        xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
         xsltStackElemPtr oldVar = ctxt->contextVariable;
 
+        if ((comp != NULL) && (comp->comp != NULL)) {
+            xpExpr = comp->comp;
+        } else {
+            xpExpr = xmlXPathCtxtCompile(ctxt->xpathCtxt, variable->select);
+        }
+        if (xpExpr == NULL)
+            return(NULL);
         /*
-        * Generate a result tree fragment.
+        * Save context states.
         */
-        container = xsltCreateRVT(ctxt);
-        if (container == NULL)
-            goto error;
+        oldXPDoc = xpctxt->doc;
+        oldXPContextNode = xpctxt->node;
+        oldXPProximityPosition = xpctxt->proximityPosition;
+        oldXPContextSize = xpctxt->contextSize;
+        oldXPNamespaces = xpctxt->namespaces;
+        oldXPNsNr = xpctxt->nsNr;
+
+        xpctxt->node = ctxt->node;
         /*
-        * NOTE: Local Result Tree Fragments of params/variables
-        * are not registered globally anymore; the life-time
-        * is not directly dependant of the param/variable itself.
-        *
-        * OLD: xsltRegisterTmpRVT(ctxt, container);
+        * OPTIMIZE TODO: Lame try to set the context doc.
+        *   Get rid of this somehow in xpath.c.
         */
+        if ((ctxt->node->type != XML_NAMESPACE_DECL) &&
+            ctxt->node->doc)
+            xpctxt->doc = ctxt->node->doc;
         /*
-        * Attach the Result Tree Fragment to the variable;
-        * when the variable is freed, it will also free
-        * the Result Tree Fragment.
+        * BUG TODO: The proximity position and the context size will
+        *  potentially be wrong.
+        *  Example:
+        *  <xsl:template select="foo">
+        *    <xsl:variable name="pos" select="position()"/>
+        *    <xsl:for-each select="bar">
+        *      <xsl:value-of select="$pos"/>
+        *    </xsl:for-each>
+        *  </xsl:template>
+        *  Here the proximity position and context size are changed
+        *  to the context of <xsl:for-each select="bar">, but
+        *  the variable needs to be evaluated in the context of
+        *  <xsl:template select="foo">.
         */
-        variable->fragment = container;
+        if (comp != NULL) {
+
+#ifdef XSLT_REFACTORED
+            if (comp->inScopeNs != NULL) {
+                xpctxt->namespaces = comp->inScopeNs->list;
+                xpctxt->nsNr = comp->inScopeNs->xpathNumber;
+            } else {
+                xpctxt->namespaces = NULL;
+                xpctxt->nsNr = 0;
+            }
+#else
+            xpctxt->namespaces = comp->nsList;
+            xpctxt->nsNr = comp->nsNr;
+#endif
+        } else {
+            xpctxt->namespaces = NULL;
+            xpctxt->nsNr = 0;
+        }
+
+        /*
+        * We need to mark that we are "selecting" a var's value;
+        * if any tree fragments are created inside the expression,
+        * then those need to be stored inside the variable; otherwise
+        * we'll eventually free still referenced fragments, before
+        * we leave the scope of the variable.
+        */
+        ctxt->contextVariable = variable;
+        variable->flags |= XSLT_VAR_IN_SELECT;
+
+        result = xmlXPathCompiledEval(xpExpr, xpctxt);
+
+        variable->flags ^= XSLT_VAR_IN_SELECT;
+        /*
+        * Restore Context states.
+        */
+        ctxt->contextVariable = oldVar;
+
+        xpctxt->doc = oldXPDoc;
+        xpctxt->node = oldXPContextNode;
+        xpctxt->contextSize = oldXPContextSize;
+        xpctxt->proximityPosition = oldXPProximityPosition;
+        xpctxt->namespaces = oldXPNamespaces;
+        xpctxt->nsNr = oldXPNsNr;
+
+        if ((comp == NULL) || (comp->comp == NULL))
+            xmlXPathFreeCompExpr(xpExpr);
+        if (result == NULL) {
+            xsltTransformError(ctxt, NULL,
+                (comp != NULL) ? comp->inst : NULL,
+                "Failed to evaluate the expression of variable '%s'.\n",
+                variable->name);
+            ctxt->state = XSLT_STATE_STOPPED;
+
+#ifdef WITH_XSLT_DEBUG_VARIABLE
+#ifdef LIBXML_DEBUG_ENABLED
+        } else {
+            if ((xsltGenericDebugContext == stdout) ||
+                (xsltGenericDebugContext == stderr))
+                xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
+                                        result, 0);
+#endif
+#endif
+        }
+    } else {
+        if (variable->tree == NULL) {
+            result = xmlXPathNewCString("");
+        } else {
+            if (variable->tree) {
+                xmlDocPtr container;
+                xmlNodePtr oldInsert;
+                xmlDocPtr  oldOutput;
+                xsltStackElemPtr oldVar = ctxt->contextVariable;
+
+                /*
+                * Generate a result tree fragment.
+                */
+                container = xsltCreateRVT(ctxt);
+                if (container == NULL)
+                    goto error;
+                /*
+                * NOTE: Local Result Tree Fragments of params/variables
+                * are not registered globally anymore; the life-time
+                * is not directly dependant of the param/variable itself.
+                *
+                * OLD: xsltRegisterTmpRVT(ctxt, container);
+                */
+                /*
+                * Attach the Result Tree Fragment to the variable;
+                * when the variable is freed, it will also free
+                * the Result Tree Fragment.
+                */
+                variable->fragment = container;
                 container->psvi = XSLT_RVT_LOCAL;
 
-        oldOutput = ctxt->output;
-        oldInsert = ctxt->insert;
+                oldOutput = ctxt->output;
+                oldInsert = ctxt->insert;
 
-        ctxt->output = container;
-        ctxt->insert = (xmlNodePtr) container;
-        ctxt->contextVariable = variable;
-        /*
-        * Process the sequence constructor (variable->tree).
-        * The resulting tree will be held by @container.
-        */
-        xsltApplyOneTemplate(ctxt, ctxt->node, variable->tree,
-            NULL, NULL);
+                ctxt->output = container;
+                ctxt->insert = (xmlNodePtr) container;
+                ctxt->contextVariable = variable;
+                /*
+                * Process the sequence constructor (variable->tree).
+                * The resulting tree will be held by @container.
+                */
+                xsltApplyOneTemplate(ctxt, ctxt->node, variable->tree,
+                    NULL, NULL);
 
-        ctxt->contextVariable = oldVar;
-        ctxt->insert = oldInsert;
-        ctxt->output = oldOutput;
+                ctxt->contextVariable = oldVar;
+                ctxt->insert = oldInsert;
+                ctxt->output = oldOutput;
 
-        result = xmlXPathNewValueTree((xmlNodePtr) container);
-        }
-        if (result == NULL) {
-        result = xmlXPathNewCString("");
-        } else {
-        /*
-        * Freeing is not handled there anymore.
-        * QUESTION TODO: What does the above comment mean?
-        */
-            result->boolval = 0;
-        }
+                result = xmlXPathNewValueTree((xmlNodePtr) container);
+            }
+            if (result == NULL) {
+                result = xmlXPathNewCString("");
+            } else {
+                /*
+                * Freeing is not handled there anymore.
+                * QUESTION TODO: What does the above comment mean?
+                */
+                result->boolval = 0;
+            }
 #ifdef WITH_XSLT_DEBUG_VARIABLE
 #ifdef LIBXML_DEBUG_ENABLED
 
-        if ((xsltGenericDebugContext == stdout) ||
-        (xsltGenericDebugContext == stderr))
-        xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
-                    result, 0);
+            if ((xsltGenericDebugContext == stdout) ||
+                (xsltGenericDebugContext == stderr))
+                xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
+                                        result, 0);
 #endif
 #endif
-    }
+        }
     }
 
 error:
@@ -1060,14 +1060,14 @@ xsltEvalGlobalVariable(xsltStackElemPtr elem, xsltTransformContextPtr ctxt)
 #endif
 
     if ((ctxt == NULL) || (elem == NULL))
-    return(NULL);
+        return(NULL);
     if (elem->computed)
-    return(elem->value);
+        return(elem->value);
 
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-    "Evaluating global variable %s\n", elem->name));
+        "Evaluating global variable %s\n", elem->name));
 #endif
 
 #ifdef WITH_DEBUGGER
@@ -1091,91 +1091,91 @@ xsltEvalGlobalVariable(xsltStackElemPtr elem, xsltTransformContextPtr ctxt)
     *  are provided by the user.
     */
     if (elem->select != NULL) {
-    xmlXPathCompExprPtr xpExpr = NULL;
-    xmlDocPtr oldXPDoc;
-    xmlNodePtr oldXPContextNode;
-    int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
-    xmlNsPtr *oldXPNamespaces;
-    xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
+        xmlXPathCompExprPtr xpExpr = NULL;
+        xmlDocPtr oldXPDoc;
+        xmlNodePtr oldXPContextNode;
+        int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
+        xmlNsPtr *oldXPNamespaces;
+        xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
 
-    if ((comp != NULL) && (comp->comp != NULL)) {
-        xpExpr = comp->comp;
-    } else {
-        xpExpr = xmlXPathCtxtCompile(ctxt->xpathCtxt, elem->select);
-    }
-    if (xpExpr == NULL)
-        goto error;
+        if ((comp != NULL) && (comp->comp != NULL)) {
+            xpExpr = comp->comp;
+        } else {
+            xpExpr = xmlXPathCtxtCompile(ctxt->xpathCtxt, elem->select);
+        }
+        if (xpExpr == NULL)
+            goto error;
 
 
-    if (comp != NULL)
-        ctxt->inst = comp->inst;
-    else
-        ctxt->inst = NULL;
-    /*
-    * SPEC XSLT 1.0:
-    * "At top-level, the expression or template specifying the
-    *  variable value is evaluated with the same context as that used
-    *  to process the root node of the source document: the current
-    *  node is the root node of the source document and the current
-    *  node list is a list containing just the root node of the source
-    *  document."
-    */
-    /*
-    * Save context states.
-    */
-    oldXPDoc = xpctxt->doc;
-    oldXPContextNode = xpctxt->node;
-    oldXPProximityPosition = xpctxt->proximityPosition;
-    oldXPContextSize = xpctxt->contextSize;
-    oldXPNamespaces = xpctxt->namespaces;
-    oldXPNsNr = xpctxt->nsNr;
+        if (comp != NULL)
+            ctxt->inst = comp->inst;
+        else
+            ctxt->inst = NULL;
+        /*
+        * SPEC XSLT 1.0:
+        * "At top-level, the expression or template specifying the
+        *  variable value is evaluated with the same context as that used
+        *  to process the root node of the source document: the current
+        *  node is the root node of the source document and the current
+        *  node list is a list containing just the root node of the source
+        *  document."
+        */
+        /*
+        * Save context states.
+        */
+        oldXPDoc = xpctxt->doc;
+        oldXPContextNode = xpctxt->node;
+        oldXPProximityPosition = xpctxt->proximityPosition;
+        oldXPContextSize = xpctxt->contextSize;
+        oldXPNamespaces = xpctxt->namespaces;
+        oldXPNsNr = xpctxt->nsNr;
 
-    xpctxt->node = ctxt->initialContextNode;
-    xpctxt->doc = ctxt->initialContextDoc;
-    xpctxt->contextSize = 1;
-    xpctxt->proximityPosition = 1;
+        xpctxt->node = ctxt->initialContextNode;
+        xpctxt->doc = ctxt->initialContextDoc;
+        xpctxt->contextSize = 1;
+        xpctxt->proximityPosition = 1;
 
-    if (comp != NULL) {
+        if (comp != NULL) {
 
 #ifdef XSLT_REFACTORED
-        if (comp->inScopeNs != NULL) {
-        xpctxt->namespaces = comp->inScopeNs->list;
-        xpctxt->nsNr = comp->inScopeNs->xpathNumber;
-        } else {
-        xpctxt->namespaces = NULL;
-        xpctxt->nsNr = 0;
-        }
+            if (comp->inScopeNs != NULL) {
+                xpctxt->namespaces = comp->inScopeNs->list;
+                xpctxt->nsNr = comp->inScopeNs->xpathNumber;
+            } else {
+                xpctxt->namespaces = NULL;
+                xpctxt->nsNr = 0;
+            }
 #else
-        xpctxt->namespaces = comp->nsList;
-        xpctxt->nsNr = comp->nsNr;
+            xpctxt->namespaces = comp->nsList;
+            xpctxt->nsNr = comp->nsNr;
 #endif
-    } else {
-        xpctxt->namespaces = NULL;
-        xpctxt->nsNr = 0;
-    }
+        } else {
+            xpctxt->namespaces = NULL;
+            xpctxt->nsNr = 0;
+        }
 
-    result = xmlXPathCompiledEval(xpExpr, xpctxt);
+        result = xmlXPathCompiledEval(xpExpr, xpctxt);
 
-    /*
-    * Restore Context states.
-    */
-    xpctxt->doc = oldXPDoc;
-    xpctxt->node = oldXPContextNode;
-    xpctxt->contextSize = oldXPContextSize;
-    xpctxt->proximityPosition = oldXPProximityPosition;
-    xpctxt->namespaces = oldXPNamespaces;
-    xpctxt->nsNr = oldXPNsNr;
+        /*
+        * Restore Context states.
+        */
+        xpctxt->doc = oldXPDoc;
+        xpctxt->node = oldXPContextNode;
+        xpctxt->contextSize = oldXPContextSize;
+        xpctxt->proximityPosition = oldXPProximityPosition;
+        xpctxt->namespaces = oldXPNamespaces;
+        xpctxt->nsNr = oldXPNsNr;
 
-    if ((comp == NULL) || (comp->comp == NULL))
-        xmlXPathFreeCompExpr(xpExpr);
-    if (result == NULL) {
-        if (comp == NULL)
-        xsltTransformError(ctxt, NULL, NULL,
-            "Evaluating global variable %s failed\n", elem->name);
-        else
-        xsltTransformError(ctxt, NULL, comp->inst,
-            "Evaluating global variable %s failed\n", elem->name);
-        ctxt->state = XSLT_STATE_STOPPED;
+        if ((comp == NULL) || (comp->comp == NULL))
+            xmlXPathFreeCompExpr(xpExpr);
+        if (result == NULL) {
+            if (comp == NULL)
+                xsltTransformError(ctxt, NULL, NULL,
+                    "Evaluating global variable %s failed\n", elem->name);
+            else
+                xsltTransformError(ctxt, NULL, comp->inst,
+                    "Evaluating global variable %s failed\n", elem->name);
+            ctxt->state = XSLT_STATE_STOPPED;
             goto error;
         }
 
@@ -1187,73 +1187,73 @@ xsltEvalGlobalVariable(xsltStackElemPtr elem, xsltTransformContextPtr ctxt)
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
 #ifdef LIBXML_DEBUG_ENABLED
-    if ((xsltGenericDebugContext == stdout) ||
-        (xsltGenericDebugContext == stderr))
-        xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
-                    result, 0);
+        if ((xsltGenericDebugContext == stdout) ||
+            (xsltGenericDebugContext == stderr))
+            xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
+                                    result, 0);
 #endif
 #endif
     } else {
-    if (elem->tree == NULL) {
-        result = xmlXPathNewCString("");
-    } else {
-        xmlDocPtr container;
-        xmlNodePtr oldInsert;
-        xmlDocPtr  oldOutput, oldXPDoc;
-        /*
-        * Generate a result tree fragment.
-        */
-        container = xsltCreateRVT(ctxt);
-        if (container == NULL)
-        goto error;
-        /*
-        * Let the lifetime of the tree fragment be handled by
-        * the Libxslt's garbage collector.
-        */
-        xsltRegisterPersistRVT(ctxt, container);
-
-        oldOutput = ctxt->output;
-        oldInsert = ctxt->insert;
-
-        oldXPDoc = ctxt->xpathCtxt->doc;
-
-        ctxt->output = container;
-        ctxt->insert = (xmlNodePtr) container;
-
-        ctxt->xpathCtxt->doc = ctxt->initialContextDoc;
-        /*
-        * Process the sequence constructor.
-        */
-        xsltApplyOneTemplate(ctxt, ctxt->node, elem->tree, NULL, NULL);
-
-        ctxt->xpathCtxt->doc = oldXPDoc;
-
-        ctxt->insert = oldInsert;
-        ctxt->output = oldOutput;
-
-        result = xmlXPathNewValueTree((xmlNodePtr) container);
-        if (result == NULL) {
-        result = xmlXPathNewCString("");
+        if (elem->tree == NULL) {
+            result = xmlXPathNewCString("");
         } else {
-            result->boolval = 0; /* Freeing is not handled there anymore */
-        }
+            xmlDocPtr container;
+            xmlNodePtr oldInsert;
+            xmlDocPtr  oldOutput, oldXPDoc;
+            /*
+            * Generate a result tree fragment.
+            */
+            container = xsltCreateRVT(ctxt);
+            if (container == NULL)
+                goto error;
+            /*
+            * Let the lifetime of the tree fragment be handled by
+            * the Libxslt's garbage collector.
+            */
+            xsltRegisterPersistRVT(ctxt, container);
+
+            oldOutput = ctxt->output;
+            oldInsert = ctxt->insert;
+
+            oldXPDoc = ctxt->xpathCtxt->doc;
+
+            ctxt->output = container;
+            ctxt->insert = (xmlNodePtr) container;
+
+            ctxt->xpathCtxt->doc = ctxt->initialContextDoc;
+            /*
+            * Process the sequence constructor.
+            */
+            xsltApplyOneTemplate(ctxt, ctxt->node, elem->tree, NULL, NULL);
+
+            ctxt->xpathCtxt->doc = oldXPDoc;
+
+            ctxt->insert = oldInsert;
+            ctxt->output = oldOutput;
+
+            result = xmlXPathNewValueTree((xmlNodePtr) container);
+            if (result == NULL) {
+                result = xmlXPathNewCString("");
+            } else {
+                result->boolval = 0; /* Freeing is not handled there anymore */
+            }
 #ifdef WITH_XSLT_DEBUG_VARIABLE
 #ifdef LIBXML_DEBUG_ENABLED
-        if ((xsltGenericDebugContext == stdout) ||
-        (xsltGenericDebugContext == stderr))
-        xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
-                    result, 0);
+            if ((xsltGenericDebugContext == stdout) ||
+                (xsltGenericDebugContext == stderr))
+                xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
+                                        result, 0);
 #endif
 #endif
-    }
+        }
     }
 
 error:
     elem->name = oldVarName;
     ctxt->inst = oldInst;
     if (result != NULL) {
-    elem->value = result;
-    elem->computed = 1;
+        elem->value = result;
+        elem->computed = 1;
     }
     return(result);
 }
@@ -1280,60 +1280,60 @@ xsltEvalGlobalVariables(xsltTransformContextPtr ctxt) {
     xsltStylesheetPtr style;
 
     if ((ctxt == NULL) || (ctxt->document == NULL))
-    return(-1);
+        return(-1);
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-    "Registering global variables\n"));
+        "Registering global variables\n"));
 #endif
     /*
      * Walk the list from the stylesheets and populate the hash table
      */
     style = ctxt->style;
     while (style != NULL) {
-    elem = style->variables;
+        elem = style->variables;
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    if ((style->doc != NULL) && (style->doc->URL != NULL)) {
-        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-                 "Registering global variables from %s\n",
-                     style->doc->URL));
-    }
+        if ((style->doc != NULL) && (style->doc->URL != NULL)) {
+            XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                             "Registering global variables from %s\n",
+                             style->doc->URL));
+        }
 #endif
 
-    while (elem != NULL) {
-        xsltStackElemPtr def;
+        while (elem != NULL) {
+            xsltStackElemPtr def;
 
-        /*
-         * Global variables are stored in the variables pool.
-         */
-        def = (xsltStackElemPtr)
-            xmlHashLookup2(ctxt->globalVars,
-                         elem->name, elem->nameURI);
-        if (def == NULL) {
+            /*
+             * Global variables are stored in the variables pool.
+             */
+            def = (xsltStackElemPtr)
+                    xmlHashLookup2(ctxt->globalVars,
+                                 elem->name, elem->nameURI);
+            if (def == NULL) {
 
-        def = xsltCopyStackElem(elem);
-        xmlHashAddEntry2(ctxt->globalVars,
-                 elem->name, elem->nameURI, def);
-        } else if ((elem->comp != NULL) &&
-               (elem->comp->type == XSLT_FUNC_VARIABLE)) {
-        /*
-         * Redefinition of variables from a different stylesheet
-         * should not generate a message.
-         */
-        if ((elem->comp->inst != NULL) &&
-            (def->comp != NULL) && (def->comp->inst != NULL) &&
-            (elem->comp->inst->doc == def->comp->inst->doc))
-        {
-            xsltTransformError(ctxt, style, elem->comp->inst,
-            "Global variable %s already defined\n", elem->name);
-            if (style != NULL) style->errors++;
+                def = xsltCopyStackElem(elem);
+                xmlHashAddEntry2(ctxt->globalVars,
+                                 elem->name, elem->nameURI, def);
+            } else if ((elem->comp != NULL) &&
+                       (elem->comp->type == XSLT_FUNC_VARIABLE)) {
+                /*
+                 * Redefinition of variables from a different stylesheet
+                 * should not generate a message.
+                 */
+                if ((elem->comp->inst != NULL) &&
+                    (def->comp != NULL) && (def->comp->inst != NULL) &&
+                    (elem->comp->inst->doc == def->comp->inst->doc))
+                {
+                    xsltTransformError(ctxt, style, elem->comp->inst,
+                        "Global variable %s already defined\n", elem->name);
+                    if (style != NULL) style->errors++;
+                }
+            }
+            elem = elem->next;
         }
-        }
-        elem = elem->next;
-    }
 
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
 
     /*
@@ -1361,61 +1361,61 @@ xsltEvalGlobalVariables(xsltTransformContextPtr ctxt) {
  */
 static int
 xsltRegisterGlobalVariable(xsltStylesheetPtr style, const xmlChar *name,
-             const xmlChar *ns_uri, const xmlChar *sel,
-             xmlNodePtr tree, xsltStylePreCompPtr comp,
-             const xmlChar *value) {
+                     const xmlChar *ns_uri, const xmlChar *sel,
+                     xmlNodePtr tree, xsltStylePreCompPtr comp,
+                     const xmlChar *value) {
     xsltStackElemPtr elem, tmp;
     if (style == NULL)
-    return(-1);
+        return(-1);
     if (name == NULL)
-    return(-1);
+        return(-1);
     if (comp == NULL)
-    return(-1);
+        return(-1);
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     if (comp->type == XSLT_FUNC_PARAM)
-    xsltGenericDebug(xsltGenericDebugContext,
-             "Defining global param %s\n", name);
+        xsltGenericDebug(xsltGenericDebugContext,
+                         "Defining global param %s\n", name);
     else
-    xsltGenericDebug(xsltGenericDebugContext,
-             "Defining global variable %s\n", name);
+        xsltGenericDebug(xsltGenericDebugContext,
+                         "Defining global variable %s\n", name);
 #endif
 
     elem = xsltNewStackElem(NULL);
     if (elem == NULL)
-    return(-1);
+        return(-1);
     elem->comp = comp;
     elem->name = xmlDictLookup(style->dict, name, -1);
     elem->select = xmlDictLookup(style->dict, sel, -1);
     if (ns_uri)
-    elem->nameURI = xmlDictLookup(style->dict, ns_uri, -1);
+        elem->nameURI = xmlDictLookup(style->dict, ns_uri, -1);
     elem->tree = tree;
     tmp = style->variables;
     if (tmp == NULL) {
-    elem->next = NULL;
-    style->variables = elem;
+        elem->next = NULL;
+        style->variables = elem;
     } else {
-    while (tmp != NULL) {
-        if ((elem->comp->type == XSLT_FUNC_VARIABLE) &&
-        (tmp->comp->type == XSLT_FUNC_VARIABLE) &&
-        (xmlStrEqual(elem->name, tmp->name)) &&
-        ((elem->nameURI == tmp->nameURI) ||
-         (xmlStrEqual(elem->nameURI, tmp->nameURI))))
-        {
-        xsltTransformError(NULL, style, comp->inst,
-        "redefinition of global variable %s\n", elem->name);
-        style->errors++;
+        while (tmp != NULL) {
+            if ((elem->comp->type == XSLT_FUNC_VARIABLE) &&
+                (tmp->comp->type == XSLT_FUNC_VARIABLE) &&
+                (xmlStrEqual(elem->name, tmp->name)) &&
+                ((elem->nameURI == tmp->nameURI) ||
+                 (xmlStrEqual(elem->nameURI, tmp->nameURI))))
+            {
+                xsltTransformError(NULL, style, comp->inst,
+                "redefinition of global variable %s\n", elem->name);
+                style->errors++;
+            }
+            if (tmp->next == NULL)
+                break;
+            tmp = tmp->next;
         }
-        if (tmp->next == NULL)
-            break;
-        tmp = tmp->next;
-    }
-    elem->next = NULL;
-    tmp->next = elem;
+        elem->next = NULL;
+        tmp->next = elem;
     }
     if (value != NULL) {
-    elem->computed = 1;
-    elem->value = xmlXPathNewString(value);
+        elem->computed = 1;
+        elem->value = xmlXPathNewString(value);
     }
     return(0);
 }
@@ -1454,9 +1454,9 @@ xsltRegisterGlobalVariable(xsltStylesheetPtr style, const xmlChar *name,
 static
 int
 xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
-                     const xmlChar * name,
-                 const xmlChar * value,
-                 int eval) {
+                             const xmlChar * name,
+                             const xmlChar * value,
+                             int eval) {
 
     xsltStylesheetPtr style;
     const xmlChar *prefix;
@@ -1469,17 +1469,17 @@ xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
     void *res_ptr;
 
     if (ctxt == NULL)
-    return(-1);
+        return(-1);
     if (name == NULL)
-    return(0);
+        return(0);
     if (value == NULL)
-    return(0);
+        return(0);
 
     style = ctxt->style;
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-        "Evaluating user parameter %s=%s\n", name, value));
+            "Evaluating user parameter %s=%s\n", name, value));
 #endif
 
     /*
@@ -1517,30 +1517,30 @@ xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
     }
 
     if (name == NULL)
-    return (-1);
+        return (-1);
 
     res_ptr = xmlHashLookup2(ctxt->globalVars, name, href);
     if (res_ptr != 0) {
-    xsltTransformError(ctxt, style, NULL,
-        "Global parameter %s already defined\n", name);
+        xsltTransformError(ctxt, style, NULL,
+            "Global parameter %s already defined\n", name);
     }
     if (ctxt->globalVars == NULL)
-    ctxt->globalVars = xmlHashCreate(20);
+        ctxt->globalVars = xmlHashCreate(20);
 
     /*
      * do not overwrite variables with parameters from the command line
      */
     while (style != NULL) {
         elem = ctxt->style->variables;
-    while (elem != NULL) {
-        if ((elem->comp != NULL) &&
-            (elem->comp->type == XSLT_FUNC_VARIABLE) &&
-        (xmlStrEqual(elem->name, name)) &&
-        (xmlStrEqual(elem->nameURI, href))) {
-        return(0);
-        }
+        while (elem != NULL) {
+            if ((elem->comp != NULL) &&
+                (elem->comp->type == XSLT_FUNC_VARIABLE) &&
+                (xmlStrEqual(elem->name, name)) &&
+                (xmlStrEqual(elem->nameURI, href))) {
+                return(0);
+            }
             elem = elem->next;
-    }
+        }
         style = xsltNextImport(style);
     }
     style = ctxt->style;
@@ -1553,63 +1553,63 @@ xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
     result = NULL;
     if (eval != 0) {
         xpExpr = xmlXPathCtxtCompile(ctxt->xpathCtxt, value);
-    if (xpExpr != NULL) {
-        xmlDocPtr oldXPDoc;
-        xmlNodePtr oldXPContextNode;
-        int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
-        xmlNsPtr *oldXPNamespaces;
-        xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
+        if (xpExpr != NULL) {
+            xmlDocPtr oldXPDoc;
+            xmlNodePtr oldXPContextNode;
+            int oldXPProximityPosition, oldXPContextSize, oldXPNsNr;
+            xmlNsPtr *oldXPNamespaces;
+            xmlXPathContextPtr xpctxt = ctxt->xpathCtxt;
 
-        /*
-        * Save context states.
-        */
-        oldXPDoc = xpctxt->doc;
-        oldXPContextNode = xpctxt->node;
-        oldXPProximityPosition = xpctxt->proximityPosition;
-        oldXPContextSize = xpctxt->contextSize;
-        oldXPNamespaces = xpctxt->namespaces;
-        oldXPNsNr = xpctxt->nsNr;
+            /*
+            * Save context states.
+            */
+            oldXPDoc = xpctxt->doc;
+            oldXPContextNode = xpctxt->node;
+            oldXPProximityPosition = xpctxt->proximityPosition;
+            oldXPContextSize = xpctxt->contextSize;
+            oldXPNamespaces = xpctxt->namespaces;
+            oldXPNsNr = xpctxt->nsNr;
 
-        /*
-        * SPEC XSLT 1.0:
-        * "At top-level, the expression or template specifying the
-        *  variable value is evaluated with the same context as that used
-        *  to process the root node of the source document: the current
-        *  node is the root node of the source document and the current
-        *  node list is a list containing just the root node of the source
-        *  document."
-        */
-        xpctxt->doc = ctxt->initialContextDoc;
-        xpctxt->node = ctxt->initialContextNode;
-        xpctxt->contextSize = 1;
-        xpctxt->proximityPosition = 1;
-        /*
-        * There is really no in scope namespace for parameters on the
-        * command line.
-        */
-        xpctxt->namespaces = NULL;
-        xpctxt->nsNr = 0;
+            /*
+            * SPEC XSLT 1.0:
+            * "At top-level, the expression or template specifying the
+            *  variable value is evaluated with the same context as that used
+            *  to process the root node of the source document: the current
+            *  node is the root node of the source document and the current
+            *  node list is a list containing just the root node of the source
+            *  document."
+            */
+            xpctxt->doc = ctxt->initialContextDoc;
+            xpctxt->node = ctxt->initialContextNode;
+            xpctxt->contextSize = 1;
+            xpctxt->proximityPosition = 1;
+            /*
+            * There is really no in scope namespace for parameters on the
+            * command line.
+            */
+            xpctxt->namespaces = NULL;
+            xpctxt->nsNr = 0;
 
-        result = xmlXPathCompiledEval(xpExpr, xpctxt);
+            result = xmlXPathCompiledEval(xpExpr, xpctxt);
 
-        /*
-        * Restore Context states.
-        */
-        xpctxt->doc = oldXPDoc;
-        xpctxt->node = oldXPContextNode;
-        xpctxt->contextSize = oldXPContextSize;
-        xpctxt->proximityPosition = oldXPProximityPosition;
-        xpctxt->namespaces = oldXPNamespaces;
-        xpctxt->nsNr = oldXPNsNr;
+            /*
+            * Restore Context states.
+            */
+            xpctxt->doc = oldXPDoc;
+            xpctxt->node = oldXPContextNode;
+            xpctxt->contextSize = oldXPContextSize;
+            xpctxt->proximityPosition = oldXPProximityPosition;
+            xpctxt->namespaces = oldXPNamespaces;
+            xpctxt->nsNr = oldXPNsNr;
 
-        xmlXPathFreeCompExpr(xpExpr);
-    }
-    if (result == NULL) {
-        xsltTransformError(ctxt, style, NULL,
-        "Evaluating user parameter %s failed\n", name);
-        ctxt->state = XSLT_STATE_STOPPED;
-        return(-1);
-    }
+            xmlXPathFreeCompExpr(xpExpr);
+        }
+        if (result == NULL) {
+            xsltTransformError(ctxt, style, NULL,
+                "Evaluating user parameter %s failed\n", name);
+            ctxt->state = XSLT_STATE_STOPPED;
+            return(-1);
+        }
     }
 
     /*
@@ -1627,25 +1627,25 @@ xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
 #ifdef LIBXML_DEBUG_ENABLED
     if ((xsltGenericDebugContext == stdout) ||
         (xsltGenericDebugContext == stderr))
-        xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
-                    result, 0);
+            xmlXPathDebugDumpObject((FILE *)xsltGenericDebugContext,
+                                    result, 0);
 #endif
 #endif
 
     elem = xsltNewStackElem(NULL);
     if (elem != NULL) {
-    elem->name = name;
-    elem->select = xmlDictLookup(ctxt->dict, value, -1);
-    if (href != NULL)
-        elem->nameURI = xmlDictLookup(ctxt->dict, href, -1);
-    elem->tree = NULL;
-    elem->computed = 1;
-    if (eval == 0) {
-        elem->value = xmlXPathNewString(value);
-    }
-    else {
-        elem->value = result;
-    }
+        elem->name = name;
+        elem->select = xmlDictLookup(ctxt->dict, value, -1);
+        if (href != NULL)
+            elem->nameURI = xmlDictLookup(ctxt->dict, href, -1);
+        elem->tree = NULL;
+        elem->computed = 1;
+        if (eval == 0) {
+            elem->value = xmlXPathNewString(value);
+        }
+        else {
+            elem->value = result;
+        }
     }
 
     /*
@@ -1654,9 +1654,9 @@ xsltProcessUserParamInternal(xsltTransformContextPtr ctxt,
 
     res = xmlHashAddEntry2(ctxt->globalVars, name, href, elem);
     if (res != 0) {
-    xsltFreeStackElem(elem);
-    xsltTransformError(ctxt, style, NULL,
-        "Global parameter %s already defined\n", name);
+        xsltFreeStackElem(elem);
+        xsltTransformError(ctxt, style, NULL,
+            "Global parameter %s already defined\n", name);
     }
     return(0);
 }
@@ -1683,12 +1683,12 @@ xsltEvalUserParams(xsltTransformContextPtr ctxt, const char **params) {
     const xmlChar *value;
 
     if (params == NULL)
-    return(0);
+        return(0);
     while (params[indx] != NULL) {
-    name = (const xmlChar *) params[indx++];
-    value = (const xmlChar *) params[indx++];
-    if (xsltEvalOneUserParam(ctxt, name, value) != 0)
-        return(-1);
+        name = (const xmlChar *) params[indx++];
+        value = (const xmlChar *) params[indx++];
+        if (xsltEvalOneUserParam(ctxt, name, value) != 0)
+            return(-1);
     }
     return 0;
 }
@@ -1713,12 +1713,12 @@ xsltQuoteUserParams(xsltTransformContextPtr ctxt, const char **params) {
     const xmlChar *value;
 
     if (params == NULL)
-    return(0);
+        return(0);
     while (params[indx] != NULL) {
-    name = (const xmlChar *) params[indx++];
-    value = (const xmlChar *) params[indx++];
-    if (xsltQuoteOneUserParam(ctxt, name, value) != 0)
-        return(-1);
+        name = (const xmlChar *) params[indx++];
+        value = (const xmlChar *) params[indx++];
+        if (xsltQuoteOneUserParam(ctxt, name, value) != 0)
+            return(-1);
     }
     return 0;
 }
@@ -1743,10 +1743,10 @@ xsltQuoteUserParams(xsltTransformContextPtr ctxt, const char **params) {
 
 int
 xsltEvalOneUserParam(xsltTransformContextPtr ctxt,
-             const xmlChar * name,
-             const xmlChar * value) {
+                     const xmlChar * name,
+                     const xmlChar * value) {
     return xsltProcessUserParamInternal(ctxt, name, value,
-                                1 /* xpath eval ? */);
+                                        1 /* xpath eval ? */);
 }
 
 /**
@@ -1764,10 +1764,10 @@ xsltEvalOneUserParam(xsltTransformContextPtr ctxt,
 
 int
 xsltQuoteOneUserParam(xsltTransformContextPtr ctxt,
-             const xmlChar * name,
-             const xmlChar * value) {
+                         const xmlChar * name,
+                         const xmlChar * value) {
     return xsltProcessUserParamInternal(ctxt, name, value,
-                    0 /* xpath eval ? */);
+                                        0 /* xpath eval ? */);
 }
 
 /**
@@ -1782,12 +1782,12 @@ xsltQuoteOneUserParam(xsltTransformContextPtr ctxt,
  */
 static xsltStackElemPtr
 xsltBuildVariable(xsltTransformContextPtr ctxt,
-          xsltStylePreCompPtr castedComp,
-          xmlNodePtr tree)
+                  xsltStylePreCompPtr castedComp,
+                  xmlNodePtr tree)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleBasicItemVariablePtr comp =
-    (xsltStyleBasicItemVariablePtr) castedComp;
+        (xsltStyleBasicItemVariablePtr) castedComp;
 #else
     xsltStylePreCompPtr comp = castedComp;
 #endif
@@ -1795,23 +1795,23 @@ xsltBuildVariable(xsltTransformContextPtr ctxt,
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-             "Building variable %s", comp->name));
+                     "Building variable %s", comp->name));
     if (comp->select != NULL)
-    XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-             " select %s", comp->select));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                         " select %s", comp->select));
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext, "\n"));
 #endif
 
     elem = xsltNewStackElem(ctxt);
     if (elem == NULL)
-    return(NULL);
+        return(NULL);
     elem->comp = (xsltStylePreCompPtr) comp;
     elem->name = comp->name;
     elem->select = comp->select;
     elem->nameURI = comp->ns;
     elem->tree = tree;
     elem->value = xsltEvalVariable(ctxt, elem,
-    (xsltStylePreCompPtr) comp);
+        (xsltStylePreCompPtr) comp);
     elem->computed = 1;
     return(elem);
 }
@@ -1829,12 +1829,12 @@ xsltBuildVariable(xsltTransformContextPtr ctxt,
  */
 static int
 xsltRegisterVariable(xsltTransformContextPtr ctxt,
-             xsltStylePreCompPtr castedComp,
-             xmlNodePtr tree, int isParam)
+                     xsltStylePreCompPtr castedComp,
+                     xmlNodePtr tree, int isParam)
 {
 #ifdef XSLT_REFACTORED
     xsltStyleBasicItemVariablePtr comp =
-    (xsltStyleBasicItemVariablePtr) castedComp;
+        (xsltStyleBasicItemVariablePtr) castedComp;
 #else
     xsltStylePreCompPtr comp = castedComp;
     int present;
@@ -1850,24 +1850,24 @@ xsltRegisterVariable(xsltTransformContextPtr ctxt,
 #else
     present = xsltCheckStackElem(ctxt, comp->name, comp->ns);
     if (isParam == 0) {
-    if ((present != 0) && (present != 3)) {
-        /* TODO: report QName. */
-        xsltTransformError(ctxt, NULL, comp->inst,
-        "XSLT-variable: Redefinition of variable '%s'.\n", comp->name);
-        return(0);
-    }
+        if ((present != 0) && (present != 3)) {
+            /* TODO: report QName. */
+            xsltTransformError(ctxt, NULL, comp->inst,
+                "XSLT-variable: Redefinition of variable '%s'.\n", comp->name);
+            return(0);
+        }
     } else if (present != 0) {
-    if ((present == 1) || (present == 2)) {
-        /* TODO: report QName. */
-        xsltTransformError(ctxt, NULL, comp->inst,
-        "XSLT-param: Redefinition of parameter '%s'.\n", comp->name);
-        return(0);
-    }
+        if ((present == 1) || (present == 2)) {
+            /* TODO: report QName. */
+            xsltTransformError(ctxt, NULL, comp->inst,
+                "XSLT-param: Redefinition of parameter '%s'.\n", comp->name);
+            return(0);
+        }
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-         "param %s defined by caller\n", comp->name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                 "param %s defined by caller\n", comp->name));
 #endif
-    return(0);
+        return(0);
     }
 #endif /* else of XSLT_REFACTORED */
 
@@ -1889,7 +1889,7 @@ xsltRegisterVariable(xsltTransformContextPtr ctxt,
  */
 static xmlXPathObjectPtr
 xsltGlobalVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
-                 const xmlChar *ns_uri) {
+                         const xmlChar *ns_uri) {
     xsltStackElemPtr elem;
     xmlXPathObjectPtr ret = NULL;
 
@@ -1897,29 +1897,29 @@ xsltGlobalVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
      * Lookup the global variables in XPath global variable hash table
      */
     if ((ctxt->xpathCtxt == NULL) || (ctxt->globalVars == NULL))
-    return(NULL);
+        return(NULL);
     elem = (xsltStackElemPtr)
-        xmlHashLookup2(ctxt->globalVars, name, ns_uri);
+            xmlHashLookup2(ctxt->globalVars, name, ns_uri);
     if (elem == NULL) {
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-             "global variable not found %s\n", name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                         "global variable not found %s\n", name));
 #endif
-    return(NULL);
+        return(NULL);
     }
     /*
     * URGENT TODO: Move the detection of recursive definitions
     * to compile-time.
     */
     if (elem->computed == 0) {
-    if (elem->name == xsltComputingGlobalVarMarker) {
-        xsltTransformError(ctxt, NULL, elem->comp->inst,
-        "Recursive definition of %s\n", name);
-        return(NULL);
-    }
-    ret = xsltEvalGlobalVariable(elem, ctxt);
+        if (elem->name == xsltComputingGlobalVarMarker) {
+            xsltTransformError(ctxt, NULL, elem->comp->inst,
+                "Recursive definition of %s\n", name);
+            return(NULL);
+        }
+        ret = xsltEvalGlobalVariable(elem, ctxt);
     } else
-    ret = elem->value;
+        ret = elem->value;
     return(xmlXPathObjectCopy(ret));
 }
 
@@ -1936,29 +1936,29 @@ xsltGlobalVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
  */
 xmlXPathObjectPtr
 xsltVariableLookup(xsltTransformContextPtr ctxt, const xmlChar *name,
-           const xmlChar *ns_uri) {
+                   const xmlChar *ns_uri) {
     xsltStackElemPtr elem;
 
     if (ctxt == NULL)
-    return(NULL);
+        return(NULL);
 
     elem = xsltStackLookup(ctxt, name, ns_uri);
     if (elem == NULL) {
-    return(xsltGlobalVariableLookup(ctxt, name, ns_uri));
+        return(xsltGlobalVariableLookup(ctxt, name, ns_uri));
     }
     if (elem->computed == 0) {
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-                 "uncomputed variable %s\n", name));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                         "uncomputed variable %s\n", name));
 #endif
         elem->value = xsltEvalVariable(ctxt, elem, NULL);
-    elem->computed = 1;
+        elem->computed = 1;
     }
     if (elem->value != NULL)
-    return(xmlXPathObjectCopy(elem->value));
+        return(xmlXPathObjectCopy(elem->value));
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-             "variable not found %s\n", name));
+                     "variable not found %s\n", name));
 #endif
     return(NULL);
 }
@@ -1989,7 +1989,7 @@ xsltParseStylesheetCallerParam(xsltTransformContextPtr ctxt, xmlNodePtr inst)
     xsltStackElemPtr param = NULL;
 
     if ((ctxt == NULL) || (inst == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
 #ifdef XSLT_REFACTORED
     comp = (xsltStyleBasicItemVariablePtr) inst->psvi;
@@ -1999,30 +1999,30 @@ xsltParseStylesheetCallerParam(xsltTransformContextPtr ctxt, xmlNodePtr inst)
 
     if (comp == NULL) {
         xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltParseStylesheetCallerParam(): "
-        "The XSLT 'with-param' instruction was not compiled.\n");
+            "Internal error in xsltParseStylesheetCallerParam(): "
+            "The XSLT 'with-param' instruction was not compiled.\n");
         return(NULL);
     }
     if (comp->name == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltParseStylesheetCallerParam(): "
-        "XSLT 'with-param': The attribute 'name' was not compiled.\n");
-    return(NULL);
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltParseStylesheetCallerParam(): "
+            "XSLT 'with-param': The attribute 'name' was not compiled.\n");
+        return(NULL);
     }
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-        "Handling xsl:with-param %s\n", comp->name));
+            "Handling xsl:with-param %s\n", comp->name));
 #endif
 
     if (comp->select == NULL) {
-    tree = inst->children;
+        tree = inst->children;
     } else {
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-        "        select %s\n", comp->select));
+        XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+            "        select %s\n", comp->select));
 #endif
-    tree = inst;
+        tree = inst;
     }
 
     param = xsltBuildVariable(ctxt, (xsltStylePreCompPtr) comp, tree);
@@ -2048,7 +2048,7 @@ xsltParseGlobalVariable(xsltStylesheetPtr style, xmlNodePtr cur)
 #endif
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     /*
@@ -2061,15 +2061,15 @@ xsltParseGlobalVariable(xsltStylesheetPtr style, xmlNodePtr cur)
     comp = (xsltStylePreCompPtr) cur->psvi;
 #endif
     if (comp == NULL) {
-    xsltTransformError(NULL, style, cur,
-         "xsl:variable : compilation failed\n");
-    return;
+        xsltTransformError(NULL, style, cur,
+             "xsl:variable : compilation failed\n");
+        return;
     }
 
     if (comp->name == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:variable : missing name attribute\n");
-    return;
+        xsltTransformError(NULL, style, cur,
+            "xsl:variable : missing name attribute\n");
+        return;
     }
 
     /*
@@ -2084,12 +2084,12 @@ xsltParseGlobalVariable(xsltStylesheetPtr style, xmlNodePtr cur)
     }
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     xsltGenericDebug(xsltGenericDebugContext,
-    "Registering global variable %s\n", comp->name);
+        "Registering global variable %s\n", comp->name);
 #endif
 
     xsltRegisterGlobalVariable(style, comp->name, comp->ns,
-    comp->select, cur->children, (xsltStylePreCompPtr) comp,
-    NULL);
+        comp->select, cur->children, (xsltStylePreCompPtr) comp,
+        NULL);
 }
 
 /**
@@ -2110,7 +2110,7 @@ xsltParseGlobalParam(xsltStylesheetPtr style, xmlNodePtr cur) {
 #endif
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
 #ifdef XSLT_REFACTORED
     /*
@@ -2123,15 +2123,15 @@ xsltParseGlobalParam(xsltStylesheetPtr style, xmlNodePtr cur) {
     comp = (xsltStylePreCompPtr) cur->psvi;
 #endif
     if (comp == NULL) {
-    xsltTransformError(NULL, style, cur,
-         "xsl:param : compilation failed\n");
-    return;
+        xsltTransformError(NULL, style, cur,
+             "xsl:param : compilation failed\n");
+        return;
     }
 
     if (comp->name == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsl:param : missing name attribute\n");
-    return;
+        xsltTransformError(NULL, style, cur,
+            "xsl:param : missing name attribute\n");
+        return;
     }
 
     /*
@@ -2147,12 +2147,12 @@ xsltParseGlobalParam(xsltStylesheetPtr style, xmlNodePtr cur) {
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     xsltGenericDebug(xsltGenericDebugContext,
-    "Registering global param %s\n", comp->name);
+        "Registering global param %s\n", comp->name);
 #endif
 
     xsltRegisterGlobalVariable(style, comp->name, comp->ns,
-    comp->select, cur->children, (xsltStylePreCompPtr) comp,
-    NULL);
+        comp->select, cur->children, (xsltStylePreCompPtr) comp,
+        NULL);
 }
 
 /**
@@ -2173,25 +2173,25 @@ xsltParseStylesheetVariable(xsltTransformContextPtr ctxt, xmlNodePtr inst)
 #endif
 
     if ((inst == NULL) || (ctxt == NULL) || (inst->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     comp = inst->psvi;
     if (comp == NULL) {
         xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltParseStylesheetVariable(): "
-        "The XSLT 'variable' instruction was not compiled.\n");
+            "Internal error in xsltParseStylesheetVariable(): "
+            "The XSLT 'variable' instruction was not compiled.\n");
         return;
     }
     if (comp->name == NULL) {
-    xsltTransformError(ctxt, NULL, inst,
-        "Internal error in xsltParseStylesheetVariable(): "
-        "The attribute 'name' was not compiled.\n");
-    return;
+        xsltTransformError(ctxt, NULL, inst,
+            "Internal error in xsltParseStylesheetVariable(): "
+            "The attribute 'name' was not compiled.\n");
+        return;
     }
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-    "Registering variable '%s'\n", comp->name));
+        "Registering variable '%s'\n", comp->name));
 #endif
 
     xsltRegisterVariable(ctxt, (xsltStylePreCompPtr) comp, inst->children, 0);
@@ -2215,19 +2215,19 @@ xsltParseStylesheetParam(xsltTransformContextPtr ctxt, xmlNodePtr cur)
 #endif
 
     if ((cur == NULL) || (ctxt == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     comp = cur->psvi;
     if ((comp == NULL) || (comp->name == NULL)) {
-    xsltTransformError(ctxt, NULL, cur,
-        "Internal error in xsltParseStylesheetParam(): "
-        "The XSLT 'param' declaration was not compiled correctly.\n");
-    return;
+        xsltTransformError(ctxt, NULL, cur,
+            "Internal error in xsltParseStylesheetParam(): "
+            "The XSLT 'param' declaration was not compiled correctly.\n");
+        return;
     }
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(ctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-    "Registering param %s\n", comp->name));
+        "Registering param %s\n", comp->name));
 #endif
 
     xsltRegisterVariable(ctxt, (xsltStylePreCompPtr) comp, cur->children, 1);
@@ -2259,16 +2259,16 @@ xsltFreeGlobalVariables(xsltTransformContextPtr ctxt) {
  */
 xmlXPathObjectPtr
 xsltXPathVariableLookup(void *ctxt, const xmlChar *name,
-                    const xmlChar *ns_uri) {
+                        const xmlChar *ns_uri) {
     xsltTransformContextPtr tctxt;
     xmlXPathObjectPtr valueObj = NULL;
 
     if ((ctxt == NULL) || (name == NULL))
-    return(NULL);
+        return(NULL);
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(((xsltTransformContextPtr)ctxt),XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-        "Lookup variable '%s'\n", name));
+            "Lookup variable '%s'\n", name));
 #endif
 
     tctxt = (xsltTransformContextPtr) ctxt;
@@ -2281,90 +2281,90 @@ xsltXPathVariableLookup(void *ctxt, const xmlChar *name,
     * come from the disctionnary and hence pointer comparison.
     */
     if (tctxt->varsNr != 0) {
-    int i;
-    xsltStackElemPtr variable = NULL, cur;
+        int i;
+        xsltStackElemPtr variable = NULL, cur;
 
-    for (i = tctxt->varsNr; i > tctxt->varsBase; i--) {
-        cur = tctxt->varsTab[i-1];
-        if ((cur->name == name) && (cur->nameURI == ns_uri)) {
-#if 0
-        stack_addr++;
-#endif
-        variable = cur;
-        goto local_variable_found;
-        }
-        cur = cur->next;
-    }
-    /*
-    * Redo the lookup with interned strings to avoid string comparison.
-    *
-    * OPTIMIZE TODO: The problem here is, that if we request a
-    *  global variable, then this will be also executed.
-    */
-    {
-        const xmlChar *tmpName = name, *tmpNsName = ns_uri;
-
-        name = xmlDictLookup(tctxt->dict, name, -1);
-        if (ns_uri)
-        ns_uri = xmlDictLookup(tctxt->dict, ns_uri, -1);
-        if ((tmpName != name) || (tmpNsName != ns_uri)) {
         for (i = tctxt->varsNr; i > tctxt->varsBase; i--) {
             cur = tctxt->varsTab[i-1];
             if ((cur->name == name) && (cur->nameURI == ns_uri)) {
 #if 0
-            stack_cmp++;
+                stack_addr++;
 #endif
-            variable = cur;
-            goto local_variable_found;
+                variable = cur;
+                goto local_variable_found;
+            }
+            cur = cur->next;
+        }
+        /*
+        * Redo the lookup with interned strings to avoid string comparison.
+        *
+        * OPTIMIZE TODO: The problem here is, that if we request a
+        *  global variable, then this will be also executed.
+        */
+        {
+            const xmlChar *tmpName = name, *tmpNsName = ns_uri;
+
+            name = xmlDictLookup(tctxt->dict, name, -1);
+            if (ns_uri)
+                ns_uri = xmlDictLookup(tctxt->dict, ns_uri, -1);
+            if ((tmpName != name) || (tmpNsName != ns_uri)) {
+                for (i = tctxt->varsNr; i > tctxt->varsBase; i--) {
+                    cur = tctxt->varsTab[i-1];
+                    if ((cur->name == name) && (cur->nameURI == ns_uri)) {
+#if 0
+                        stack_cmp++;
+#endif
+                        variable = cur;
+                        goto local_variable_found;
+                    }
+                }
             }
         }
-        }
-    }
 
 local_variable_found:
 
-    if (variable) {
-        if (variable->computed == 0) {
+        if (variable) {
+            if (variable->computed == 0) {
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-        XSLT_TRACE(tctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-            "uncomputed variable '%s'\n", name));
+                XSLT_TRACE(tctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+                    "uncomputed variable '%s'\n", name));
 #endif
-        variable->value = xsltEvalVariable(tctxt, variable, NULL);
-        variable->computed = 1;
+                variable->value = xsltEvalVariable(tctxt, variable, NULL);
+                variable->computed = 1;
+            }
+            if (variable->value != NULL) {
+                valueObj = xmlXPathObjectCopy(variable->value);
+            }
+            return(valueObj);
         }
-        if (variable->value != NULL) {
-        valueObj = xmlXPathObjectCopy(variable->value);
-        }
-        return(valueObj);
-    }
     }
     /*
     * Global variables/params --------------------------------------------
     */
     if (tctxt->globalVars) {
-    valueObj = xsltGlobalVariableLookup(tctxt, name, ns_uri);
+        valueObj = xsltGlobalVariableLookup(tctxt, name, ns_uri);
     }
 
     if (valueObj == NULL) {
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
     XSLT_TRACE(tctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-             "variable not found '%s'\n", name));
+                     "variable not found '%s'\n", name));
 #endif
 
-    if (ns_uri) {
-        xsltTransformError(tctxt, NULL, tctxt->inst,
-        "Variable '{%s}%s' has not been declared.\n", ns_uri, name);
-    } else {
-        xsltTransformError(tctxt, NULL, tctxt->inst,
-        "Variable '%s' has not been declared.\n", name);
-    }
+        if (ns_uri) {
+            xsltTransformError(tctxt, NULL, tctxt->inst,
+                "Variable '{%s}%s' has not been declared.\n", ns_uri, name);
+        } else {
+            xsltTransformError(tctxt, NULL, tctxt->inst,
+                "Variable '%s' has not been declared.\n", name);
+        }
     } else {
 
 #ifdef WITH_XSLT_DEBUG_VARIABLE
-    XSLT_TRACE(tctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
-        "found variable '%s'\n", name));
+        XSLT_TRACE(tctxt,XSLT_TRACE_VARIABLES,xsltGenericDebug(xsltGenericDebugContext,
+            "found variable '%s'\n", name));
 #endif
     }
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/variables.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/variables.h
@@ -27,11 +27,11 @@ extern "C" {
  * Registering macro, not general purpose at all but used in different modules.
  */
 
-#define XSLT_REGISTER_VARIABLE_LOOKUP(ctxt)         \
-    xmlXPathRegisterVariableLookup((ctxt)->xpathCtxt,       \
-           xsltXPathVariableLookup, (void *)(ctxt));    \
-    xsltRegisterAllFunctions((ctxt)->xpathCtxt);        \
-    xsltRegisterAllElement(ctxt);               \
+#define XSLT_REGISTER_VARIABLE_LOOKUP(ctxt)                     \
+    xmlXPathRegisterVariableLookup((ctxt)->xpathCtxt,           \
+               xsltXPathVariableLookup, (void *)(ctxt));        \
+    xsltRegisterAllFunctions((ctxt)->xpathCtxt);                \
+    xsltRegisterAllElement(ctxt);                               \
     (ctxt)->xpathCtxt->extra = ctxt
 
 /*
@@ -66,50 +66,50 @@ extern "C" {
  */
 
 XSLTPUBFUN int XSLTCALL
-        xsltEvalGlobalVariables     (xsltTransformContextPtr ctxt);
+                xsltEvalGlobalVariables         (xsltTransformContextPtr ctxt);
 XSLTPUBFUN int XSLTCALL
-        xsltEvalUserParams      (xsltTransformContextPtr ctxt,
-                         const char **params);
+                xsltEvalUserParams              (xsltTransformContextPtr ctxt,
+                                                 const char **params);
 XSLTPUBFUN int XSLTCALL
-        xsltQuoteUserParams     (xsltTransformContextPtr ctxt,
-                         const char **params);
+                xsltQuoteUserParams             (xsltTransformContextPtr ctxt,
+                                                 const char **params);
 XSLTPUBFUN int XSLTCALL
-        xsltEvalOneUserParam        (xsltTransformContextPtr ctxt,
-                         const xmlChar * name,
-                         const xmlChar * value);
+                xsltEvalOneUserParam            (xsltTransformContextPtr ctxt,
+                                                 const xmlChar * name,
+                                                 const xmlChar * value);
 XSLTPUBFUN int XSLTCALL
-        xsltQuoteOneUserParam       (xsltTransformContextPtr ctxt,
-                         const xmlChar * name,
-                         const xmlChar * value);
+                xsltQuoteOneUserParam           (xsltTransformContextPtr ctxt,
+                                                 const xmlChar * name,
+                                                 const xmlChar * value);
 
 XSLTPUBFUN void XSLTCALL
-        xsltParseGlobalVariable     (xsltStylesheetPtr style,
-                         xmlNodePtr cur);
+                xsltParseGlobalVariable         (xsltStylesheetPtr style,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN void XSLTCALL
-        xsltParseGlobalParam        (xsltStylesheetPtr style,
-                         xmlNodePtr cur);
+                xsltParseGlobalParam            (xsltStylesheetPtr style,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN void XSLTCALL
-        xsltParseStylesheetVariable (xsltTransformContextPtr ctxt,
-                         xmlNodePtr cur);
+                xsltParseStylesheetVariable     (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN void XSLTCALL
-        xsltParseStylesheetParam    (xsltTransformContextPtr ctxt,
-                         xmlNodePtr cur);
+                xsltParseStylesheetParam        (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN xsltStackElemPtr XSLTCALL
-        xsltParseStylesheetCallerParam  (xsltTransformContextPtr ctxt,
-                         xmlNodePtr cur);
+                xsltParseStylesheetCallerParam  (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN int XSLTCALL
-        xsltAddStackElemList        (xsltTransformContextPtr ctxt,
-                         xsltStackElemPtr elems);
+                xsltAddStackElemList            (xsltTransformContextPtr ctxt,
+                                                 xsltStackElemPtr elems);
 XSLTPUBFUN void XSLTCALL
-        xsltFreeGlobalVariables     (xsltTransformContextPtr ctxt);
+                xsltFreeGlobalVariables         (xsltTransformContextPtr ctxt);
 XSLTPUBFUN xmlXPathObjectPtr XSLTCALL
-        xsltVariableLookup      (xsltTransformContextPtr ctxt,
-                         const xmlChar *name,
-                         const xmlChar *ns_uri);
+                xsltVariableLookup              (xsltTransformContextPtr ctxt,
+                                                 const xmlChar *name,
+                                                 const xmlChar *ns_uri);
 XSLTPUBFUN xmlXPathObjectPtr XSLTCALL
-        xsltXPathVariableLookup     (void *ctxt,
-                         const xmlChar *name,
-                         const xmlChar *ns_uri);
+                xsltXPathVariableLookup         (void *ctxt,
+                                                 const xmlChar *name,
+                                                 const xmlChar *ns_uri);
 #ifdef __cplusplus
 }
 #endif

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/win32config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/win32config.h
@@ -37,7 +37,7 @@
    _fpclass() function. */
 #ifndef isinf
 #define isinf(d) ((_fpclass(d) == _FPCLASS_PINF) ? 1 \
-    : ((_fpclass(d) == _FPCLASS_NINF) ? -1 : 0))
+        : ((_fpclass(d) == _FPCLASS_NINF) ? -1 : 0))
 #endif
 /* _isnan(x) returns nonzero if (x == NaN) and zero otherwise. */
 #ifndef isnan

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xslt.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xslt.c
@@ -111,7 +111,7 @@ double xmlXPathStringEvalNumber(const xmlChar *str);
 #ifdef  IS_BLANK_NODE
 #undef  IS_BLANK_NODE
 #endif
-#define IS_BLANK_NODE(n)                        \
+#define IS_BLANK_NODE(n)                                                \
     (((n)->type == XML_TEXT_NODE) && (xsltIsBlank((n)->content)))
 
 /**
@@ -124,19 +124,19 @@ double xmlXPathStringEvalNumber(const xmlChar *str);
  */
 static void
 xsltParseContentError(xsltStylesheetPtr style,
-               xmlNodePtr node)
+                       xmlNodePtr node)
 {
     if ((style == NULL) || (node == NULL))
-    return;
+        return;
 
     if (IS_XSLT_ELEM(node))
-    xsltTransformError(NULL, style, node,
-        "The XSLT-element '%s' is not allowed at this position.\n",
-        node->name);
+        xsltTransformError(NULL, style, node,
+            "The XSLT-element '%s' is not allowed at this position.\n",
+            node->name);
     else
-    xsltTransformError(NULL, style, node,
-        "The element '%s' is not allowed at this position.\n",
-        node->name);
+        xsltTransformError(NULL, style, node,
+            "The element '%s' is not allowed at this position.\n",
+            node->name);
     style->errors++;
 }
 
@@ -170,7 +170,7 @@ exclPrefixPush(xsltStylesheetPtr style, xmlChar * value)
     /* do not push duplicates */
     for (i = 0;i < style->exclPrefixNr;i++) {
         if (xmlStrEqual(style->exclPrefixTab[i], value))
-        return(-1);
+            return(-1);
     }
     if (style->exclPrefixNr >= style->exclPrefixMax) {
         style->exclPrefixMax *= 2;
@@ -214,9 +214,9 @@ exclPrefixPop(xsltStylesheetPtr style)
 #endif
 
 /************************************************************************
- *                                  *
- *          Helper functions                *
- *                                  *
+ *                                                                      *
+ *                      Helper functions                                *
+ *                                                                      *
  ************************************************************************/
 
 static int initialized = 0;
@@ -229,9 +229,9 @@ static int initialized = 0;
 void
 xsltInit (void) {
     if (initialized == 0) {
-    initialized = 1;
+        initialized = 1;
 #ifdef XSLT_LOCALE_WINAPI
-    xsltLocaleMutex = xmlNewRMutex();
+        xsltLocaleMutex = xmlNewRMutex();
 #endif
         xsltRegisterAllExtras();
     }
@@ -262,18 +262,18 @@ xsltUninit (void) {
 int
 xsltIsBlank(xmlChar *str) {
     if (str == NULL)
-    return(1);
+        return(1);
     while (*str != 0) {
-    if (!(IS_BLANK(*str))) return(0);
-    str++;
+        if (!(IS_BLANK(*str))) return(0);
+        str++;
     }
     return(1);
 }
 
 /************************************************************************
- *                                  *
- *      Routines to handle XSLT data structures         *
- *                                  *
+ *                                                                      *
+ *              Routines to handle XSLT data structures                 *
+ *                                                                      *
  ************************************************************************/
 static xsltDecimalFormatPtr
 xsltNewDecimalFormat(const xmlChar *nsUri, xmlChar *name)
@@ -284,21 +284,21 @@ xsltNewDecimalFormat(const xmlChar *nsUri, xmlChar *name)
 
     self = xmlMalloc(sizeof(xsltDecimalFormat));
     if (self != NULL) {
-    self->next = NULL;
+        self->next = NULL;
         self->nsUri = nsUri;
-    self->name = name;
+        self->name = name;
 
-    /* Default values */
-    self->digit = xmlStrdup(BAD_CAST("#"));
-    self->patternSeparator = xmlStrdup(BAD_CAST(";"));
-    self->decimalPoint = xmlStrdup(BAD_CAST("."));
-    self->grouping = xmlStrdup(BAD_CAST(","));
-    self->percent = xmlStrdup(BAD_CAST("%"));
-    self->permille = xmlStrdup(BAD_CAST(permille));
-    self->zeroDigit = xmlStrdup(BAD_CAST("0"));
-    self->minusSign = xmlStrdup(BAD_CAST("-"));
-    self->infinity = xmlStrdup(BAD_CAST("Infinity"));
-    self->noNumber = xmlStrdup(BAD_CAST("NaN"));
+        /* Default values */
+        self->digit = xmlStrdup(BAD_CAST("#"));
+        self->patternSeparator = xmlStrdup(BAD_CAST(";"));
+        self->decimalPoint = xmlStrdup(BAD_CAST("."));
+        self->grouping = xmlStrdup(BAD_CAST(","));
+        self->percent = xmlStrdup(BAD_CAST("%"));
+        self->permille = xmlStrdup(BAD_CAST(permille));
+        self->zeroDigit = xmlStrdup(BAD_CAST("0"));
+        self->minusSign = xmlStrdup(BAD_CAST("-"));
+        self->infinity = xmlStrdup(BAD_CAST("Infinity"));
+        self->noNumber = xmlStrdup(BAD_CAST("NaN"));
     }
     return self;
 }
@@ -307,29 +307,29 @@ static void
 xsltFreeDecimalFormat(xsltDecimalFormatPtr self)
 {
     if (self != NULL) {
-    if (self->digit)
-        xmlFree(self->digit);
-    if (self->patternSeparator)
-        xmlFree(self->patternSeparator);
-    if (self->decimalPoint)
-        xmlFree(self->decimalPoint);
-    if (self->grouping)
-        xmlFree(self->grouping);
-    if (self->percent)
-        xmlFree(self->percent);
-    if (self->permille)
-        xmlFree(self->permille);
-    if (self->zeroDigit)
-        xmlFree(self->zeroDigit);
-    if (self->minusSign)
-        xmlFree(self->minusSign);
-    if (self->infinity)
-        xmlFree(self->infinity);
-    if (self->noNumber)
-        xmlFree(self->noNumber);
-    if (self->name)
-        xmlFree(self->name);
-    xmlFree(self);
+        if (self->digit)
+            xmlFree(self->digit);
+        if (self->patternSeparator)
+            xmlFree(self->patternSeparator);
+        if (self->decimalPoint)
+            xmlFree(self->decimalPoint);
+        if (self->grouping)
+            xmlFree(self->grouping);
+        if (self->percent)
+            xmlFree(self->percent);
+        if (self->permille)
+            xmlFree(self->permille);
+        if (self->zeroDigit)
+            xmlFree(self->zeroDigit);
+        if (self->minusSign)
+            xmlFree(self->minusSign);
+        if (self->infinity)
+            xmlFree(self->infinity);
+        if (self->noNumber)
+            xmlFree(self->noNumber);
+        if (self->name)
+            xmlFree(self->name);
+        xmlFree(self);
     }
 }
 
@@ -340,13 +340,13 @@ xsltFreeDecimalFormatList(xsltStylesheetPtr self)
     xsltDecimalFormatPtr tmp;
 
     if (self == NULL)
-    return;
+        return;
 
     iter = self->decimalFormat;
     while (iter != NULL) {
-    tmp = iter->next;
-    xsltFreeDecimalFormat(iter);
-    iter = tmp;
+        tmp = iter->next;
+        xsltFreeDecimalFormat(iter);
+        iter = tmp;
     }
 }
 
@@ -365,16 +365,16 @@ xsltDecimalFormatGetByName(xsltStylesheetPtr style, xmlChar *name)
     xsltDecimalFormatPtr result = NULL;
 
     if (name == NULL)
-    return style->decimalFormat;
+        return style->decimalFormat;
 
     while (style != NULL) {
-    for (result = style->decimalFormat->next;
-         result != NULL;
-         result = result->next) {
-        if ((result->nsUri == NULL) && xmlStrEqual(name, result->name))
-        return result;
-    }
-    style = xsltNextImport(style);
+        for (result = style->decimalFormat->next;
+             result != NULL;
+             result = result->next) {
+            if ((result->nsUri == NULL) && xmlStrEqual(name, result->name))
+                return result;
+        }
+        style = xsltNextImport(style);
     }
     return result;
 }
@@ -396,17 +396,17 @@ xsltDecimalFormatGetByQName(xsltStylesheetPtr style, const xmlChar *nsUri,
     xsltDecimalFormatPtr result = NULL;
 
     if (name == NULL)
-    return style->decimalFormat;
+        return style->decimalFormat;
 
     while (style != NULL) {
-    for (result = style->decimalFormat->next;
-         result != NULL;
-         result = result->next) {
-        if (xmlStrEqual(nsUri, result->nsUri) &&
+        for (result = style->decimalFormat->next;
+             result != NULL;
+             result = result->next) {
+            if (xmlStrEqual(nsUri, result->nsUri) &&
                 xmlStrEqual(name, result->name))
-        return result;
-    }
-    style = xsltNextImport(style);
+                return result;
+        }
+        style = xsltNextImport(style);
     }
     return result;
 }
@@ -425,9 +425,9 @@ xsltNewTemplate(void) {
 
     cur = (xsltTemplatePtr) xmlMalloc(sizeof(xsltTemplate));
     if (cur == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewTemplate : malloc failed\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewTemplate : malloc failed\n");
+        return(NULL);
     }
     memset(cur, 0, sizeof(xsltTemplate));
     cur->priority = XSLT_PAT_NO_PRIORITY;
@@ -443,7 +443,7 @@ xsltNewTemplate(void) {
 static void
 xsltFreeTemplate(xsltTemplatePtr template) {
     if (template == NULL)
-    return;
+        return;
     if (template->match) xmlFree(template->match);
 /*
 *   NOTE: @name and @nameURI are put into the string dict now.
@@ -475,9 +475,9 @@ xsltFreeTemplateList(xsltTemplatePtr template) {
     xsltTemplatePtr cur;
 
     while (template != NULL) {
-    cur = template;
-    template = template->next;
-    xsltFreeTemplate(cur);
+        cur = template;
+        template = template->next;
+        xsltFreeTemplate(cur);
     }
 }
 
@@ -489,9 +489,9 @@ xsltFreeNsAliasList(xsltNsAliasPtr item)
     xsltNsAliasPtr tmp;
 
     while (item) {
-    tmp = item;
-    item = item->next;
-    xmlFree(tmp);
+        tmp = item;
+        item = item->next;
+        xmlFree(tmp);
     }
     return;
 }
@@ -503,30 +503,30 @@ xsltFreeNamespaceMap(xsltNsMapPtr item)
     xsltNsMapPtr tmp;
 
     while (item) {
-    tmp = item;
-    item = item->next;
-    xmlFree(tmp);
+        tmp = item;
+        item = item->next;
+        xmlFree(tmp);
     }
     return;
 }
 
 static xsltNsMapPtr
 xsltNewNamespaceMapItem(xsltCompilerCtxtPtr cctxt,
-            xmlDocPtr doc,
-            xmlNsPtr ns,
-            xmlNodePtr elem)
+                        xmlDocPtr doc,
+                        xmlNsPtr ns,
+                        xmlNodePtr elem)
 {
     xsltNsMapPtr ret;
 
     if ((cctxt == NULL) || (doc == NULL) || (ns == NULL))
-    return(NULL);
+        return(NULL);
 
     ret = (xsltNsMapPtr) xmlMalloc(sizeof(xsltNsMap));
     if (ret == NULL) {
-    xsltTransformError(NULL, cctxt->style, elem,
-        "Internal error: (xsltNewNamespaceMapItem) "
-        "memory allocation failed.\n");
-    return(NULL);
+        xsltTransformError(NULL, cctxt->style, elem,
+            "Internal error: (xsltNewNamespaceMapItem) "
+            "memory allocation failed.\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltNsMap));
     ret->doc = doc;
@@ -536,7 +536,7 @@ xsltNewNamespaceMapItem(xsltCompilerCtxtPtr cctxt,
     * Store the item at current stylesheet-level.
     */
     if (cctxt->psData->nsMap != NULL)
-    ret->next = cctxt->psData->nsMap;
+        ret->next = cctxt->psData->nsMap;
     cctxt->psData->nsMap = ret;
 
     return(ret);
@@ -555,9 +555,9 @@ xsltCompilerVarInfoFree(xsltCompilerCtxtPtr cctxt)
     xsltVarInfoPtr ivar = cctxt->ivars, ivartmp;
 
     while (ivar) {
-    ivartmp = ivar;
-    ivar = ivar->next;
-    xmlFree(ivartmp);
+        ivartmp = ivar;
+        ivar = ivar->next;
+        xmlFree(ivartmp);
     }
 }
 
@@ -570,33 +570,33 @@ static void
 xsltCompilationCtxtFree(xsltCompilerCtxtPtr cctxt)
 {
     if (cctxt == NULL)
-    return;
+        return;
 #ifdef WITH_XSLT_DEBUG_PARSING
     xsltGenericDebug(xsltGenericDebugContext,
-    "Freeing compilation context\n");
+        "Freeing compilation context\n");
     xsltGenericDebug(xsltGenericDebugContext,
-    "### Max inodes: %d\n", cctxt->maxNodeInfos);
+        "### Max inodes: %d\n", cctxt->maxNodeInfos);
     xsltGenericDebug(xsltGenericDebugContext,
-    "### Max LREs  : %d\n", cctxt->maxLREs);
+        "### Max LREs  : %d\n", cctxt->maxLREs);
 #endif
     /*
     * Free node-infos.
     */
     if (cctxt->inodeList != NULL) {
-    xsltCompilerNodeInfoPtr tmp, cur = cctxt->inodeList;
-    while (cur != NULL) {
-        tmp = cur;
-        cur = cur->next;
-        xmlFree(tmp);
-    }
+        xsltCompilerNodeInfoPtr tmp, cur = cctxt->inodeList;
+        while (cur != NULL) {
+            tmp = cur;
+            cur = cur->next;
+            xmlFree(tmp);
+        }
     }
     if (cctxt->tmpList != NULL)
-    xsltPointerListFree(cctxt->tmpList);
+        xsltPointerListFree(cctxt->tmpList);
     if (cctxt->nsAliases != NULL)
-    xsltFreeNsAliasList(cctxt->nsAliases);
+        xsltFreeNsAliasList(cctxt->nsAliases);
 
     if (cctxt->ivars)
-    xsltCompilerVarInfoFree(cctxt);
+        xsltCompilerVarInfoFree(cctxt);
 
     xmlFree(cctxt);
 }
@@ -615,17 +615,17 @@ xsltCompilationCtxtCreate(xsltStylesheetPtr style) {
 
     ret = (xsltCompilerCtxtPtr) xmlMalloc(sizeof(xsltCompilerCtxt));
     if (ret == NULL) {
-    xsltTransformError(NULL, style, NULL,
-        "xsltCompilerCreate: allocation of compiler "
-        "context failed.\n");
-    return(NULL);
+        xsltTransformError(NULL, style, NULL,
+            "xsltCompilerCreate: allocation of compiler "
+            "context failed.\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltCompilerCtxt));
 
     ret->errSeverity = XSLT_ERROR_SEVERITY_ERROR;
     ret->tmpList = xsltPointerListCreate(20);
     if (ret->tmpList == NULL) {
-    goto internal_err;
+        goto internal_err;
     }
 
     return(ret);
@@ -641,9 +641,9 @@ xsltLREEffectiveNsNodesFree(xsltEffectiveNsPtr first)
     xsltEffectiveNsPtr tmp;
 
     while (first != NULL) {
-    tmp = first;
-    first = first->nextInStore;
-    xmlFree(tmp);
+        tmp = first;
+        first = first->nextInStore;
+        xmlFree(tmp);
     }
 }
 
@@ -651,53 +651,53 @@ static void
 xsltFreePrincipalStylesheetData(xsltPrincipalStylesheetDataPtr data)
 {
     if (data == NULL)
-    return;
+        return;
 
     if (data->inScopeNamespaces != NULL) {
-    int i;
-    xsltNsListContainerPtr nsi;
-    xsltPointerListPtr list =
-        (xsltPointerListPtr) data->inScopeNamespaces;
+        int i;
+        xsltNsListContainerPtr nsi;
+        xsltPointerListPtr list =
+            (xsltPointerListPtr) data->inScopeNamespaces;
 
-    for (i = 0; i < list->number; i++) {
-        /*
-        * REVISIT TODO: Free info of in-scope namespaces.
-        */
-        nsi = (xsltNsListContainerPtr) list->items[i];
-        if (nsi->list != NULL)
-        xmlFree(nsi->list);
-        xmlFree(nsi);
-    }
-    xsltPointerListFree(list);
-    data->inScopeNamespaces = NULL;
+        for (i = 0; i < list->number; i++) {
+            /*
+            * REVISIT TODO: Free info of in-scope namespaces.
+            */
+            nsi = (xsltNsListContainerPtr) list->items[i];
+            if (nsi->list != NULL)
+                xmlFree(nsi->list);
+            xmlFree(nsi);
+        }
+        xsltPointerListFree(list);
+        data->inScopeNamespaces = NULL;
     }
 
     if (data->exclResultNamespaces != NULL) {
-    int i;
-    xsltPointerListPtr list = (xsltPointerListPtr)
-        data->exclResultNamespaces;
+        int i;
+        xsltPointerListPtr list = (xsltPointerListPtr)
+            data->exclResultNamespaces;
 
-    for (i = 0; i < list->number; i++)
-        xsltPointerListFree((xsltPointerListPtr) list->items[i]);
+        for (i = 0; i < list->number; i++)
+            xsltPointerListFree((xsltPointerListPtr) list->items[i]);
 
-    xsltPointerListFree(list);
-    data->exclResultNamespaces = NULL;
+        xsltPointerListFree(list);
+        data->exclResultNamespaces = NULL;
     }
 
     if (data->extElemNamespaces != NULL) {
-    xsltPointerListPtr list = (xsltPointerListPtr)
-        data->extElemNamespaces;
-    int i;
+        xsltPointerListPtr list = (xsltPointerListPtr)
+            data->extElemNamespaces;
+        int i;
 
-    for (i = 0; i < list->number; i++)
-        xsltPointerListFree((xsltPointerListPtr) list->items[i]);
+        for (i = 0; i < list->number; i++)
+            xsltPointerListFree((xsltPointerListPtr) list->items[i]);
 
-    xsltPointerListFree(list);
-    data->extElemNamespaces = NULL;
+        xsltPointerListFree(list);
+        data->extElemNamespaces = NULL;
     }
     if (data->effectiveNs) {
-    xsltLREEffectiveNsNodesFree(data->effectiveNs);
-    data->effectiveNs = NULL;
+        xsltLREEffectiveNsNodesFree(data->effectiveNs);
+        data->effectiveNs = NULL;
     }
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
     xsltFreeNamespaceMap(data->nsMap);
@@ -711,11 +711,11 @@ xsltNewPrincipalStylesheetData(void)
     xsltPrincipalStylesheetDataPtr ret;
 
     ret = (xsltPrincipalStylesheetDataPtr)
-    xmlMalloc(sizeof(xsltPrincipalStylesheetData));
+        xmlMalloc(sizeof(xsltPrincipalStylesheetData));
     if (ret == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewPrincipalStylesheetData: memory allocation failed.\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+            "xsltNewPrincipalStylesheetData: memory allocation failed.\n");
+        return(NULL);
     }
     memset(ret, 0, sizeof(xsltPrincipalStylesheetData));
 
@@ -724,19 +724,19 @@ xsltNewPrincipalStylesheetData(void)
     */
     ret->inScopeNamespaces = xsltPointerListCreate(-1);
     if (ret->inScopeNamespaces == NULL)
-    goto internal_err;
+        goto internal_err;
     /*
     * Global list of excluded result ns-decls.
     */
     ret->exclResultNamespaces = xsltPointerListCreate(-1);
     if (ret->exclResultNamespaces == NULL)
-    goto internal_err;
+        goto internal_err;
     /*
     * Global list of extension instruction namespace names.
     */
     ret->extElemNamespaces = xsltPointerListCreate(-1);
     if (ret->extElemNamespaces == NULL)
-    goto internal_err;
+        goto internal_err;
 
     return(ret);
 
@@ -761,9 +761,9 @@ xsltNewStylesheetInternal(xsltStylesheetPtr parent) {
 
     ret = (xsltStylesheetPtr) xmlMalloc(sizeof(xsltStylesheet));
     if (ret == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltNewStylesheet : malloc failed\n");
-    goto internal_err;
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltNewStylesheet : malloc failed\n");
+        goto internal_err;
     }
     memset(ret, 0, sizeof(xsltStylesheet));
 
@@ -785,7 +785,7 @@ xsltNewStylesheetInternal(xsltStylesheetPtr parent) {
     ret->dict = xmlDictCreate();
 #ifdef WITH_XSLT_DEBUG
     xsltGenericDebug(xsltGenericDebugContext,
-    "creating dictionary for stylesheet\n");
+        "creating dictionary for stylesheet\n");
 #endif
 
     if (parent == NULL) {
@@ -809,7 +809,7 @@ xsltNewStylesheetInternal(xsltStylesheetPtr parent) {
 
 internal_err:
     if (ret != NULL)
-    xsltFreeStylesheet(ret);
+        xsltFreeStylesheet(ret);
     return(NULL);
 }
 
@@ -854,40 +854,40 @@ int
 xsltAllocateExtraCtxt(xsltTransformContextPtr ctxt)
 {
     if (ctxt->extrasNr >= ctxt->extrasMax) {
-    int i;
-    if (ctxt->extrasNr == 0) {
-        ctxt->extrasMax = 20;
-        ctxt->extras = (xsltRuntimeExtraPtr)
-        xmlMalloc(ctxt->extrasMax * sizeof(xsltRuntimeExtra));
-        if (ctxt->extras == NULL) {
-        xsltTransformError(ctxt, NULL, NULL,
-            "xsltAllocateExtraCtxt: out of memory\n");
-        return(0);
-        }
-        for (i = 0;i < ctxt->extrasMax;i++) {
-        ctxt->extras[i].info = NULL;
-        ctxt->extras[i].deallocate = NULL;
-        ctxt->extras[i].val.ptr = NULL;
-        }
+        int i;
+        if (ctxt->extrasNr == 0) {
+            ctxt->extrasMax = 20;
+            ctxt->extras = (xsltRuntimeExtraPtr)
+                xmlMalloc(ctxt->extrasMax * sizeof(xsltRuntimeExtra));
+            if (ctxt->extras == NULL) {
+                xsltTransformError(ctxt, NULL, NULL,
+                        "xsltAllocateExtraCtxt: out of memory\n");
+                return(0);
+            }
+            for (i = 0;i < ctxt->extrasMax;i++) {
+                ctxt->extras[i].info = NULL;
+                ctxt->extras[i].deallocate = NULL;
+                ctxt->extras[i].val.ptr = NULL;
+            }
 
-    } else {
-        xsltRuntimeExtraPtr tmp;
+        } else {
+            xsltRuntimeExtraPtr tmp;
 
-        ctxt->extrasMax += 100;
-        tmp = (xsltRuntimeExtraPtr) xmlRealloc(ctxt->extras,
-                    ctxt->extrasMax * sizeof(xsltRuntimeExtra));
-        if (tmp == NULL) {
-        xsltTransformError(ctxt, NULL, NULL,
-            "xsltAllocateExtraCtxt: out of memory\n");
-        return(0);
+            ctxt->extrasMax += 100;
+            tmp = (xsltRuntimeExtraPtr) xmlRealloc(ctxt->extras,
+                            ctxt->extrasMax * sizeof(xsltRuntimeExtra));
+            if (tmp == NULL) {
+                xsltTransformError(ctxt, NULL, NULL,
+                        "xsltAllocateExtraCtxt: out of memory\n");
+                return(0);
+            }
+            ctxt->extras = tmp;
+            for (i = ctxt->extrasNr;i < ctxt->extrasMax;i++) {
+                ctxt->extras[i].info = NULL;
+                ctxt->extras[i].deallocate = NULL;
+                ctxt->extras[i].val.ptr = NULL;
+            }
         }
-        ctxt->extras = tmp;
-        for (i = ctxt->extrasNr;i < ctxt->extrasMax;i++) {
-        ctxt->extras[i].info = NULL;
-        ctxt->extras[i].deallocate = NULL;
-        ctxt->extras[i].val.ptr = NULL;
-        }
-    }
     }
     return(ctxt->extrasNr++);
 }
@@ -903,9 +903,9 @@ xsltFreeStylesheetList(xsltStylesheetPtr style) {
     xsltStylesheetPtr next;
 
     while (style != NULL) {
-    next = style->next;
-    xsltFreeStylesheet(style);
-    style = next;
+        next = style->next;
+        xsltFreeStylesheet(style);
+        style = next;
     }
 }
 
@@ -922,15 +922,15 @@ xsltFreeStylesheetList(xsltStylesheetPtr style) {
  */
 static int
 xsltCleanupStylesheetTree(xmlDocPtr doc ATTRIBUTE_UNUSED,
-              xmlNodePtr rootElem ATTRIBUTE_UNUSED)
+                          xmlNodePtr rootElem ATTRIBUTE_UNUSED)
 {
 #if 0 /* TODO: Currently disabled, since probably not needed. */
     xmlNodePtr cur;
 
     if ((doc == NULL) || (rootElem == NULL) ||
-    (rootElem->type != XML_ELEMENT_NODE) ||
-    (doc != rootElem->doc))
-    return(-1);
+        (rootElem->type != XML_ELEMENT_NODE) ||
+        (doc != rootElem->doc))
+        return(-1);
 
     /*
     * Cleanup was suggested by Aleksey Sanin:
@@ -942,28 +942,28 @@ xsltCleanupStylesheetTree(xmlDocPtr doc ATTRIBUTE_UNUSED,
 
     cur = rootElem;
     while (cur != NULL) {
-    if (cur->type == XML_ELEMENT_NODE) {
-        /*
-        * Clear the PSVI field.
-        */
-        cur->psvi = NULL;
-        if (cur->children) {
-        cur = cur->children;
-        continue;
+        if (cur->type == XML_ELEMENT_NODE) {
+            /*
+            * Clear the PSVI field.
+            */
+            cur->psvi = NULL;
+            if (cur->children) {
+                cur = cur->children;
+                continue;
+            }
         }
-    }
 
 leave_node:
-    if (cur == rootElem)
-        break;
-    if (cur->next != NULL)
-        cur = cur->next;
-    else {
-        cur = cur->parent;
-        if (cur == NULL)
-        break;
-        goto leave_node;
-    }
+        if (cur == rootElem)
+            break;
+        if (cur->next != NULL)
+            cur = cur->next;
+        else {
+            cur = cur->parent;
+            if (cur == NULL)
+                break;
+            goto leave_node;
+        }
     }
 #endif /* #if 0 */
     return(0);
@@ -986,17 +986,17 @@ xsltFreeStylesheet(xsltStylesheetPtr style)
     * Start with a cleanup of the main stylesheet's doc.
     */
     if ((style->principal == style) && (style->doc))
-    xsltCleanupStylesheetTree(style->doc,
-        xmlDocGetRootElement(style->doc));
+        xsltCleanupStylesheetTree(style->doc,
+            xmlDocGetRootElement(style->doc));
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
     /*
     * Restore changed ns-decls before freeing the document.
     */
     if ((style->doc != NULL) &&
-    XSLT_HAS_INTERNAL_NSMAP(style))
+        XSLT_HAS_INTERNAL_NSMAP(style))
     {
-    xsltRestoreDocumentNamespaces(XSLT_GET_INTERNAL_NSMAP(style),
-        style->doc);
+        xsltRestoreDocumentNamespaces(XSLT_GET_INTERNAL_NSMAP(style),
+            style->doc);
     }
 #endif /* XSLT_REFACTORED_XSLT_NSCOMP */
 #else
@@ -1004,8 +1004,8 @@ xsltFreeStylesheet(xsltStylesheetPtr style)
     * Start with a cleanup of the main stylesheet's doc.
     */
     if ((style->parent == NULL) && (style->doc))
-    xsltCleanupStylesheetTree(style->doc,
-        xmlDocGetRootElement(style->doc));
+        xsltCleanupStylesheetTree(style->doc,
+            xmlDocGetRootElement(style->doc));
 #endif /* XSLT_REFACTORED */
 
     xsltFreeKeys(style);
@@ -1061,10 +1061,10 @@ xsltFreeStylesheet(xsltStylesheetPtr style)
     * free its internal data.
     */
     if (style->principal == style) {
-    if (style->principalData) {
-        xsltFreePrincipalStylesheetData(style->principalData);
-        style->principalData = NULL;
-    }
+        if (style->principalData) {
+            xsltFreePrincipalStylesheetData(style->principalData);
+            style->principalData = NULL;
+        }
     }
 #endif
     /*
@@ -1082,16 +1082,16 @@ xsltFreeStylesheet(xsltStylesheetPtr style)
     xmlDictFree(style->dict);
 
     if (style->xpathCtxt != NULL)
-    xmlXPathFreeContext(style->xpathCtxt);
+        xmlXPathFreeContext(style->xpathCtxt);
 
     memset(style, -1, sizeof(xsltStylesheet));
     xmlFree(style);
 }
 
 /************************************************************************
- *                                  *
- *      Parsing of an XSLT Stylesheet               *
- *                                  *
+ *                                                                      *
+ *              Parsing of an XSLT Stylesheet                           *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef XSLT_REFACTORED
@@ -1113,8 +1113,8 @@ xsltFreeStylesheet(xsltStylesheetPtr style)
  */
 static int
 xsltGetInheritedNsList(xsltStylesheetPtr style,
-                   xsltTemplatePtr template,
-                   xmlNodePtr node)
+                       xsltTemplatePtr template,
+                       xmlNodePtr node)
 {
     xmlNsPtr cur;
     xmlNsPtr *ret = NULL;
@@ -1123,27 +1123,27 @@ xsltGetInheritedNsList(xsltStylesheetPtr style,
     int i;
 
     if ((style == NULL) || (template == NULL) || (node == NULL) ||
-    (template->inheritedNsNr != 0) || (template->inheritedNs != NULL))
-    return(0);
+        (template->inheritedNsNr != 0) || (template->inheritedNs != NULL))
+        return(0);
     while (node != NULL) {
         if (node->type == XML_ELEMENT_NODE) {
             cur = node->nsDef;
             while (cur != NULL) {
-        if (xmlStrEqual(cur->href, XSLT_NAMESPACE))
-            goto skip_ns;
+                if (xmlStrEqual(cur->href, XSLT_NAMESPACE))
+                    goto skip_ns;
 
-        if ((cur->prefix != NULL) &&
-            (xsltCheckExtPrefix(style, cur->prefix)))
-            goto skip_ns;
-        /*
-        * Check if this namespace was excluded.
-        * Note that at this point only the exclusions defined
-        * on the topmost stylesheet element are in the exclusion-list.
-        */
-        for (i = 0;i < style->exclPrefixNr;i++) {
-            if (xmlStrEqual(cur->href, style->exclPrefixTab[i]))
-            goto skip_ns;
-        }
+                if ((cur->prefix != NULL) &&
+                    (xsltCheckExtPrefix(style, cur->prefix)))
+                    goto skip_ns;
+                /*
+                * Check if this namespace was excluded.
+                * Note that at this point only the exclusions defined
+                * on the topmost stylesheet element are in the exclusion-list.
+                */
+                for (i = 0;i < style->exclPrefixNr;i++) {
+                    if (xmlStrEqual(cur->href, style->exclPrefixTab[i]))
+                        goto skip_ns;
+                }
                 if (ret == NULL) {
                     ret =
                         (xmlNsPtr *) xmlMalloc((maxns + 1) *
@@ -1155,9 +1155,9 @@ xsltGetInheritedNsList(xsltStylesheetPtr style,
                     }
                     ret[nbns] = NULL;
                 }
-        /*
-        * Skip shadowed namespace bindings.
-        */
+                /*
+                * Skip shadowed namespace bindings.
+                */
                 for (i = 0; i < nbns; i++) {
                     if ((cur->prefix == ret[i]->prefix) ||
                         (xmlStrEqual(cur->prefix, ret[i]->prefix)))
@@ -1190,8 +1190,8 @@ skip_ns:
         xsltGenericDebug(xsltGenericDebugContext,
                          "template has %d inherited namespaces\n", nbns);
 #endif
-    template->inheritedNsNr = nbns;
-    template->inheritedNs = ret;
+        template->inheritedNsNr = nbns;
+        template->inheritedNs = ret;
     }
     return (nbns);
 }
@@ -1245,27 +1245,27 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
             xmlFree(style->methodURI);
         style->methodURI = NULL;
 
-    /*
-    * TODO: Don't use xsltGetQNameURI().
-    */
-    URI = xsltGetQNameURI(cur, &prop);
-    if (prop == NULL) {
-        if (style != NULL) style->errors++;
-    } else if (URI == NULL) {
+        /*
+        * TODO: Don't use xsltGetQNameURI().
+        */
+        URI = xsltGetQNameURI(cur, &prop);
+        if (prop == NULL) {
+            if (style != NULL) style->errors++;
+        } else if (URI == NULL) {
             if ((xmlStrEqual(prop, (const xmlChar *) "xml")) ||
                 (xmlStrEqual(prop, (const xmlChar *) "html")) ||
                 (xmlStrEqual(prop, (const xmlChar *) "text"))) {
                 style->method = prop;
             } else {
-        xsltTransformError(NULL, style, cur,
+                xsltTransformError(NULL, style, cur,
                                  "invalid value for method: %s\n", prop);
                 if (style != NULL) style->warnings++;
                 xmlFree(prop);
             }
-    } else {
-        style->method = prop;
-        style->methodURI = xmlStrdup(URI);
-    }
+        } else {
+            style->method = prop;
+            style->methodURI = xmlStrdup(URI);
+        }
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *) "doctype-system", NULL);
@@ -1289,7 +1289,7 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
         } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
             style->standalone = 0;
         } else {
-        xsltTransformError(NULL, style, cur,
+            xsltTransformError(NULL, style, cur,
                              "invalid value for standalone: %s\n", prop);
             style->errors++;
         }
@@ -1303,7 +1303,7 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
         } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
             style->indent = 0;
         } else {
-        xsltTransformError(NULL, style, cur,
+            xsltTransformError(NULL, style, cur,
                              "invalid value for indent: %s\n", prop);
             style->errors++;
         }
@@ -1317,7 +1317,7 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
         } else if (xmlStrEqual(prop, (const xmlChar *) "no")) {
             style->omitXmlDeclaration = 0;
         } else {
-        xsltTransformError(NULL, style, cur,
+            xsltTransformError(NULL, style, cur,
                              "invalid value for omit-xml-declaration: %s\n",
                              prop);
             style->errors++;
@@ -1326,7 +1326,7 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
     }
 
     elements = xmlGetNsProp(cur, (const xmlChar *) "cdata-section-elements",
-    NULL);
+        NULL);
     if (elements != NULL) {
         if (style->cdataSection == NULL)
             style->cdataSection = xmlHashCreate(10);
@@ -1349,49 +1349,49 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
                                  "add cdata section output element %s\n",
                                  element);
 #endif
-        if (xmlValidateQName(BAD_CAST element, 0) != 0) {
-            xsltTransformError(NULL, style, cur,
-            "Attribute 'cdata-section-elements': The value "
-            "'%s' is not a valid QName.\n", element);
-            xmlFree(element);
-            style->errors++;
-        } else {
-            const xmlChar *URI;
+                if (xmlValidateQName(BAD_CAST element, 0) != 0) {
+                    xsltTransformError(NULL, style, cur,
+                        "Attribute 'cdata-section-elements': The value "
+                        "'%s' is not a valid QName.\n", element);
+                    xmlFree(element);
+                    style->errors++;
+                } else {
+                    const xmlChar *URI;
 
-            /*
-            * TODO: Don't use xsltGetQNameURI().
-            */
-            URI = xsltGetQNameURI(cur, &element);
-            if (element == NULL) {
-            /*
-            * TODO: We'll report additionally an error
-            *  via the stylesheet's error handling.
-            */
-            xsltTransformError(NULL, style, cur,
-                "Attribute 'cdata-section-elements': "
-                "Not a valid QName.\n");
-            style->errors++;
-            } else {
-            xmlNsPtr ns;
+                    /*
+                    * TODO: Don't use xsltGetQNameURI().
+                    */
+                    URI = xsltGetQNameURI(cur, &element);
+                    if (element == NULL) {
+                        /*
+                        * TODO: We'll report additionally an error
+                        *  via the stylesheet's error handling.
+                        */
+                        xsltTransformError(NULL, style, cur,
+                            "Attribute 'cdata-section-elements': "
+                            "Not a valid QName.\n");
+                        style->errors++;
+                    } else {
+                        xmlNsPtr ns;
 
-            /*
-            * XSLT-1.0 "Each QName is expanded into an
-            *  expanded-name using the namespace declarations in
-            *  effect on the xsl:output element in which the QName
-            *  occurs; if there is a default namespace, it is used
-            *  for QNames that do not have a prefix"
-            * NOTE: Fix of bug #339570.
-            */
-            if (URI == NULL) {
-                ns = xmlSearchNs(style->doc, cur, NULL);
-                if (ns != NULL)
-                URI = ns->href;
-            }
-            xmlHashAddEntry2(style->cdataSection, element, URI,
-                (void *) "cdata");
-            xmlFree(element);
-            }
-        }
+                        /*
+                        * XSLT-1.0 "Each QName is expanded into an
+                        *  expanded-name using the namespace declarations in
+                        *  effect on the xsl:output element in which the QName
+                        *  occurs; if there is a default namespace, it is used
+                        *  for QNames that do not have a prefix"
+                        * NOTE: Fix of bug #339570.
+                        */
+                        if (URI == NULL) {
+                            ns = xmlSearchNs(style->doc, cur, NULL);
+                            if (ns != NULL)
+                                URI = ns->href;
+                        }
+                        xmlHashAddEntry2(style->cdataSection, element, URI,
+                            (void *) "cdata");
+                        xmlFree(element);
+                    }
+                }
             }
             element = end;
         }
@@ -1400,12 +1400,12 @@ xsltParseStylesheetOutput(xsltStylesheetPtr style, xmlNodePtr cur)
 
     prop = xmlGetNsProp(cur, (const xmlChar *) "media-type", NULL);
     if (prop != NULL) {
-    if (style->mediaType)
-        xmlFree(style->mediaType);
-    style->mediaType = prop;
+        if (style->mediaType)
+            xmlFree(style->mediaType);
+        style->mediaType = prop;
     }
     if (cur->children != NULL) {
-    xsltParseContentError(style, cur->children);
+        xsltParseContentError(style, cur->children);
     }
 }
 
@@ -1432,7 +1432,7 @@ xsltParseStylesheetDecimalFormat(xsltStylesheetPtr style, xmlNodePtr cur)
     xsltDecimalFormatPtr iter;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     format = style->decimalFormat;
 
@@ -1443,7 +1443,7 @@ xsltParseStylesheetDecimalFormat(xsltStylesheetPtr style, xmlNodePtr cur)
         if (xmlValidateQName(prop, 0) != 0) {
             xsltTransformError(NULL, style, cur,
                 "xsl:decimal-format: Invalid QName '%s'.\n", prop);
-        style->warnings++;
+            style->warnings++;
             xmlFree(prop);
             return;
         }
@@ -1452,93 +1452,93 @@ xsltParseStylesheetDecimalFormat(xsltStylesheetPtr style, xmlNodePtr cur)
         */
         nsUri = xsltGetQNameURI(cur, &prop);
         if (prop == NULL) {
-        style->warnings++;
+            style->warnings++;
             return;
         }
-    format = xsltDecimalFormatGetByQName(style, nsUri, prop);
-    if (format != NULL) {
-        xsltTransformError(NULL, style, cur,
-     "xsltParseStylestyleDecimalFormat: %s already exists\n", prop);
-        style->warnings++;
+        format = xsltDecimalFormatGetByQName(style, nsUri, prop);
+        if (format != NULL) {
+            xsltTransformError(NULL, style, cur,
+         "xsltParseStylestyleDecimalFormat: %s already exists\n", prop);
+            style->warnings++;
             xmlFree(prop);
-        return;
-    }
-    format = xsltNewDecimalFormat(nsUri, prop);
-    if (format == NULL) {
-        xsltTransformError(NULL, style, cur,
+            return;
+        }
+        format = xsltNewDecimalFormat(nsUri, prop);
+        if (format == NULL) {
+            xsltTransformError(NULL, style, cur,
      "xsltParseStylestyleDecimalFormat: failed creating new decimal-format\n");
-        style->errors++;
+            style->errors++;
             xmlFree(prop);
-        return;
-    }
-    /* Append new decimal-format structure */
-    for (iter = style->decimalFormat; iter->next; iter = iter->next)
-        ;
-    if (iter)
-        iter->next = format;
+            return;
+        }
+        /* Append new decimal-format structure */
+        for (iter = style->decimalFormat; iter->next; iter = iter->next)
+            ;
+        if (iter)
+            iter->next = format;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"decimal-separator", NULL);
     if (prop != NULL) {
-    if (format->decimalPoint != NULL) xmlFree(format->decimalPoint);
-    format->decimalPoint  = prop;
+        if (format->decimalPoint != NULL) xmlFree(format->decimalPoint);
+        format->decimalPoint  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"grouping-separator", NULL);
     if (prop != NULL) {
-    if (format->grouping != NULL) xmlFree(format->grouping);
-    format->grouping  = prop;
+        if (format->grouping != NULL) xmlFree(format->grouping);
+        format->grouping  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"infinity", NULL);
     if (prop != NULL) {
-    if (format->infinity != NULL) xmlFree(format->infinity);
-    format->infinity  = prop;
+        if (format->infinity != NULL) xmlFree(format->infinity);
+        format->infinity  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"minus-sign", NULL);
     if (prop != NULL) {
-    if (format->minusSign != NULL) xmlFree(format->minusSign);
-    format->minusSign  = prop;
+        if (format->minusSign != NULL) xmlFree(format->minusSign);
+        format->minusSign  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"NaN", NULL);
     if (prop != NULL) {
-    if (format->noNumber != NULL) xmlFree(format->noNumber);
-    format->noNumber  = prop;
+        if (format->noNumber != NULL) xmlFree(format->noNumber);
+        format->noNumber  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"percent", NULL);
     if (prop != NULL) {
-    if (format->percent != NULL) xmlFree(format->percent);
-    format->percent  = prop;
+        if (format->percent != NULL) xmlFree(format->percent);
+        format->percent  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"per-mille", NULL);
     if (prop != NULL) {
-    if (format->permille != NULL) xmlFree(format->permille);
-    format->permille  = prop;
+        if (format->permille != NULL) xmlFree(format->permille);
+        format->permille  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"zero-digit", NULL);
     if (prop != NULL) {
-    if (format->zeroDigit != NULL) xmlFree(format->zeroDigit);
-    format->zeroDigit  = prop;
+        if (format->zeroDigit != NULL) xmlFree(format->zeroDigit);
+        format->zeroDigit  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"digit", NULL);
     if (prop != NULL) {
-    if (format->digit != NULL) xmlFree(format->digit);
-    format->digit  = prop;
+        if (format->digit != NULL) xmlFree(format->digit);
+        format->digit  = prop;
     }
 
     prop = xmlGetNsProp(cur, (const xmlChar *)"pattern-separator", NULL);
     if (prop != NULL) {
-    if (format->patternSeparator != NULL) xmlFree(format->patternSeparator);
-    format->patternSeparator  = prop;
+        if (format->patternSeparator != NULL) xmlFree(format->patternSeparator);
+        format->patternSeparator  = prop;
     }
     if (cur->children != NULL) {
-    xsltParseContentError(style, cur->children);
+        xsltParseContentError(style, cur->children);
     }
 }
 
@@ -1557,54 +1557,54 @@ xsltParseStylesheetPreserveSpace(xsltStylesheetPtr style, xmlNodePtr cur) {
     xmlChar *element, *end;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     elements = xmlGetNsProp(cur, (const xmlChar *)"elements", NULL);
     if (elements == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsltParseStylesheetPreserveSpace: missing elements attribute\n");
-    if (style != NULL) style->warnings++;
-    return;
+        xsltTransformError(NULL, style, cur,
+            "xsltParseStylesheetPreserveSpace: missing elements attribute\n");
+        if (style != NULL) style->warnings++;
+        return;
     }
 
     if (style->stripSpaces == NULL)
-    style->stripSpaces = xmlHashCreate(10);
+        style->stripSpaces = xmlHashCreate(10);
     if (style->stripSpaces == NULL)
-    return;
+        return;
 
     element = elements;
     while (*element != 0) {
-    while (IS_BLANK(*element)) element++;
-    if (*element == 0)
-        break;
+        while (IS_BLANK(*element)) element++;
+        if (*element == 0)
+            break;
         end = element;
-    while ((*end != 0) && (!IS_BLANK(*end))) end++;
-    element = xmlStrndup(element, end - element);
-    if (element) {
+        while ((*end != 0) && (!IS_BLANK(*end))) end++;
+        element = xmlStrndup(element, end - element);
+        if (element) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-        "add preserved space element %s\n", element);
+            xsltGenericDebug(xsltGenericDebugContext,
+                "add preserved space element %s\n", element);
 #endif
-        if (xmlStrEqual(element, (const xmlChar *)"*")) {
-        style->stripAll = -1;
-        } else {
-        const xmlChar *URI;
+            if (xmlStrEqual(element, (const xmlChar *)"*")) {
+                style->stripAll = -1;
+            } else {
+                const xmlChar *URI;
 
-        /*
-        * TODO: Don't use xsltGetQNameURI().
-        */
+                /*
+                * TODO: Don't use xsltGetQNameURI().
+                */
                 URI = xsltGetQNameURI(cur, &element);
 
-        xmlHashAddEntry2(style->stripSpaces, element, URI,
-                (xmlChar *) "preserve");
+                xmlHashAddEntry2(style->stripSpaces, element, URI,
+                                (xmlChar *) "preserve");
+            }
+            xmlFree(element);
         }
-        xmlFree(element);
-    }
-    element = end;
+        element = end;
     }
     xmlFree(elements);
     if (cur->children != NULL) {
-    xsltParseContentError(style, cur->children);
+        xsltParseContentError(style, cur->children);
     }
 }
 
@@ -1626,56 +1626,56 @@ xsltParseStylesheetPreserveSpace(xsltStylesheetPtr style, xmlNodePtr cur) {
  */
 static void
 xsltParseStylesheetExtPrefix(xsltStylesheetPtr style, xmlNodePtr cur,
-                 int isXsltElem) {
+                             int isXsltElem) {
     xmlChar *prefixes;
     xmlChar *prefix, *end;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     if (isXsltElem) {
-    /* For xsl:stylesheet/xsl:transform. */
-    prefixes = xmlGetNsProp(cur,
-        (const xmlChar *)"extension-element-prefixes", NULL);
+        /* For xsl:stylesheet/xsl:transform. */
+        prefixes = xmlGetNsProp(cur,
+            (const xmlChar *)"extension-element-prefixes", NULL);
     } else {
-    /* For literal result elements and extension instructions. */
-    prefixes = xmlGetNsProp(cur,
-        (const xmlChar *)"extension-element-prefixes", XSLT_NAMESPACE);
+        /* For literal result elements and extension instructions. */
+        prefixes = xmlGetNsProp(cur,
+            (const xmlChar *)"extension-element-prefixes", XSLT_NAMESPACE);
     }
     if (prefixes == NULL) {
-    return;
+        return;
     }
 
     prefix = prefixes;
     while (*prefix != 0) {
-    while (IS_BLANK(*prefix)) prefix++;
-    if (*prefix == 0)
-        break;
+        while (IS_BLANK(*prefix)) prefix++;
+        if (*prefix == 0)
+            break;
         end = prefix;
-    while ((*end != 0) && (!IS_BLANK(*end))) end++;
-    prefix = xmlStrndup(prefix, end - prefix);
-    if (prefix) {
-        xmlNsPtr ns;
+        while ((*end != 0) && (!IS_BLANK(*end))) end++;
+        prefix = xmlStrndup(prefix, end - prefix);
+        if (prefix) {
+            xmlNsPtr ns;
 
-        if (xmlStrEqual(prefix, (const xmlChar *)"#default"))
-        ns = xmlSearchNs(style->doc, cur, NULL);
-        else
-        ns = xmlSearchNs(style->doc, cur, prefix);
-        if (ns == NULL) {
-        xsltTransformError(NULL, style, cur,
-        "xsl:extension-element-prefix : undefined namespace %s\n",
-                             prefix);
-        if (style != NULL) style->warnings++;
-        } else {
+            if (xmlStrEqual(prefix, (const xmlChar *)"#default"))
+                ns = xmlSearchNs(style->doc, cur, NULL);
+            else
+                ns = xmlSearchNs(style->doc, cur, prefix);
+            if (ns == NULL) {
+                xsltTransformError(NULL, style, cur,
+            "xsl:extension-element-prefix : undefined namespace %s\n",
+                                 prefix);
+                if (style != NULL) style->warnings++;
+            } else {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "add extension prefix %s\n", prefix);
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "add extension prefix %s\n", prefix);
 #endif
-        xsltRegisterExtPrefix(style, prefix, ns->href);
+                xsltRegisterExtPrefix(style, prefix, ns->href);
+            }
+            xmlFree(prefix);
         }
-        xmlFree(prefix);
-    }
-    prefix = end;
+        prefix = end;
     }
     xmlFree(prefixes);
 }
@@ -1696,54 +1696,54 @@ xsltParseStylesheetStripSpace(xsltStylesheetPtr style, xmlNodePtr cur) {
     xmlChar *element, *end;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     elements = xmlGetNsProp(cur, (const xmlChar *)"elements", NULL);
     if (elements == NULL) {
-    xsltTransformError(NULL, style, cur,
-        "xsltParseStylesheetStripSpace: missing elements attribute\n");
-    if (style != NULL) style->warnings++;
-    return;
+        xsltTransformError(NULL, style, cur,
+            "xsltParseStylesheetStripSpace: missing elements attribute\n");
+        if (style != NULL) style->warnings++;
+        return;
     }
 
     if (style->stripSpaces == NULL)
-    style->stripSpaces = xmlHashCreate(10);
+        style->stripSpaces = xmlHashCreate(10);
     if (style->stripSpaces == NULL)
-    return;
+        return;
 
     element = elements;
     while (*element != 0) {
-    while (IS_BLANK(*element)) element++;
-    if (*element == 0)
-        break;
+        while (IS_BLANK(*element)) element++;
+        if (*element == 0)
+            break;
         end = element;
-    while ((*end != 0) && (!IS_BLANK(*end))) end++;
-    element = xmlStrndup(element, end - element);
-    if (element) {
+        while ((*end != 0) && (!IS_BLANK(*end))) end++;
+        element = xmlStrndup(element, end - element);
+        if (element) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-        "add stripped space element %s\n", element);
+            xsltGenericDebug(xsltGenericDebugContext,
+                "add stripped space element %s\n", element);
 #endif
-        if (xmlStrEqual(element, (const xmlChar *)"*")) {
-        style->stripAll = 1;
-        } else {
-        const xmlChar *URI;
+            if (xmlStrEqual(element, (const xmlChar *)"*")) {
+                style->stripAll = 1;
+            } else {
+                const xmlChar *URI;
 
-        /*
-        * TODO: Don't use xsltGetQNameURI().
-        */
+                /*
+                * TODO: Don't use xsltGetQNameURI().
+                */
                 URI = xsltGetQNameURI(cur, &element);
 
-        xmlHashAddEntry2(style->stripSpaces, element, URI,
-                    (xmlChar *) "strip");
+                xmlHashAddEntry2(style->stripSpaces, element, URI,
+                                (xmlChar *) "strip");
+            }
+            xmlFree(element);
         }
-        xmlFree(element);
-    }
-    element = end;
+        element = end;
     }
     xmlFree(elements);
     if (cur->children != NULL) {
-    xsltParseContentError(style, cur->children);
+        xsltParseContentError(style, cur->children);
     }
 }
 
@@ -1762,58 +1762,58 @@ xsltParseStylesheetStripSpace(xsltStylesheetPtr style, xmlNodePtr cur) {
 
 static int
 xsltParseStylesheetExcludePrefix(xsltStylesheetPtr style, xmlNodePtr cur,
-                 int isXsltElem)
+                                 int isXsltElem)
 {
     int nb = 0;
     xmlChar *prefixes;
     xmlChar *prefix, *end;
 
     if ((cur == NULL) || (style == NULL) || (cur->type != XML_ELEMENT_NODE))
-    return(0);
+        return(0);
 
     if (isXsltElem)
-    prefixes = xmlGetNsProp(cur,
-        (const xmlChar *)"exclude-result-prefixes", NULL);
+        prefixes = xmlGetNsProp(cur,
+            (const xmlChar *)"exclude-result-prefixes", NULL);
     else
-    prefixes = xmlGetNsProp(cur,
-        (const xmlChar *)"exclude-result-prefixes", XSLT_NAMESPACE);
+        prefixes = xmlGetNsProp(cur,
+            (const xmlChar *)"exclude-result-prefixes", XSLT_NAMESPACE);
 
     if (prefixes == NULL) {
-    return(0);
+        return(0);
     }
 
     prefix = prefixes;
     while (*prefix != 0) {
-    while (IS_BLANK(*prefix)) prefix++;
-    if (*prefix == 0)
-        break;
+        while (IS_BLANK(*prefix)) prefix++;
+        if (*prefix == 0)
+            break;
         end = prefix;
-    while ((*end != 0) && (!IS_BLANK(*end))) end++;
-    prefix = xmlStrndup(prefix, end - prefix);
-    if (prefix) {
-        xmlNsPtr ns;
+        while ((*end != 0) && (!IS_BLANK(*end))) end++;
+        prefix = xmlStrndup(prefix, end - prefix);
+        if (prefix) {
+            xmlNsPtr ns;
 
-        if (xmlStrEqual(prefix, (const xmlChar *)"#default"))
-        ns = xmlSearchNs(style->doc, cur, NULL);
-        else
-        ns = xmlSearchNs(style->doc, cur, prefix);
-        if (ns == NULL) {
-        xsltTransformError(NULL, style, cur,
-        "xsl:exclude-result-prefixes : undefined namespace %s\n",
-                             prefix);
-        if (style != NULL) style->warnings++;
-        } else {
-        if (exclPrefixPush(style, (xmlChar *) ns->href) >= 0) {
+            if (xmlStrEqual(prefix, (const xmlChar *)"#default"))
+                ns = xmlSearchNs(style->doc, cur, NULL);
+            else
+                ns = xmlSearchNs(style->doc, cur, prefix);
+            if (ns == NULL) {
+                xsltTransformError(NULL, style, cur,
+            "xsl:exclude-result-prefixes : undefined namespace %s\n",
+                                 prefix);
+                if (style != NULL) style->warnings++;
+            } else {
+                if (exclPrefixPush(style, (xmlChar *) ns->href) >= 0) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-            xsltGenericDebug(xsltGenericDebugContext,
-            "exclude result prefix %s\n", prefix);
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "exclude result prefix %s\n", prefix);
 #endif
-            nb++;
+                    nb++;
+                }
+            }
+            xmlFree(prefix);
         }
-        }
-        xmlFree(prefix);
-    }
-    prefix = end;
+        prefix = end;
     }
     xmlFree(prefixes);
     return(nb);
@@ -1836,34 +1836,34 @@ static xmlNsPtr
 xsltTreeEnsureXMLDecl(xmlDocPtr doc)
 {
     if (doc == NULL)
-    return (NULL);
-    if (doc->oldNs != NULL)
-    return (doc->oldNs);
-    {
-    xmlNsPtr ns;
-    ns = (xmlNsPtr) xmlMalloc(sizeof(xmlNs));
-    if (ns == NULL) {
-        xmlGenericError(xmlGenericErrorContext,
-        "xsltTreeEnsureXMLDecl: Failed to allocate "
-        "the XML namespace.\n");
         return (NULL);
-    }
-    memset(ns, 0, sizeof(xmlNs));
-    ns->type = XML_LOCAL_NAMESPACE;
-    /*
-    * URGENT TODO: revisit this.
-    */
+    if (doc->oldNs != NULL)
+        return (doc->oldNs);
+    {
+        xmlNsPtr ns;
+        ns = (xmlNsPtr) xmlMalloc(sizeof(xmlNs));
+        if (ns == NULL) {
+            xmlGenericError(xmlGenericErrorContext,
+                "xsltTreeEnsureXMLDecl: Failed to allocate "
+                "the XML namespace.\n");
+            return (NULL);
+        }
+        memset(ns, 0, sizeof(xmlNs));
+        ns->type = XML_LOCAL_NAMESPACE;
+        /*
+        * URGENT TODO: revisit this.
+        */
 #ifdef LIBXML_NAMESPACE_DICT
-    if (doc->dict)
-        ns->href = xmlDictLookup(doc->dict, XML_XML_NAMESPACE, -1);
-    else
-        ns->href = xmlStrdup(XML_XML_NAMESPACE);
+        if (doc->dict)
+            ns->href = xmlDictLookup(doc->dict, XML_XML_NAMESPACE, -1);
+        else
+            ns->href = xmlStrdup(XML_XML_NAMESPACE);
 #else
-    ns->href = xmlStrdup(XML_XML_NAMESPACE);
+        ns->href = xmlStrdup(XML_XML_NAMESPACE);
 #endif
-    ns->prefix = xmlStrdup((const xmlChar *)"xml");
-    doc->oldNs = ns;
-    return (ns);
+        ns->prefix = xmlStrdup((const xmlChar *)"xml");
+        doc->oldNs = ns;
+        return (ns);
     }
 }
 
@@ -1883,39 +1883,39 @@ xsltTreeEnsureXMLDecl(xmlDocPtr doc)
 */
 static xmlNsPtr
 xsltTreeAcquireStoredNs(xmlDocPtr doc,
-            const xmlChar *nsName,
-            const xmlChar *prefix)
+                        const xmlChar *nsName,
+                        const xmlChar *prefix)
 {
     xmlNsPtr ns;
 
     if (doc == NULL)
-    return (NULL);
+        return (NULL);
     if (doc->oldNs != NULL)
-    ns = doc->oldNs;
+        ns = doc->oldNs;
     else
-    ns = xsltTreeEnsureXMLDecl(doc);
+        ns = xsltTreeEnsureXMLDecl(doc);
     if (ns == NULL)
-    return (NULL);
+        return (NULL);
     if (ns->next != NULL) {
-    /* Reuse. */
-    ns = ns->next;
-    while (ns != NULL) {
-        if ((ns->prefix == NULL) != (prefix == NULL)) {
-        /* NOP */
-        } else if (prefix == NULL) {
-        if (xmlStrEqual(ns->href, nsName))
-            return (ns);
-        } else {
-        if ((ns->prefix[0] == prefix[0]) &&
-             xmlStrEqual(ns->prefix, prefix) &&
-             xmlStrEqual(ns->href, nsName))
-            return (ns);
-
-        }
-        if (ns->next == NULL)
-        break;
+        /* Reuse. */
         ns = ns->next;
-    }
+        while (ns != NULL) {
+            if ((ns->prefix == NULL) != (prefix == NULL)) {
+                /* NOP */
+            } else if (prefix == NULL) {
+                if (xmlStrEqual(ns->href, nsName))
+                    return (ns);
+            } else {
+                if ((ns->prefix[0] == prefix[0]) &&
+                     xmlStrEqual(ns->prefix, prefix) &&
+                     xmlStrEqual(ns->href, nsName))
+                    return (ns);
+
+            }
+            if (ns->next == NULL)
+                break;
+            ns = ns->next;
+        }
     }
     /* Create. */
     ns->next = xmlNewNs(NULL, nsName, prefix);
@@ -1930,108 +1930,18 @@ xsltTreeAcquireStoredNs(xmlDocPtr doc,
  */
 static int
 xsltLREBuildEffectiveNs(xsltCompilerCtxtPtr cctxt,
-            xmlNodePtr elem)
+                        xmlNodePtr elem)
 {
     xmlNsPtr ns;
     xsltNsAliasPtr alias;
 
     if ((cctxt == NULL) || (elem == NULL))
-    return(-1);
+        return(-1);
     if ((cctxt->nsAliases == NULL) || (! cctxt->hasNsAliases))
-    return(0);
+        return(0);
 
     alias = cctxt->nsAliases;
     while (alias != NULL) {
-    if ( /* If both namespaces are NULL... */
-        ( (elem->ns == NULL) &&
-        ((alias->literalNs == NULL) ||
-        (alias->literalNs->href == NULL)) ) ||
-        /* ... or both namespace are equal */
-        ( (elem->ns != NULL) &&
-        (alias->literalNs != NULL) &&
-        xmlStrEqual(elem->ns->href, alias->literalNs->href) ) )
-    {
-        if ((alias->targetNs != NULL) &&
-        (alias->targetNs->href != NULL))
-        {
-        /*
-        * Convert namespace.
-        */
-        if (elem->doc == alias->docOfTargetNs) {
-            /*
-            * This is the nice case: same docs.
-            * This will eventually assign a ns-decl which
-            * is shadowed, but this has no negative effect on
-            * the generation of the result tree.
-            */
-            elem->ns = alias->targetNs;
-        } else {
-            /*
-            * This target xmlNs originates from a different
-            * stylesheet tree. Try to locate it in the
-            * in-scope namespaces.
-            * OPTIMIZE TODO: Use the compiler-node-info inScopeNs.
-            */
-            ns = xmlSearchNs(elem->doc, elem,
-            alias->targetNs->prefix);
-            /*
-            * If no matching ns-decl found, then assign a
-            * ns-decl stored in xmlDoc.
-            */
-            if ((ns == NULL) ||
-            (! xmlStrEqual(ns->href, alias->targetNs->href)))
-            {
-            /*
-            * BIG NOTE: The use of xsltTreeAcquireStoredNs()
-            *  is not very efficient, but currently I don't
-            *  see an other way of *safely* changing a node's
-            *  namespace, since the xmlNs struct in
-            *  alias->targetNs might come from an other
-            *  stylesheet tree. So we need to anchor it in the
-            *  current document, without adding it to the tree,
-            *  which would otherwise change the in-scope-ns
-            *  semantic of the tree.
-            */
-            ns = xsltTreeAcquireStoredNs(elem->doc,
-                alias->targetNs->href,
-                alias->targetNs->prefix);
-
-            if (ns == NULL) {
-                xsltTransformError(NULL, cctxt->style, elem,
-                "Internal error in "
-                "xsltLREBuildEffectiveNs(): "
-                "failed to acquire a stored "
-                "ns-declaration.\n");
-                cctxt->style->errors++;
-                return(-1);
-
-            }
-            }
-            elem->ns = ns;
-        }
-        } else {
-        /*
-        * Move into or leave in the NULL namespace.
-        */
-        elem->ns = NULL;
-        }
-        break;
-    }
-    alias = alias->next;
-    }
-    /*
-    * Same with attributes of literal result elements.
-    */
-    if (elem->properties != NULL) {
-    xmlAttrPtr attr = elem->properties;
-
-    while (attr != NULL) {
-        if (attr->ns == NULL) {
-        attr = attr->next;
-        continue;
-        }
-        alias = cctxt->nsAliases;
-        while (alias != NULL) {
         if ( /* If both namespaces are NULL... */
             ( (elem->ns == NULL) &&
             ((alias->literalNs == NULL) ||
@@ -2042,46 +1952,136 @@ xsltLREBuildEffectiveNs(xsltCompilerCtxtPtr cctxt,
             xmlStrEqual(elem->ns->href, alias->literalNs->href) ) )
         {
             if ((alias->targetNs != NULL) &&
-            (alias->targetNs->href != NULL))
+                (alias->targetNs->href != NULL))
             {
-            if (elem->doc == alias->docOfTargetNs) {
-                elem->ns = alias->targetNs;
-            } else {
-                ns = xmlSearchNs(elem->doc, elem,
-                alias->targetNs->prefix);
-                if ((ns == NULL) ||
-                (! xmlStrEqual(ns->href, alias->targetNs->href)))
-                {
-                ns = xsltTreeAcquireStoredNs(elem->doc,
-                    alias->targetNs->href,
-                    alias->targetNs->prefix);
+                /*
+                * Convert namespace.
+                */
+                if (elem->doc == alias->docOfTargetNs) {
+                    /*
+                    * This is the nice case: same docs.
+                    * This will eventually assign a ns-decl which
+                    * is shadowed, but this has no negative effect on
+                    * the generation of the result tree.
+                    */
+                    elem->ns = alias->targetNs;
+                } else {
+                    /*
+                    * This target xmlNs originates from a different
+                    * stylesheet tree. Try to locate it in the
+                    * in-scope namespaces.
+                    * OPTIMIZE TODO: Use the compiler-node-info inScopeNs.
+                    */
+                    ns = xmlSearchNs(elem->doc, elem,
+                        alias->targetNs->prefix);
+                    /*
+                    * If no matching ns-decl found, then assign a
+                    * ns-decl stored in xmlDoc.
+                    */
+                    if ((ns == NULL) ||
+                        (! xmlStrEqual(ns->href, alias->targetNs->href)))
+                    {
+                        /*
+                        * BIG NOTE: The use of xsltTreeAcquireStoredNs()
+                        *  is not very efficient, but currently I don't
+                        *  see an other way of *safely* changing a node's
+                        *  namespace, since the xmlNs struct in
+                        *  alias->targetNs might come from an other
+                        *  stylesheet tree. So we need to anchor it in the
+                        *  current document, without adding it to the tree,
+                        *  which would otherwise change the in-scope-ns
+                        *  semantic of the tree.
+                        */
+                        ns = xsltTreeAcquireStoredNs(elem->doc,
+                            alias->targetNs->href,
+                            alias->targetNs->prefix);
 
-                if (ns == NULL) {
-                    xsltTransformError(NULL, cctxt->style, elem,
-                    "Internal error in "
-                    "xsltLREBuildEffectiveNs(): "
-                    "failed to acquire a stored "
-                    "ns-declaration.\n");
-                    cctxt->style->errors++;
-                    return(-1);
+                        if (ns == NULL) {
+                            xsltTransformError(NULL, cctxt->style, elem,
+                                "Internal error in "
+                                "xsltLREBuildEffectiveNs(): "
+                                "failed to acquire a stored "
+                                "ns-declaration.\n");
+                            cctxt->style->errors++;
+                            return(-1);
 
+                        }
+                    }
+                    elem->ns = ns;
                 }
-                }
-                elem->ns = ns;
-            }
             } else {
-            /*
-            * Move into or leave in the NULL namespace.
-            */
-            elem->ns = NULL;
+                /*
+                * Move into or leave in the NULL namespace.
+                */
+                elem->ns = NULL;
             }
             break;
         }
         alias = alias->next;
-        }
-
-        attr = attr->next;
     }
+    /*
+    * Same with attributes of literal result elements.
+    */
+    if (elem->properties != NULL) {
+        xmlAttrPtr attr = elem->properties;
+
+        while (attr != NULL) {
+            if (attr->ns == NULL) {
+                attr = attr->next;
+                continue;
+            }
+            alias = cctxt->nsAliases;
+            while (alias != NULL) {
+                if ( /* If both namespaces are NULL... */
+                    ( (elem->ns == NULL) &&
+                    ((alias->literalNs == NULL) ||
+                    (alias->literalNs->href == NULL)) ) ||
+                    /* ... or both namespace are equal */
+                    ( (elem->ns != NULL) &&
+                    (alias->literalNs != NULL) &&
+                    xmlStrEqual(elem->ns->href, alias->literalNs->href) ) )
+                {
+                    if ((alias->targetNs != NULL) &&
+                        (alias->targetNs->href != NULL))
+                    {
+                        if (elem->doc == alias->docOfTargetNs) {
+                            elem->ns = alias->targetNs;
+                        } else {
+                            ns = xmlSearchNs(elem->doc, elem,
+                                alias->targetNs->prefix);
+                            if ((ns == NULL) ||
+                                (! xmlStrEqual(ns->href, alias->targetNs->href)))
+                            {
+                                ns = xsltTreeAcquireStoredNs(elem->doc,
+                                    alias->targetNs->href,
+                                    alias->targetNs->prefix);
+
+                                if (ns == NULL) {
+                                    xsltTransformError(NULL, cctxt->style, elem,
+                                        "Internal error in "
+                                        "xsltLREBuildEffectiveNs(): "
+                                        "failed to acquire a stored "
+                                        "ns-declaration.\n");
+                                    cctxt->style->errors++;
+                                    return(-1);
+
+                                }
+                            }
+                            elem->ns = ns;
+                        }
+                    } else {
+                    /*
+                    * Move into or leave in the NULL namespace.
+                        */
+                        elem->ns = NULL;
+                    }
+                    break;
+                }
+                alias = alias->next;
+            }
+
+            attr = attr->next;
+        }
     }
     return(0);
 }
@@ -2101,9 +2101,9 @@ xsltLREBuildEffectiveNs(xsltCompilerCtxtPtr cctxt,
  */
 static int
 xsltLREBuildEffectiveNsNodes(xsltCompilerCtxtPtr cctxt,
-                 xsltStyleItemLRElementInfoPtr item,
-                 xmlNodePtr elem,
-                 int isLRE)
+                             xsltStyleItemLRElementInfoPtr item,
+                             xmlNodePtr elem,
+                             int isLRE)
 {
     xmlNsPtr ns, tmpns;
     xsltEffectiveNsPtr effNs, lastEffNs = NULL;
@@ -2112,154 +2112,154 @@ xsltLREBuildEffectiveNsNodes(xsltCompilerCtxtPtr cctxt,
     xsltPointerListPtr exclResultNs = cctxt->inode->exclResultNs;
 
     if ((cctxt == NULL) || (cctxt->inode == NULL) || (elem == NULL) ||
-    (item == NULL) || (item->effectiveNs != NULL))
-    return(-1);
+        (item == NULL) || (item->effectiveNs != NULL))
+        return(-1);
 
     if (item->inScopeNs == NULL)
-    return(0);
+        return(0);
 
     extElemNs = cctxt->inode->extElemNs;
     exclResultNs = cctxt->inode->exclResultNs;
 
     for (i = 0; i < item->inScopeNs->totalNumber; i++) {
-    ns = item->inScopeNs->list[i];
-    /*
-    * Skip namespaces designated as excluded namespaces
-    * -------------------------------------------------
-    *
-    * XSLT-20 TODO: In XSLT 2.0 we need to keep namespaces
-    *  which are target namespaces of namespace-aliases
-    *  regardless if designated as excluded.
-    *
-    * Exclude the XSLT namespace.
-    */
-    if (xmlStrEqual(ns->href, XSLT_NAMESPACE))
-        goto skip_ns;
+        ns = item->inScopeNs->list[i];
+        /*
+        * Skip namespaces designated as excluded namespaces
+        * -------------------------------------------------
+        *
+        * XSLT-20 TODO: In XSLT 2.0 we need to keep namespaces
+        *  which are target namespaces of namespace-aliases
+        *  regardless if designated as excluded.
+        *
+        * Exclude the XSLT namespace.
+        */
+        if (xmlStrEqual(ns->href, XSLT_NAMESPACE))
+            goto skip_ns;
 
-    /*
-    * Apply namespace aliasing
-    * ------------------------
-    *
-    * SPEC XSLT 2.0
-    *  "- A namespace node whose string value is a literal namespace
-    *     URI is not copied to the result tree.
-    *   - A namespace node whose string value is a target namespace URI
-    *     is copied to the result tree, whether or not the URI
-    *     identifies an excluded namespace."
-    *
-    * NOTE: The ns-aliasing machanism is non-cascading.
-    *  (checked with Saxon, Xalan and MSXML .NET).
-    * URGENT TODO: is style->nsAliases the effective list of
-    *  ns-aliases, or do we need to lookup the whole
-    *  import-tree?
-    * TODO: Get rid of import-tree lookup.
-    */
-    if (cctxt->hasNsAliases) {
-        xsltNsAliasPtr alias;
         /*
-        * First check for being a target namespace.
+        * Apply namespace aliasing
+        * ------------------------
+        *
+        * SPEC XSLT 2.0
+        *  "- A namespace node whose string value is a literal namespace
+        *     URI is not copied to the result tree.
+        *   - A namespace node whose string value is a target namespace URI
+        *     is copied to the result tree, whether or not the URI
+        *     identifies an excluded namespace."
+        *
+        * NOTE: The ns-aliasing machanism is non-cascading.
+        *  (checked with Saxon, Xalan and MSXML .NET).
+        * URGENT TODO: is style->nsAliases the effective list of
+        *  ns-aliases, or do we need to lookup the whole
+        *  import-tree?
+        * TODO: Get rid of import-tree lookup.
         */
-        alias = cctxt->nsAliases;
-        do {
-        /*
-        * TODO: Is xmlns="" handled already?
-        */
-        if ((alias->targetNs != NULL) &&
-            (xmlStrEqual(alias->targetNs->href, ns->href)))
-        {
+        if (cctxt->hasNsAliases) {
+            xsltNsAliasPtr alias;
             /*
-            * Recognized as a target namespace; use it regardless
-            * if excluded otherwise.
+            * First check for being a target namespace.
             */
-            goto add_effective_ns;
-        }
-        alias = alias->next;
-        } while (alias != NULL);
+            alias = cctxt->nsAliases;
+            do {
+                /*
+                * TODO: Is xmlns="" handled already?
+                */
+                if ((alias->targetNs != NULL) &&
+                    (xmlStrEqual(alias->targetNs->href, ns->href)))
+                {
+                    /*
+                    * Recognized as a target namespace; use it regardless
+                    * if excluded otherwise.
+                    */
+                    goto add_effective_ns;
+                }
+                alias = alias->next;
+            } while (alias != NULL);
 
-        alias = cctxt->nsAliases;
-        do {
+            alias = cctxt->nsAliases;
+            do {
+                /*
+                * TODO: Is xmlns="" handled already?
+                */
+                if ((alias->literalNs != NULL) &&
+                    (xmlStrEqual(alias->literalNs->href, ns->href)))
+                {
+                    /*
+                    * Recognized as an namespace alias; do not use it.
+                    */
+                    goto skip_ns;
+                }
+                alias = alias->next;
+            } while (alias != NULL);
+        }
+
         /*
-        * TODO: Is xmlns="" handled already?
+        * Exclude excluded result namespaces.
         */
-        if ((alias->literalNs != NULL) &&
-            (xmlStrEqual(alias->literalNs->href, ns->href)))
-        {
-            /*
-            * Recognized as an namespace alias; do not use it.
-            */
-            goto skip_ns;
+        if (exclResultNs) {
+            for (j = 0; j < exclResultNs->number; j++)
+                if (xmlStrEqual(ns->href, BAD_CAST exclResultNs->items[j]))
+                    goto skip_ns;
         }
-        alias = alias->next;
-        } while (alias != NULL);
-    }
-
-    /*
-    * Exclude excluded result namespaces.
-    */
-    if (exclResultNs) {
-        for (j = 0; j < exclResultNs->number; j++)
-        if (xmlStrEqual(ns->href, BAD_CAST exclResultNs->items[j]))
-            goto skip_ns;
-    }
-    /*
-    * Exclude extension-element namespaces.
-    */
-    if (extElemNs) {
-        for (j = 0; j < extElemNs->number; j++)
-        if (xmlStrEqual(ns->href, BAD_CAST extElemNs->items[j]))
-            goto skip_ns;
-    }
+        /*
+        * Exclude extension-element namespaces.
+        */
+        if (extElemNs) {
+            for (j = 0; j < extElemNs->number; j++)
+                if (xmlStrEqual(ns->href, BAD_CAST extElemNs->items[j]))
+                    goto skip_ns;
+        }
 
 add_effective_ns:
-    /*
-    * OPTIMIZE TODO: This information may not be needed.
-    */
-    if (isLRE && (elem->nsDef != NULL)) {
-        holdByElem = 0;
-        tmpns = elem->nsDef;
-        do {
-        if (tmpns == ns) {
-            holdByElem = 1;
-            break;
+        /*
+        * OPTIMIZE TODO: This information may not be needed.
+        */
+        if (isLRE && (elem->nsDef != NULL)) {
+            holdByElem = 0;
+            tmpns = elem->nsDef;
+            do {
+                if (tmpns == ns) {
+                    holdByElem = 1;
+                    break;
+                }
+                tmpns = tmpns->next;
+            } while (tmpns != NULL);
+        } else
+            holdByElem = 0;
+
+
+        /*
+        * Add the effective namespace declaration.
+        */
+        effNs = (xsltEffectiveNsPtr) xmlMalloc(sizeof(xsltEffectiveNs));
+        if (effNs == NULL) {
+            xsltTransformError(NULL, cctxt->style, elem,
+                "Internal error in xsltLREBuildEffectiveNs(): "
+                "failed to allocate memory.\n");
+            cctxt->style->errors++;
+            return(-1);
         }
-        tmpns = tmpns->next;
-        } while (tmpns != NULL);
-    } else
-        holdByElem = 0;
+        if (cctxt->psData->effectiveNs == NULL) {
+            cctxt->psData->effectiveNs = effNs;
+            effNs->nextInStore = NULL;
+        } else {
+            effNs->nextInStore = cctxt->psData->effectiveNs;
+            cctxt->psData->effectiveNs = effNs;
+        }
 
+        effNs->next = NULL;
+        effNs->prefix = ns->prefix;
+        effNs->nsName = ns->href;
+        effNs->holdByElem = holdByElem;
 
-    /*
-    * Add the effective namespace declaration.
-    */
-    effNs = (xsltEffectiveNsPtr) xmlMalloc(sizeof(xsltEffectiveNs));
-    if (effNs == NULL) {
-        xsltTransformError(NULL, cctxt->style, elem,
-        "Internal error in xsltLREBuildEffectiveNs(): "
-        "failed to allocate memory.\n");
-        cctxt->style->errors++;
-        return(-1);
-    }
-    if (cctxt->psData->effectiveNs == NULL) {
-        cctxt->psData->effectiveNs = effNs;
-        effNs->nextInStore = NULL;
-    } else {
-        effNs->nextInStore = cctxt->psData->effectiveNs;
-        cctxt->psData->effectiveNs = effNs;
-    }
-
-    effNs->next = NULL;
-    effNs->prefix = ns->prefix;
-    effNs->nsName = ns->href;
-    effNs->holdByElem = holdByElem;
-
-    if (lastEffNs == NULL)
-        item->effectiveNs = effNs;
-    else
-        lastEffNs->next = effNs;
-    lastEffNs = effNs;
+        if (lastEffNs == NULL)
+            item->effectiveNs = effNs;
+        else
+            lastEffNs->next = effNs;
+        lastEffNs = effNs;
 
 skip_ns:
-    {}
+        {}
     }
     return(0);
 }
@@ -2274,22 +2274,22 @@ skip_ns:
  */
 static int
 xsltLREInfoCreate(xsltCompilerCtxtPtr cctxt,
-          xmlNodePtr elem,
-          int isLRE)
+                  xmlNodePtr elem,
+                  int isLRE)
 {
     xsltStyleItemLRElementInfoPtr item;
 
     if ((cctxt == NULL) || (cctxt->inode == NULL))
-    return(-1);
+        return(-1);
 
     item = (xsltStyleItemLRElementInfoPtr)
-    xmlMalloc(sizeof(xsltStyleItemLRElementInfo));
+        xmlMalloc(sizeof(xsltStyleItemLRElementInfo));
     if (item == NULL) {
-    xsltTransformError(NULL, cctxt->style, NULL,
-        "Internal error in xsltLREInfoCreate(): "
-        "memory allocation failed.\n");
-    cctxt->style->errors++;
-    return(-1);
+        xsltTransformError(NULL, cctxt->style, NULL,
+            "Internal error in xsltLREInfoCreate(): "
+            "memory allocation failed.\n");
+        cctxt->style->errors++;
+        return(-1);
     }
     memset(item, 0, sizeof(xsltStyleItemLRElementInfo));
     item->type = XSLT_FUNC_LITERAL_RESULT_ELEMENT;
@@ -2305,7 +2305,7 @@ xsltLREInfoCreate(xsltCompilerCtxtPtr cctxt,
     item->inScopeNs = cctxt->inode->inScopeNs;
 
     if (elem)
-    xsltLREBuildEffectiveNsNodes(cctxt, item, elem, isLRE);
+        xsltLREBuildEffectiveNsNodes(cctxt, item, elem, isLRE);
 
     cctxt->inode->litResElemInfo = item;
     cctxt->inode->nsChanged = 0;
@@ -2323,34 +2323,34 @@ xsltLREInfoCreate(xsltCompilerCtxtPtr cctxt,
  */
 static xsltVarInfoPtr
 xsltCompilerVarInfoPush(xsltCompilerCtxtPtr cctxt,
-                  xmlNodePtr inst,
-                  const xmlChar *name,
-                  const xmlChar *nsName)
+                                  xmlNodePtr inst,
+                                  const xmlChar *name,
+                                  const xmlChar *nsName)
 {
     xsltVarInfoPtr ivar;
 
     if ((cctxt->ivar != NULL) && (cctxt->ivar->next != NULL)) {
-    ivar = cctxt->ivar->next;
+        ivar = cctxt->ivar->next;
     } else if ((cctxt->ivar == NULL) && (cctxt->ivars != NULL)) {
-    ivar = cctxt->ivars;
+        ivar = cctxt->ivars;
     } else {
-    ivar = (xsltVarInfoPtr) xmlMalloc(sizeof(xsltVarInfo));
-    if (ivar == NULL) {
-        xsltTransformError(NULL, cctxt->style, inst,
-        "xsltParseInScopeVarPush: xmlMalloc() failed!\n");
-        cctxt->style->errors++;
-        return(NULL);
-    }
-    /* memset(retVar, 0, sizeof(xsltInScopeVar)); */
-    if (cctxt->ivars == NULL) {
-        cctxt->ivars = ivar;
-        ivar->prev = NULL;
-    } else {
-        cctxt->ivar->next = ivar;
-        ivar->prev = cctxt->ivar;
-    }
-    cctxt->ivar = ivar;
-    ivar->next = NULL;
+        ivar = (xsltVarInfoPtr) xmlMalloc(sizeof(xsltVarInfo));
+        if (ivar == NULL) {
+            xsltTransformError(NULL, cctxt->style, inst,
+                "xsltParseInScopeVarPush: xmlMalloc() failed!\n");
+            cctxt->style->errors++;
+            return(NULL);
+        }
+        /* memset(retVar, 0, sizeof(xsltInScopeVar)); */
+        if (cctxt->ivars == NULL) {
+            cctxt->ivars = ivar;
+            ivar->prev = NULL;
+        } else {
+            cctxt->ivar->next = ivar;
+            ivar->prev = cctxt->ivar;
+        }
+        cctxt->ivar = ivar;
+        ivar->next = NULL;
     }
     ivar->depth = cctxt->depth;
     ivar->name = name;
@@ -2370,9 +2370,9 @@ xsltCompilerVarInfoPop(xsltCompilerCtxtPtr cctxt)
 {
 
     while ((cctxt->ivar != NULL) &&
-    (cctxt->ivar->depth > cctxt->depth))
+        (cctxt->ivar->depth > cctxt->depth))
     {
-    cctxt->ivar = cctxt->ivar->prev;
+        cctxt->ivar = cctxt->ivar->prev;
     }
 }
 
@@ -2393,37 +2393,37 @@ xsltCompilerNodePush(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     xsltCompilerNodeInfoPtr inode, iprev;
 
     if ((cctxt->inode != NULL) && (cctxt->inode->next != NULL)) {
-    inode = cctxt->inode->next;
+        inode = cctxt->inode->next;
     } else if ((cctxt->inode == NULL) && (cctxt->inodeList != NULL)) {
-    inode = cctxt->inodeList;
+        inode = cctxt->inodeList;
     } else {
-    /*
-    * Create a new node-info.
-    */
-    inode = (xsltCompilerNodeInfoPtr)
-        xmlMalloc(sizeof(xsltCompilerNodeInfo));
-    if (inode == NULL) {
-        xsltTransformError(NULL, cctxt->style, NULL,
-        "xsltCompilerNodePush: malloc failed.\n");
-        return(NULL);
-    }
-    memset(inode, 0, sizeof(xsltCompilerNodeInfo));
-    if (cctxt->inodeList == NULL)
-        cctxt->inodeList = inode;
-    else {
-        cctxt->inodeLast->next = inode;
-        inode->prev = cctxt->inodeLast;
-    }
-    cctxt->inodeLast = inode;
-    cctxt->maxNodeInfos++;
-    if (cctxt->inode == NULL) {
-        cctxt->inode = inode;
         /*
-        * Create an initial literal result element info for
-        * the root of the stylesheet.
+        * Create a new node-info.
         */
-        xsltLREInfoCreate(cctxt, NULL, 0);
-    }
+        inode = (xsltCompilerNodeInfoPtr)
+            xmlMalloc(sizeof(xsltCompilerNodeInfo));
+        if (inode == NULL) {
+            xsltTransformError(NULL, cctxt->style, NULL,
+                "xsltCompilerNodePush: malloc failed.\n");
+            return(NULL);
+        }
+        memset(inode, 0, sizeof(xsltCompilerNodeInfo));
+        if (cctxt->inodeList == NULL)
+            cctxt->inodeList = inode;
+        else {
+            cctxt->inodeLast->next = inode;
+            inode->prev = cctxt->inodeLast;
+        }
+        cctxt->inodeLast = inode;
+        cctxt->maxNodeInfos++;
+        if (cctxt->inode == NULL) {
+            cctxt->inode = inode;
+            /*
+            * Create an initial literal result element info for
+            * the root of the stylesheet.
+            */
+            xsltLREInfoCreate(cctxt, NULL, 0);
+        }
     }
     cctxt->depth++;
     cctxt->inode = inode;
@@ -2443,41 +2443,41 @@ xsltCompilerNodePush(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     inode->isRoot = 0;
 
     if (inode->prev != NULL) {
-    iprev = inode->prev;
-    /*
-    * Inherit the following information:
-    * ---------------------------------
-    *
-    * In-scope namespaces
-    */
-    inode->inScopeNs = iprev->inScopeNs;
-    /*
-    * Info for literal result elements
-    */
-    inode->litResElemInfo = iprev->litResElemInfo;
-    inode->nsChanged = iprev->nsChanged;
-    /*
-    * Excluded result namespaces
-    */
-    inode->exclResultNs = iprev->exclResultNs;
-    /*
-    * Extension instruction namespaces
-    */
-    inode->extElemNs = iprev->extElemNs;
-    /*
-    * Whitespace preservation
-    */
-    inode->preserveWhitespace = iprev->preserveWhitespace;
-    /*
-    * Forwards-compatible mode
-    */
-    inode->forwardsCompat = iprev->forwardsCompat;
+        iprev = inode->prev;
+        /*
+        * Inherit the following information:
+        * ---------------------------------
+        *
+        * In-scope namespaces
+        */
+        inode->inScopeNs = iprev->inScopeNs;
+        /*
+        * Info for literal result elements
+        */
+        inode->litResElemInfo = iprev->litResElemInfo;
+        inode->nsChanged = iprev->nsChanged;
+        /*
+        * Excluded result namespaces
+        */
+        inode->exclResultNs = iprev->exclResultNs;
+        /*
+        * Extension instruction namespaces
+        */
+        inode->extElemNs = iprev->extElemNs;
+        /*
+        * Whitespace preservation
+        */
+        inode->preserveWhitespace = iprev->preserveWhitespace;
+        /*
+        * Forwards-compatible mode
+        */
+        inode->forwardsCompat = iprev->forwardsCompat;
     } else {
-    inode->inScopeNs = NULL;
-    inode->exclResultNs = NULL;
-    inode->extElemNs = NULL;
-    inode->preserveWhitespace = 0;
-    inode->forwardsCompat = 0;
+        inode->inScopeNs = NULL;
+        inode->exclResultNs = NULL;
+        inode->extElemNs = NULL;
+        inode->preserveWhitespace = 0;
+        inode->forwardsCompat = 0;
     }
 
     return(inode);
@@ -2495,76 +2495,76 @@ static void
 xsltCompilerNodePop(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
 {
     if (cctxt->inode == NULL) {
-    xmlGenericError(xmlGenericErrorContext,
-        "xsltCompilerNodePop: Top-node mismatch.\n");
-    return;
+        xmlGenericError(xmlGenericErrorContext,
+            "xsltCompilerNodePop: Top-node mismatch.\n");
+        return;
     }
     /*
     * NOTE: Be carefull with the @node, since it might be
     *  a doc-node.
     */
     if (cctxt->inode->node != node) {
-    xmlGenericError(xmlGenericErrorContext,
-    "xsltCompilerNodePop: Node mismatch.\n");
-    goto mismatch;
+        xmlGenericError(xmlGenericErrorContext,
+        "xsltCompilerNodePop: Node mismatch.\n");
+        goto mismatch;
     }
     if (cctxt->inode->depth != cctxt->depth) {
-    xmlGenericError(xmlGenericErrorContext,
-    "xsltCompilerNodePop: Depth mismatch.\n");
-    goto mismatch;
+        xmlGenericError(xmlGenericErrorContext,
+        "xsltCompilerNodePop: Depth mismatch.\n");
+        goto mismatch;
     }
     cctxt->depth--;
     /*
     * Pop information of variables.
     */
     if ((cctxt->ivar) && (cctxt->ivar->depth > cctxt->depth))
-    xsltCompilerVarInfoPop(cctxt);
+        xsltCompilerVarInfoPop(cctxt);
 
     cctxt->inode = cctxt->inode->prev;
     if (cctxt->inode != NULL)
-    cctxt->inode->curChildType = 0;
+        cctxt->inode->curChildType = 0;
     return;
 
 mismatch:
     {
-    const xmlChar *nsName = NULL, *name = NULL;
-    const xmlChar *infnsName = NULL, *infname = NULL;
+        const xmlChar *nsName = NULL, *name = NULL;
+        const xmlChar *infnsName = NULL, *infname = NULL;
 
-    if (node) {
-        if (node->type == XML_ELEMENT_NODE) {
-        name = node->name;
-        if (node->ns != NULL)
-            nsName = node->ns->href;
-        else
-            nsName = BAD_CAST "";
-        } else {
-        name = BAD_CAST "#document";
-        nsName = BAD_CAST "";
-        }
-    } else
-        name = BAD_CAST "Not given";
+        if (node) {
+            if (node->type == XML_ELEMENT_NODE) {
+                name = node->name;
+                if (node->ns != NULL)
+                    nsName = node->ns->href;
+                else
+                    nsName = BAD_CAST "";
+            } else {
+                name = BAD_CAST "#document";
+                nsName = BAD_CAST "";
+            }
+        } else
+            name = BAD_CAST "Not given";
 
-    if (cctxt->inode->node) {
-        if (node->type == XML_ELEMENT_NODE) {
-        infname = cctxt->inode->node->name;
-        if (cctxt->inode->node->ns != NULL)
-            infnsName = cctxt->inode->node->ns->href;
-        else
-            infnsName = BAD_CAST "";
-        } else {
-        infname = BAD_CAST "#document";
-        infnsName = BAD_CAST "";
-        }
-    } else
-        infname = BAD_CAST "Not given";
+        if (cctxt->inode->node) {
+            if (node->type == XML_ELEMENT_NODE) {
+                infname = cctxt->inode->node->name;
+                if (cctxt->inode->node->ns != NULL)
+                    infnsName = cctxt->inode->node->ns->href;
+                else
+                    infnsName = BAD_CAST "";
+            } else {
+                infname = BAD_CAST "#document";
+                infnsName = BAD_CAST "";
+            }
+        } else
+            infname = BAD_CAST "Not given";
 
 
-    xmlGenericError(xmlGenericErrorContext,
-        "xsltCompilerNodePop: Given   : '%s' URI '%s'\n",
-        name, nsName);
-    xmlGenericError(xmlGenericErrorContext,
-        "xsltCompilerNodePop: Expected: '%s' URI '%s'\n",
-        infname, infnsName);
+        xmlGenericError(xmlGenericErrorContext,
+            "xsltCompilerNodePop: Given   : '%s' URI '%s'\n",
+            name, nsName);
+        xmlGenericError(xmlGenericErrorContext,
+            "xsltCompilerNodePop: Expected: '%s' URI '%s'\n",
+            infname, infnsName);
     }
 }
 
@@ -2596,44 +2596,44 @@ xsltCompilerBuildInScopeNsList(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
             ns = node->nsDef;
             while (ns != NULL) {
                 if (nsi == NULL) {
-            nsi = (xsltNsListContainerPtr)
-            xmlMalloc(sizeof(xsltNsListContainer));
-            if (nsi == NULL) {
-            xsltTransformError(NULL, cctxt->style, NULL,
-                "xsltCompilerBuildInScopeNsList: "
-                "malloc failed!\n");
-            goto internal_err;
-            }
-            memset(nsi, 0, sizeof(xsltNsListContainer));
+                    nsi = (xsltNsListContainerPtr)
+                        xmlMalloc(sizeof(xsltNsListContainer));
+                    if (nsi == NULL) {
+                        xsltTransformError(NULL, cctxt->style, NULL,
+                            "xsltCompilerBuildInScopeNsList: "
+                            "malloc failed!\n");
+                        goto internal_err;
+                    }
+                    memset(nsi, 0, sizeof(xsltNsListContainer));
                     nsi->list =
                         (xmlNsPtr *) xmlMalloc(maxns * sizeof(xmlNsPtr));
                     if (nsi->list == NULL) {
-            xsltTransformError(NULL, cctxt->style, NULL,
-                "xsltCompilerBuildInScopeNsList: "
-                "malloc failed!\n");
-            goto internal_err;
+                        xsltTransformError(NULL, cctxt->style, NULL,
+                            "xsltCompilerBuildInScopeNsList: "
+                            "malloc failed!\n");
+                        goto internal_err;
                     }
                     nsi->list[0] = NULL;
                 }
-        /*
-        * Skip shadowed namespace bindings.
-        */
+                /*
+                * Skip shadowed namespace bindings.
+                */
                 for (i = 0; i < nsi->totalNumber; i++) {
                     if ((ns->prefix == nsi->list[i]->prefix) ||
                         (xmlStrEqual(ns->prefix, nsi->list[i]->prefix)))
-            break;
+                    break;
                 }
                 if (i >= nsi->totalNumber) {
                     if (nsi->totalNumber +1 >= maxns) {
                         maxns *= 2;
-            nsi->list =
-                (xmlNsPtr *) xmlRealloc(nsi->list,
-                maxns * sizeof(xmlNsPtr));
+                        nsi->list =
+                            (xmlNsPtr *) xmlRealloc(nsi->list,
+                                maxns * sizeof(xmlNsPtr));
                         if (nsi->list == NULL) {
                             xsltTransformError(NULL, cctxt->style, NULL,
-                "xsltCompilerBuildInScopeNsList: "
-                "realloc failed!\n");
-                goto internal_err;
+                                "xsltCompilerBuildInScopeNsList: "
+                                "realloc failed!\n");
+                                goto internal_err;
                         }
                     }
                     nsi->list[nsi->totalNumber++] = ns;
@@ -2646,120 +2646,120 @@ xsltCompilerBuildInScopeNsList(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
         node = node->parent;
     }
     if (nsi == NULL)
-    return(NULL);
+        return(NULL);
     /*
     * Move the default namespace to last position.
     */
     nsi->xpathNumber = nsi->totalNumber;
     for (i = 0; i < nsi->totalNumber; i++) {
-    if (nsi->list[i]->prefix == NULL) {
-        ns = nsi->list[i];
-        nsi->list[i] = nsi->list[nsi->totalNumber-1];
-        nsi->list[nsi->totalNumber-1] = ns;
-        nsi->xpathNumber--;
-        break;
-    }
+        if (nsi->list[i]->prefix == NULL) {
+            ns = nsi->list[i];
+            nsi->list[i] = nsi->list[nsi->totalNumber-1];
+            nsi->list[nsi->totalNumber-1] = ns;
+            nsi->xpathNumber--;
+            break;
+        }
     }
     /*
     * Store the ns-list in the stylesheet.
     */
     if (xsltPointerListAddSize(
-    (xsltPointerListPtr)cctxt->psData->inScopeNamespaces,
-    (void *) nsi, 5) == -1)
+        (xsltPointerListPtr)cctxt->psData->inScopeNamespaces,
+        (void *) nsi, 5) == -1)
     {
-    xmlFree(nsi);
-    nsi = NULL;
-    xsltTransformError(NULL, cctxt->style, NULL,
-        "xsltCompilerBuildInScopeNsList: failed to add ns-info.\n");
-    goto internal_err;
+        xmlFree(nsi);
+        nsi = NULL;
+        xsltTransformError(NULL, cctxt->style, NULL,
+            "xsltCompilerBuildInScopeNsList: failed to add ns-info.\n");
+        goto internal_err;
     }
     /*
     * Notify of change in status wrt namespaces.
     */
     if (cctxt->inode != NULL)
-    cctxt->inode->nsChanged = 1;
+        cctxt->inode->nsChanged = 1;
 
     return(nsi);
 
 internal_err:
     if (list != NULL)
-    xmlFree(list);
+        xmlFree(list);
     cctxt->style->errors++;
     return(NULL);
 }
 
 static int
 xsltParseNsPrefixList(xsltCompilerCtxtPtr cctxt,
-              xsltPointerListPtr list,
-              xmlNodePtr node,
-              const xmlChar *value)
+                      xsltPointerListPtr list,
+                      xmlNodePtr node,
+                      const xmlChar *value)
 {
     xmlChar *cur, *end;
     xmlNsPtr ns;
 
     if ((cctxt == NULL) || (value == NULL) || (list == NULL))
-    return(-1);
+        return(-1);
 
     list->number = 0;
 
     cur = (xmlChar *) value;
     while (*cur != 0) {
-    while (IS_BLANK(*cur)) cur++;
-    if (*cur == 0)
-        break;
-    end = cur;
-    while ((*end != 0) && (!IS_BLANK(*end))) end++;
-    cur = xmlStrndup(cur, end - cur);
-    if (cur == NULL) {
-        cur = end;
-        continue;
-    }
-    /*
-    * TODO: Export and use xmlSearchNsByPrefixStrict()
-    *   in Libxml2, tree.c, since xmlSearchNs() is in most
-    *   cases not efficient and in some cases not correct.
-    *
-    * XSLT-2 TODO: XSLT 2.0 allows an additional "#all" value.
-    */
-    if ((cur[0] == '#') &&
-        xmlStrEqual(cur, (const xmlChar *)"#default"))
-        ns = xmlSearchNs(cctxt->style->doc, node, NULL);
-    else
-        ns = xmlSearchNs(cctxt->style->doc, node, cur);
-
-    if (ns == NULL) {
-        /*
-        * TODO: Better to report the attr-node, otherwise
-        *  the user won't know which attribute was invalid.
-        */
-        xsltTransformError(NULL, cctxt->style, node,
-        "No namespace binding in scope for prefix '%s'.\n", cur);
-        /*
-        * XSLT-1.0: "It is an error if there is no namespace
-        *  bound to the prefix on the element bearing the
-        *  exclude-result-prefixes or xsl:exclude-result-prefixes
-        *  attribute."
-        */
-        cctxt->style->errors++;
-    } else {
-#ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-        "resolved prefix '%s'\n", cur);
-#endif
-        /*
-        * Note that we put the namespace name into the dict.
-        */
-        if (xsltPointerListAddSize(list,
-        (void *) xmlDictLookup(cctxt->style->dict,
-        ns->href, -1), 5) == -1)
-        {
-        xmlFree(cur);
-        goto internal_err;
+        while (IS_BLANK(*cur)) cur++;
+        if (*cur == 0)
+            break;
+        end = cur;
+        while ((*end != 0) && (!IS_BLANK(*end))) end++;
+        cur = xmlStrndup(cur, end - cur);
+        if (cur == NULL) {
+            cur = end;
+            continue;
         }
-    }
-    xmlFree(cur);
+        /*
+        * TODO: Export and use xmlSearchNsByPrefixStrict()
+        *   in Libxml2, tree.c, since xmlSearchNs() is in most
+        *   cases not efficient and in some cases not correct.
+        *
+        * XSLT-2 TODO: XSLT 2.0 allows an additional "#all" value.
+        */
+        if ((cur[0] == '#') &&
+            xmlStrEqual(cur, (const xmlChar *)"#default"))
+            ns = xmlSearchNs(cctxt->style->doc, node, NULL);
+        else
+            ns = xmlSearchNs(cctxt->style->doc, node, cur);
 
-    cur = end;
+        if (ns == NULL) {
+            /*
+            * TODO: Better to report the attr-node, otherwise
+            *  the user won't know which attribute was invalid.
+            */
+            xsltTransformError(NULL, cctxt->style, node,
+                "No namespace binding in scope for prefix '%s'.\n", cur);
+            /*
+            * XSLT-1.0: "It is an error if there is no namespace
+            *  bound to the prefix on the element bearing the
+            *  exclude-result-prefixes or xsl:exclude-result-prefixes
+            *  attribute."
+            */
+            cctxt->style->errors++;
+        } else {
+#ifdef WITH_XSLT_DEBUG_PARSING
+            xsltGenericDebug(xsltGenericDebugContext,
+                "resolved prefix '%s'\n", cur);
+#endif
+            /*
+            * Note that we put the namespace name into the dict.
+            */
+            if (xsltPointerListAddSize(list,
+                (void *) xmlDictLookup(cctxt->style->dict,
+                ns->href, -1), 5) == -1)
+            {
+                xmlFree(cur);
+                goto internal_err;
+            }
+        }
+        xmlFree(cur);
+
+        cur = end;
     }
     return(0);
 
@@ -2781,34 +2781,34 @@ internal_err:
  */
 static xsltPointerListPtr
 xsltCompilerUtilsCreateMergedList(xsltPointerListPtr first,
-                xsltPointerListPtr second)
+                            xsltPointerListPtr second)
 {
     xsltPointerListPtr ret;
     size_t num;
 
     if (first)
-    num = first->number;
+        num = first->number;
     else
-    num = 0;
+        num = 0;
     if (second)
-    num += second->number;
+        num += second->number;
     if (num == 0)
-    return(NULL);
+        return(NULL);
     ret = xsltPointerListCreate(num);
     if (ret == NULL)
-    return(NULL);
+        return(NULL);
     /*
     * Copy contents.
     */
     if ((first != NULL) &&  (first->number != 0)) {
-    memcpy(ret->items, first->items,
-        first->number * sizeof(void *));
-    if ((second != NULL) && (second->number != 0))
-        memcpy(ret->items + first->number, second->items,
-        second->number * sizeof(void *));
+        memcpy(ret->items, first->items,
+            first->number * sizeof(void *));
+        if ((second != NULL) && (second->number != 0))
+            memcpy(ret->items + first->number, second->items,
+                second->number * sizeof(void *));
     } else if ((second != NULL) && (second->number != 0))
-    memcpy(ret->items, (void *) second->items,
-        second->number * sizeof(void *));
+        memcpy(ret->items, (void *) second->items,
+            second->number * sizeof(void *));
     ret->number = num;
     return(ret);
 }
@@ -2825,73 +2825,73 @@ xsltCompilerUtilsCreateMergedList(xsltPointerListPtr first,
 */
 static xsltPointerListPtr
 xsltParseExclResultPrefixes(xsltCompilerCtxtPtr cctxt, xmlNodePtr node,
-                xsltPointerListPtr def,
-                int instrCategory)
+                            xsltPointerListPtr def,
+                            int instrCategory)
 {
     xsltPointerListPtr list = NULL;
     xmlChar *value;
     xmlAttrPtr attr;
 
     if ((cctxt == NULL) || (node == NULL))
-    return(NULL);
+        return(NULL);
 
     if (instrCategory == XSLT_ELEMENT_CATEGORY_XSLT)
-    attr = xmlHasNsProp(node, BAD_CAST "exclude-result-prefixes", NULL);
+        attr = xmlHasNsProp(node, BAD_CAST "exclude-result-prefixes", NULL);
     else
-    attr = xmlHasNsProp(node, BAD_CAST "exclude-result-prefixes",
-        XSLT_NAMESPACE);
+        attr = xmlHasNsProp(node, BAD_CAST "exclude-result-prefixes",
+            XSLT_NAMESPACE);
     if (attr == NULL)
-    return(def);
+        return(def);
 
     if (attr && (instrCategory == XSLT_ELEMENT_CATEGORY_LRE)) {
-    /*
-    * Mark the XSLT attr.
-    */
-    attr->psvi = (void *) xsltXSLTAttrMarker;
+        /*
+        * Mark the XSLT attr.
+        */
+        attr->psvi = (void *) xsltXSLTAttrMarker;
     }
 
     if ((attr->children != NULL) &&
-    (attr->children->content != NULL))
-    value = attr->children->content;
+        (attr->children->content != NULL))
+        value = attr->children->content;
     else {
-    xsltTransformError(NULL, cctxt->style, node,
-        "Attribute 'exclude-result-prefixes': Invalid value.\n");
-    cctxt->style->errors++;
-    return(def);
+        xsltTransformError(NULL, cctxt->style, node,
+            "Attribute 'exclude-result-prefixes': Invalid value.\n");
+        cctxt->style->errors++;
+        return(def);
     }
 
     if (xsltParseNsPrefixList(cctxt, cctxt->tmpList, node,
-    BAD_CAST value) != 0)
-    goto exit;
+        BAD_CAST value) != 0)
+        goto exit;
     if (cctxt->tmpList->number == 0)
-    goto exit;
+        goto exit;
     /*
     * Merge the list with the inherited list.
     */
     list = xsltCompilerUtilsCreateMergedList(def, cctxt->tmpList);
     if (list == NULL)
-    goto exit;
+        goto exit;
     /*
     * Store the list in the stylesheet/compiler context.
     */
     if (xsltPointerListAddSize(
-    cctxt->psData->exclResultNamespaces, list, 5) == -1)
+        cctxt->psData->exclResultNamespaces, list, 5) == -1)
     {
-    xsltPointerListFree(list);
-    list = NULL;
-    goto exit;
+        xsltPointerListFree(list);
+        list = NULL;
+        goto exit;
     }
     /*
     * Notify of change in status wrt namespaces.
     */
     if (cctxt->inode != NULL)
-    cctxt->inode->nsChanged = 1;
+        cctxt->inode->nsChanged = 1;
 
 exit:
     if (list != NULL)
-    return(list);
+        return(list);
     else
-    return(def);
+        return(def);
 }
 
 /*
@@ -2906,8 +2906,8 @@ exit:
 */
 static xsltPointerListPtr
 xsltParseExtElemPrefixes(xsltCompilerCtxtPtr cctxt, xmlNodePtr node,
-             xsltPointerListPtr def,
-             int instrCategory)
+                         xsltPointerListPtr def,
+                         int instrCategory)
 {
     xsltPointerListPtr list = NULL;
     xmlAttrPtr attr;
@@ -2915,73 +2915,73 @@ xsltParseExtElemPrefixes(xsltCompilerCtxtPtr cctxt, xmlNodePtr node,
     int i;
 
     if ((cctxt == NULL) || (node == NULL))
-    return(NULL);
+        return(NULL);
 
     if (instrCategory == XSLT_ELEMENT_CATEGORY_XSLT)
-    attr = xmlHasNsProp(node, BAD_CAST "extension-element-prefixes", NULL);
+        attr = xmlHasNsProp(node, BAD_CAST "extension-element-prefixes", NULL);
     else
-    attr = xmlHasNsProp(node, BAD_CAST "extension-element-prefixes",
-        XSLT_NAMESPACE);
+        attr = xmlHasNsProp(node, BAD_CAST "extension-element-prefixes",
+            XSLT_NAMESPACE);
     if (attr == NULL)
-    return(def);
+        return(def);
 
     if (attr && (instrCategory == XSLT_ELEMENT_CATEGORY_LRE)) {
-    /*
-    * Mark the XSLT attr.
-    */
-    attr->psvi = (void *) xsltXSLTAttrMarker;
+        /*
+        * Mark the XSLT attr.
+        */
+        attr->psvi = (void *) xsltXSLTAttrMarker;
     }
 
     if ((attr->children != NULL) &&
-    (attr->children->content != NULL))
-    value = attr->children->content;
+        (attr->children->content != NULL))
+        value = attr->children->content;
     else {
-    xsltTransformError(NULL, cctxt->style, node,
-        "Attribute 'extension-element-prefixes': Invalid value.\n");
-    cctxt->style->errors++;
-    return(def);
+        xsltTransformError(NULL, cctxt->style, node,
+            "Attribute 'extension-element-prefixes': Invalid value.\n");
+        cctxt->style->errors++;
+        return(def);
     }
 
 
     if (xsltParseNsPrefixList(cctxt, cctxt->tmpList, node,
-    BAD_CAST value) != 0)
-    goto exit;
+        BAD_CAST value) != 0)
+        goto exit;
 
     if (cctxt->tmpList->number == 0)
-    goto exit;
+        goto exit;
     /*
     * REVISIT: Register the extension namespaces.
     */
     for (i = 0; i < cctxt->tmpList->number; i++)
-    xsltRegisterExtPrefix(cctxt->style, NULL,
-    BAD_CAST cctxt->tmpList->items[i]);
+        xsltRegisterExtPrefix(cctxt->style, NULL,
+        BAD_CAST cctxt->tmpList->items[i]);
     /*
     * Merge the list with the inherited list.
     */
     list = xsltCompilerUtilsCreateMergedList(def, cctxt->tmpList);
     if (list == NULL)
-    goto exit;
+        goto exit;
     /*
     * Store the list in the stylesheet.
     */
     if (xsltPointerListAddSize(
-    cctxt->psData->extElemNamespaces, list, 5) == -1)
+        cctxt->psData->extElemNamespaces, list, 5) == -1)
     {
-    xsltPointerListFree(list);
-    list = NULL;
-    goto exit;
+        xsltPointerListFree(list);
+        list = NULL;
+        goto exit;
     }
     /*
     * Notify of change in status wrt namespaces.
     */
     if (cctxt->inode != NULL)
-    cctxt->inode->nsChanged = 1;
+        cctxt->inode->nsChanged = 1;
 
 exit:
     if (list != NULL)
-    return(list);
+        return(list);
     else
-    return(def);
+        return(def);
 }
 
 /*
@@ -2998,63 +2998,63 @@ exit:
 */
 static int
 xsltParseAttrXSLTVersion(xsltCompilerCtxtPtr cctxt, xmlNodePtr node,
-             int instrCategory)
+                         int instrCategory)
 {
     xmlChar *value;
     xmlAttrPtr attr;
 
     if ((cctxt == NULL) || (node == NULL))
-    return(-1);
+        return(-1);
 
     if (instrCategory == XSLT_ELEMENT_CATEGORY_XSLT)
-    attr = xmlHasNsProp(node, BAD_CAST "version", NULL);
+        attr = xmlHasNsProp(node, BAD_CAST "version", NULL);
     else
-    attr = xmlHasNsProp(node, BAD_CAST "version", XSLT_NAMESPACE);
+        attr = xmlHasNsProp(node, BAD_CAST "version", XSLT_NAMESPACE);
 
     if (attr == NULL)
-    return(0);
+        return(0);
 
     attr->psvi = (void *) xsltXSLTAttrMarker;
 
     if ((attr->children != NULL) &&
-    (attr->children->content != NULL))
-    value = attr->children->content;
+        (attr->children->content != NULL))
+        value = attr->children->content;
     else {
-    xsltTransformError(NULL, cctxt->style, node,
-        "Attribute 'version': Invalid value.\n");
-    cctxt->style->errors++;
-    return(1);
+        xsltTransformError(NULL, cctxt->style, node,
+            "Attribute 'version': Invalid value.\n");
+        cctxt->style->errors++;
+        return(1);
     }
 
     if (! xmlStrEqual(value, (const xmlChar *)"1.0")) {
-    cctxt->inode->forwardsCompat = 1;
-    /*
-    * TODO: To what extent do we support the
-    *  forwards-compatible mode?
-    */
-    /*
-    * Report this only once per compilation episode.
-    */
-    if (! cctxt->hasForwardsCompat) {
-        cctxt->hasForwardsCompat = 1;
-        cctxt->errSeverity = XSLT_ERROR_SEVERITY_WARNING;
-        xsltTransformError(NULL, cctxt->style, node,
-        "Warning: the attribute xsl:version specifies a value "
-        "different from '1.0'. Switching to forwards-compatible "
-        "mode. Only features of XSLT 1.0 are supported by this "
-        "processor.\n");
-        cctxt->style->warnings++;
-        cctxt->errSeverity = XSLT_ERROR_SEVERITY_ERROR;
-    }
+        cctxt->inode->forwardsCompat = 1;
+        /*
+        * TODO: To what extent do we support the
+        *  forwards-compatible mode?
+        */
+        /*
+        * Report this only once per compilation episode.
+        */
+        if (! cctxt->hasForwardsCompat) {
+            cctxt->hasForwardsCompat = 1;
+            cctxt->errSeverity = XSLT_ERROR_SEVERITY_WARNING;
+            xsltTransformError(NULL, cctxt->style, node,
+                "Warning: the attribute xsl:version specifies a value "
+                "different from '1.0'. Switching to forwards-compatible "
+                "mode. Only features of XSLT 1.0 are supported by this "
+                "processor.\n");
+            cctxt->style->warnings++;
+            cctxt->errSeverity = XSLT_ERROR_SEVERITY_ERROR;
+        }
     } else {
-    cctxt->inode->forwardsCompat = 0;
+        cctxt->inode->forwardsCompat = 0;
     }
 
     if (attr && (instrCategory == XSLT_ELEMENT_CATEGORY_LRE)) {
-    /*
-    * Set a marker on XSLT attributes.
-    */
-    attr->psvi = (void *) xsltXSLTAttrMarker;
+        /*
+        * Set a marker on XSLT attributes.
+        */
+        attr->psvi = (void *) xsltXSLTAttrMarker;
     }
     return(1);
 }
@@ -3076,16 +3076,16 @@ xsltParsePreprocessStylesheetTree(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
 #endif
 
     if ((cctxt == NULL) || (cctxt->style == NULL) ||
-    (node == NULL) || (node->type != XML_ELEMENT_NODE))
+        (node == NULL) || (node->type != XML_ELEMENT_NODE))
         return(-1);
 
     doc = node->doc;
     if (doc == NULL)
-    goto internal_err;
+        goto internal_err;
 
     style = cctxt->style;
     if ((style->dict != NULL) && (doc->dict == style->dict))
-    internalize = 1;
+        internalize = 1;
     else
         style->internalized = 0;
 
@@ -3096,14 +3096,14 @@ xsltParsePreprocessStylesheetTree(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     * ancestors into account.
     */
     if (! cctxt->simplified)
-    xsltStylesheetElemDepth = cctxt->depth +1;
+        xsltStylesheetElemDepth = cctxt->depth +1;
     else
-    xsltStylesheetElemDepth = 0;
+        xsltStylesheetElemDepth = 0;
 
     if (xmlNodeGetSpacePreserve(node) != 1)
-    cctxt->inode->preserveWhitespace = 0;
+        cctxt->inode->preserveWhitespace = 0;
     else
-    cctxt->inode->preserveWhitespace = 1;
+        cctxt->inode->preserveWhitespace = 1;
 
     /*
     * Eval if we should keep the old incorrect behaviour.
@@ -3115,374 +3115,374 @@ xsltParsePreprocessStylesheetTree(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     deleteNode = NULL;
     cur = node;
     while (cur != NULL) {
-    if (deleteNode != NULL) {
+        if (deleteNode != NULL) {
 
 #ifdef WITH_XSLT_DEBUG_BLANKS
+            xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParsePreprocessStylesheetTree: removing node\n");
+#endif
+            xmlUnlinkNode(deleteNode);
+            xmlFreeNode(deleteNode);
+            deleteNode = NULL;
+        }
+        if (cur->type == XML_ELEMENT_NODE) {
+
+            /*
+            * Clear the PSVI field.
+            */
+            cur->psvi = NULL;
+
+            xsltCompilerNodePush(cctxt, cur);
+
+            inXSLText = 0;
+            textNode = NULL;
+            findSpaceAttr = 1;
+            cctxt->inode->stripWhitespace = 0;
+            /*
+            * TODO: I'd love to use a string pointer comparison here :-/
+            */
+            if (IS_XSLT_ELEM(cur)) {
+#ifdef XSLT_REFACTORED_XSLT_NSCOMP
+                if (cur->ns->href != nsNameXSLT) {
+                    nsMapItem = xsltNewNamespaceMapItem(cctxt,
+                        doc, cur->ns, cur);
+                    if (nsMapItem == NULL)
+                        goto internal_err;
+                    cur->ns->href = nsNameXSLT;
+                }
+#endif
+
+                if (cur->name == NULL)
+                    goto process_attributes;
+                /*
+                * Mark the XSLT element for later recognition.
+                * TODO: Using the marker is still too dangerous, since if
+                *   the parsing mechanism leaves out an XSLT element, then
+                *   this might hit the transformation-mechanism, which
+                *   will break if it doesn't expect such a marker.
+                */
+                /* cur->psvi = (void *) xsltXSLTElemMarker; */
+
+                /*
+                * XSLT 2.0: "Any whitespace text node whose parent is
+                * one of the following elements is removed from the "
+                * tree, regardless of any xml:space attributes:..."
+                * xsl:apply-imports,
+                * xsl:apply-templates,
+                * xsl:attribute-set,
+                * xsl:call-template,
+                * xsl:choose,
+                * xsl:stylesheet, xsl:transform.
+                * XSLT 2.0: xsl:analyze-string,
+                *           xsl:character-map,
+                *           xsl:next-match
+                *
+                * TODO: I'd love to use a string pointer comparison here :-/
+                */
+                name = cur->name;
+                switch (*name) {
+                    case 't':
+                        if ((name[0] == 't') && (name[1] == 'e') &&
+                            (name[2] == 'x') && (name[3] == 't') &&
+                            (name[4] == 0))
+                        {
+                            /*
+                            * Process the xsl:text element.
+                            * ----------------------------
+                            * Mark it for later recognition.
+                            */
+                            cur->psvi = (void *) xsltXSLTTextMarker;
+                            /*
+                            * For stylesheets, the set of
+                            * whitespace-preserving element names
+                            * consists of just xsl:text.
+                            */
+                            findSpaceAttr = 0;
+                            cctxt->inode->preserveWhitespace = 1;
+                            inXSLText = 1;
+                        }
+                        break;
+                    case 'c':
+                        if (xmlStrEqual(name, BAD_CAST "choose") ||
+                            xmlStrEqual(name, BAD_CAST "call-template"))
+                            cctxt->inode->stripWhitespace = 1;
+                        break;
+                    case 'a':
+                        if (xmlStrEqual(name, BAD_CAST "apply-templates") ||
+                            xmlStrEqual(name, BAD_CAST "apply-imports") ||
+                            xmlStrEqual(name, BAD_CAST "attribute-set"))
+
+                            cctxt->inode->stripWhitespace = 1;
+                        break;
+                    default:
+                        if (xsltStylesheetElemDepth == cctxt->depth) {
+                            /*
+                            * This is a xsl:stylesheet/xsl:transform.
+                            */
+                            cctxt->inode->stripWhitespace = 1;
+                            break;
+                        }
+
+                        if ((cur->prev != NULL) &&
+                            (cur->prev->type == XML_TEXT_NODE))
+                        {
+                            /*
+                            * XSLT 2.0 : "Any whitespace text node whose
+                            *  following-sibling node is an xsl:param or
+                            *  xsl:sort element is removed from the tree,
+                            *  regardless of any xml:space attributes."
+                            */
+                            if (((*name == 'p') || (*name == 's')) &&
+                                (xmlStrEqual(name, BAD_CAST "param") ||
+                                 xmlStrEqual(name, BAD_CAST "sort")))
+                            {
+                                do {
+                                    if (IS_BLANK_NODE(cur->prev)) {
+                                        txt = cur->prev;
+                                        xmlUnlinkNode(txt);
+                                        xmlFreeNode(txt);
+                                    } else {
+                                        /*
+                                        * This will result in a content
+                                        * error, when hitting the parsing
+                                        * functions.
+                                        */
+                                        break;
+                                    }
+                                } while (cur->prev);
+                            }
+                        }
+                        break;
+                }
+            }
+
+process_attributes:
+            /*
+            * Process attributes.
+            * ------------------
+            */
+            if (cur->properties != NULL) {
+                if (cur->children == NULL)
+                    findSpaceAttr = 0;
+                attr = cur->properties;
+                do {
+#ifdef XSLT_REFACTORED_XSLT_NSCOMP
+                    if ((attr->ns) && (attr->ns->href != nsNameXSLT) &&
+                        xmlStrEqual(attr->ns->href, nsNameXSLT))
+                    {
+                        nsMapItem = xsltNewNamespaceMapItem(cctxt,
+                            doc, attr->ns, cur);
+                        if (nsMapItem == NULL)
+                            goto internal_err;
+                        attr->ns->href = nsNameXSLT;
+                    }
+#endif
+                    if (internalize) {
+                        /*
+                        * Internalize the attribute's value; the goal is to
+                        * speed up operations and minimize used space by
+                        * compiled stylesheets.
+                        */
+                        txt = attr->children;
+                        /*
+                        * NOTE that this assumes only one
+                        *  text-node in the attribute's content.
+                        */
+                        if ((txt != NULL) && (txt->content != NULL) &&
+                            (!xmlDictOwns(style->dict, txt->content)))
+                        {
+                            value = (xmlChar *) xmlDictLookup(style->dict,
+                                txt->content, -1);
+                            xmlNodeSetContent(txt, NULL);
+                            txt->content = value;
+                        }
+                    }
+                    /*
+                    * Process xml:space attributes.
+                    * ----------------------------
+                    */
+                    if ((findSpaceAttr != 0) &&
+                        (attr->ns != NULL) &&
+                        (attr->name != NULL) &&
+                        (attr->name[0] == 's') &&
+                        (attr->ns->prefix != NULL) &&
+                        (attr->ns->prefix[0] == 'x') &&
+                        (attr->ns->prefix[1] == 'm') &&
+                        (attr->ns->prefix[2] == 'l') &&
+                        (attr->ns->prefix[3] == 0))
+                    {
+                        value = xmlGetNsProp(cur, BAD_CAST "space",
+                            XML_XML_NAMESPACE);
+                        if (value != NULL) {
+                            if (xmlStrEqual(value, BAD_CAST "preserve")) {
+                                cctxt->inode->preserveWhitespace = 1;
+                            } else if (xmlStrEqual(value, BAD_CAST "default")) {
+                                cctxt->inode->preserveWhitespace = 0;
+                            } else {
+                                /* Invalid value for xml:space. */
+                                xsltTransformError(NULL, style, cur,
+                                    "Attribute xml:space: Invalid value.\n");
+                                cctxt->style->warnings++;
+                            }
+                            findSpaceAttr = 0;
+                            xmlFree(value);
+                        }
+
+                    }
+                    attr = attr->next;
+                } while (attr != NULL);
+            }
+            /*
+            * We'll descend into the children of element nodes only.
+            */
+            if (cur->children != NULL) {
+                cur = cur->children;
+                continue;
+            }
+        } else if ((cur->type == XML_TEXT_NODE) ||
+                (cur->type == XML_CDATA_SECTION_NODE))
+        {
+            /*
+            * Merge adjacent text/CDATA-section-nodes
+            * ---------------------------------------
+            * In order to avoid breaking of existing stylesheets,
+            * if the old behaviour is wanted (strictWhitespace == 0),
+            * then we *won't* merge adjacent text-nodes
+            * (except in xsl:text); this will ensure that whitespace-only
+            * text nodes are (incorrectly) not stripped in some cases.
+            *
+            * Example:               : <foo>  <!-- bar -->zoo</foo>
+            * Corrent (strict) result: <foo>  zoo</foo>
+            * Incorrect (old) result : <foo>zoo</foo>
+            *
+            * NOTE that we *will* merge adjacent text-nodes if
+            * they are in xsl:text.
+            * Example, the following:
+            * <xsl:text>  <!-- bar -->zoo<xsl:text>
+            * will result in both cases in:
+            * <xsl:text>  zoo<xsl:text>
+            */
+            cur->type = XML_TEXT_NODE;
+            if ((strictWhitespace != 0) || (inXSLText != 0)) {
+                /*
+                * New behaviour; merge nodes.
+                */
+                if (textNode == NULL)
+                    textNode = cur;
+                else {
+                    if (cur->content != NULL)
+                        xmlNodeAddContent(textNode, cur->content);
+                    deleteNode = cur;
+                }
+                if ((cur->next == NULL) ||
+                    (cur->next->type == XML_ELEMENT_NODE))
+                    goto end_of_text;
+                else
+                    goto next_sibling;
+            } else {
+                /*
+                * Old behaviour.
+                */
+                if (textNode == NULL)
+                    textNode = cur;
+                goto end_of_text;
+            }
+        } else if ((cur->type == XML_COMMENT_NODE) ||
+            (cur->type == XML_PI_NODE))
+        {
+            /*
+            * Remove processing instructions and comments.
+            */
+            deleteNode = cur;
+            if ((cur->next == NULL) ||
+                (cur->next->type == XML_ELEMENT_NODE))
+                goto end_of_text;
+            else
+                goto next_sibling;
+        } else {
+            textNode = NULL;
+            /*
+            * Invalid node-type for this data-model.
+            */
+            xsltTransformError(NULL, style, cur,
+                "Invalid type of node for the XSLT data model.\n");
+            cctxt->style->errors++;
+            goto next_sibling;
+        }
+
+end_of_text:
+        if (textNode) {
+            value = textNode->content;
+            /*
+            * At this point all adjacent text/CDATA-section nodes
+            * have been merged.
+            *
+            * Strip whitespace-only text-nodes.
+            * (cctxt->inode->stripWhitespace)
+            */
+            if ((value == NULL) || (*value == 0) ||
+                (((cctxt->inode->stripWhitespace) ||
+                  (! cctxt->inode->preserveWhitespace)) &&
+                 IS_BLANK(*value) &&
+                 xsltIsBlank(value)))
+            {
+                if (textNode != cur) {
+                    xmlUnlinkNode(textNode);
+                    xmlFreeNode(textNode);
+                } else
+                    deleteNode = textNode;
+                textNode = NULL;
+                goto next_sibling;
+            }
+            /*
+            * Convert CDATA-section nodes to text-nodes.
+            * TODO: Can this produce problems?
+            */
+            if (textNode->type != XML_TEXT_NODE) {
+                textNode->type = XML_TEXT_NODE;
+                textNode->name = xmlStringText;
+            }
+            if (internalize &&
+                (textNode->content != NULL) &&
+                (!xmlDictOwns(style->dict, textNode->content)))
+            {
+                /*
+                * Internalize the string.
+                */
+                value = (xmlChar *) xmlDictLookup(style->dict,
+                    textNode->content, -1);
+                xmlNodeSetContent(textNode, NULL);
+                textNode->content = value;
+            }
+            textNode = NULL;
+            /*
+            * Note that "disable-output-escaping" of the xsl:text
+            * element will be applied at a later level, when
+            * XSLT elements are processed.
+            */
+        }
+
+next_sibling:
+        if (cur->type == XML_ELEMENT_NODE) {
+            xsltCompilerNodePop(cctxt, cur);
+        }
+        if (cur == node)
+            break;
+        if (cur->next != NULL) {
+            cur = cur->next;
+        } else {
+            cur = cur->parent;
+            inXSLText = 0;
+            goto next_sibling;
+        };
+    }
+    if (deleteNode != NULL) {
+#ifdef WITH_XSLT_DEBUG_PARSING
         xsltGenericDebug(xsltGenericDebugContext,
          "xsltParsePreprocessStylesheetTree: removing node\n");
 #endif
         xmlUnlinkNode(deleteNode);
         xmlFreeNode(deleteNode);
-        deleteNode = NULL;
-    }
-    if (cur->type == XML_ELEMENT_NODE) {
-
-        /*
-        * Clear the PSVI field.
-        */
-        cur->psvi = NULL;
-
-        xsltCompilerNodePush(cctxt, cur);
-
-        inXSLText = 0;
-        textNode = NULL;
-        findSpaceAttr = 1;
-        cctxt->inode->stripWhitespace = 0;
-        /*
-        * TODO: I'd love to use a string pointer comparison here :-/
-        */
-        if (IS_XSLT_ELEM(cur)) {
-#ifdef XSLT_REFACTORED_XSLT_NSCOMP
-        if (cur->ns->href != nsNameXSLT) {
-            nsMapItem = xsltNewNamespaceMapItem(cctxt,
-            doc, cur->ns, cur);
-            if (nsMapItem == NULL)
-            goto internal_err;
-            cur->ns->href = nsNameXSLT;
-        }
-#endif
-
-        if (cur->name == NULL)
-            goto process_attributes;
-        /*
-        * Mark the XSLT element for later recognition.
-        * TODO: Using the marker is still too dangerous, since if
-        *   the parsing mechanism leaves out an XSLT element, then
-        *   this might hit the transformation-mechanism, which
-        *   will break if it doesn't expect such a marker.
-        */
-        /* cur->psvi = (void *) xsltXSLTElemMarker; */
-
-        /*
-        * XSLT 2.0: "Any whitespace text node whose parent is
-        * one of the following elements is removed from the "
-        * tree, regardless of any xml:space attributes:..."
-        * xsl:apply-imports,
-        * xsl:apply-templates,
-        * xsl:attribute-set,
-        * xsl:call-template,
-        * xsl:choose,
-        * xsl:stylesheet, xsl:transform.
-        * XSLT 2.0: xsl:analyze-string,
-        *           xsl:character-map,
-        *           xsl:next-match
-        *
-        * TODO: I'd love to use a string pointer comparison here :-/
-        */
-        name = cur->name;
-        switch (*name) {
-            case 't':
-            if ((name[0] == 't') && (name[1] == 'e') &&
-                (name[2] == 'x') && (name[3] == 't') &&
-                (name[4] == 0))
-            {
-                /*
-                * Process the xsl:text element.
-                * ----------------------------
-                * Mark it for later recognition.
-                */
-                cur->psvi = (void *) xsltXSLTTextMarker;
-                /*
-                * For stylesheets, the set of
-                * whitespace-preserving element names
-                * consists of just xsl:text.
-                */
-                findSpaceAttr = 0;
-                cctxt->inode->preserveWhitespace = 1;
-                inXSLText = 1;
-            }
-            break;
-            case 'c':
-            if (xmlStrEqual(name, BAD_CAST "choose") ||
-                xmlStrEqual(name, BAD_CAST "call-template"))
-                cctxt->inode->stripWhitespace = 1;
-            break;
-            case 'a':
-            if (xmlStrEqual(name, BAD_CAST "apply-templates") ||
-                xmlStrEqual(name, BAD_CAST "apply-imports") ||
-                xmlStrEqual(name, BAD_CAST "attribute-set"))
-
-                cctxt->inode->stripWhitespace = 1;
-            break;
-            default:
-            if (xsltStylesheetElemDepth == cctxt->depth) {
-                /*
-                * This is a xsl:stylesheet/xsl:transform.
-                */
-                cctxt->inode->stripWhitespace = 1;
-                break;
-            }
-
-            if ((cur->prev != NULL) &&
-                (cur->prev->type == XML_TEXT_NODE))
-            {
-                /*
-                * XSLT 2.0 : "Any whitespace text node whose
-                *  following-sibling node is an xsl:param or
-                *  xsl:sort element is removed from the tree,
-                *  regardless of any xml:space attributes."
-                */
-                if (((*name == 'p') || (*name == 's')) &&
-                (xmlStrEqual(name, BAD_CAST "param") ||
-                 xmlStrEqual(name, BAD_CAST "sort")))
-                {
-                do {
-                    if (IS_BLANK_NODE(cur->prev)) {
-                    txt = cur->prev;
-                    xmlUnlinkNode(txt);
-                    xmlFreeNode(txt);
-                    } else {
-                    /*
-                    * This will result in a content
-                    * error, when hitting the parsing
-                    * functions.
-                    */
-                    break;
-                    }
-                } while (cur->prev);
-                }
-            }
-            break;
-        }
-        }
-
-process_attributes:
-        /*
-        * Process attributes.
-        * ------------------
-        */
-        if (cur->properties != NULL) {
-        if (cur->children == NULL)
-            findSpaceAttr = 0;
-        attr = cur->properties;
-        do {
-#ifdef XSLT_REFACTORED_XSLT_NSCOMP
-            if ((attr->ns) && (attr->ns->href != nsNameXSLT) &&
-            xmlStrEqual(attr->ns->href, nsNameXSLT))
-            {
-            nsMapItem = xsltNewNamespaceMapItem(cctxt,
-                doc, attr->ns, cur);
-            if (nsMapItem == NULL)
-                goto internal_err;
-            attr->ns->href = nsNameXSLT;
-            }
-#endif
-            if (internalize) {
-            /*
-            * Internalize the attribute's value; the goal is to
-            * speed up operations and minimize used space by
-            * compiled stylesheets.
-            */
-            txt = attr->children;
-            /*
-            * NOTE that this assumes only one
-            *  text-node in the attribute's content.
-            */
-            if ((txt != NULL) && (txt->content != NULL) &&
-                (!xmlDictOwns(style->dict, txt->content)))
-            {
-                value = (xmlChar *) xmlDictLookup(style->dict,
-                txt->content, -1);
-                xmlNodeSetContent(txt, NULL);
-                txt->content = value;
-            }
-            }
-            /*
-            * Process xml:space attributes.
-            * ----------------------------
-            */
-            if ((findSpaceAttr != 0) &&
-            (attr->ns != NULL) &&
-            (attr->name != NULL) &&
-            (attr->name[0] == 's') &&
-            (attr->ns->prefix != NULL) &&
-            (attr->ns->prefix[0] == 'x') &&
-            (attr->ns->prefix[1] == 'm') &&
-            (attr->ns->prefix[2] == 'l') &&
-            (attr->ns->prefix[3] == 0))
-            {
-            value = xmlGetNsProp(cur, BAD_CAST "space",
-                XML_XML_NAMESPACE);
-            if (value != NULL) {
-                if (xmlStrEqual(value, BAD_CAST "preserve")) {
-                cctxt->inode->preserveWhitespace = 1;
-                } else if (xmlStrEqual(value, BAD_CAST "default")) {
-                cctxt->inode->preserveWhitespace = 0;
-                } else {
-                /* Invalid value for xml:space. */
-                xsltTransformError(NULL, style, cur,
-                    "Attribute xml:space: Invalid value.\n");
-                cctxt->style->warnings++;
-                }
-                findSpaceAttr = 0;
-                xmlFree(value);
-            }
-
-            }
-            attr = attr->next;
-        } while (attr != NULL);
-        }
-        /*
-        * We'll descend into the children of element nodes only.
-        */
-        if (cur->children != NULL) {
-        cur = cur->children;
-        continue;
-        }
-    } else if ((cur->type == XML_TEXT_NODE) ||
-        (cur->type == XML_CDATA_SECTION_NODE))
-    {
-        /*
-        * Merge adjacent text/CDATA-section-nodes
-        * ---------------------------------------
-        * In order to avoid breaking of existing stylesheets,
-        * if the old behaviour is wanted (strictWhitespace == 0),
-        * then we *won't* merge adjacent text-nodes
-        * (except in xsl:text); this will ensure that whitespace-only
-        * text nodes are (incorrectly) not stripped in some cases.
-        *
-        * Example:               : <foo>  <!-- bar -->zoo</foo>
-        * Corrent (strict) result: <foo>  zoo</foo>
-        * Incorrect (old) result : <foo>zoo</foo>
-        *
-        * NOTE that we *will* merge adjacent text-nodes if
-        * they are in xsl:text.
-        * Example, the following:
-        * <xsl:text>  <!-- bar -->zoo<xsl:text>
-        * will result in both cases in:
-        * <xsl:text>  zoo<xsl:text>
-        */
-        cur->type = XML_TEXT_NODE;
-        if ((strictWhitespace != 0) || (inXSLText != 0)) {
-        /*
-        * New behaviour; merge nodes.
-        */
-        if (textNode == NULL)
-            textNode = cur;
-        else {
-            if (cur->content != NULL)
-            xmlNodeAddContent(textNode, cur->content);
-            deleteNode = cur;
-        }
-        if ((cur->next == NULL) ||
-            (cur->next->type == XML_ELEMENT_NODE))
-            goto end_of_text;
-        else
-            goto next_sibling;
-        } else {
-        /*
-        * Old behaviour.
-        */
-        if (textNode == NULL)
-            textNode = cur;
-        goto end_of_text;
-        }
-    } else if ((cur->type == XML_COMMENT_NODE) ||
-        (cur->type == XML_PI_NODE))
-    {
-        /*
-        * Remove processing instructions and comments.
-        */
-        deleteNode = cur;
-        if ((cur->next == NULL) ||
-        (cur->next->type == XML_ELEMENT_NODE))
-        goto end_of_text;
-        else
-        goto next_sibling;
-    } else {
-        textNode = NULL;
-        /*
-        * Invalid node-type for this data-model.
-        */
-        xsltTransformError(NULL, style, cur,
-        "Invalid type of node for the XSLT data model.\n");
-        cctxt->style->errors++;
-        goto next_sibling;
-    }
-
-end_of_text:
-    if (textNode) {
-        value = textNode->content;
-        /*
-        * At this point all adjacent text/CDATA-section nodes
-        * have been merged.
-        *
-        * Strip whitespace-only text-nodes.
-        * (cctxt->inode->stripWhitespace)
-        */
-        if ((value == NULL) || (*value == 0) ||
-        (((cctxt->inode->stripWhitespace) ||
-          (! cctxt->inode->preserveWhitespace)) &&
-         IS_BLANK(*value) &&
-         xsltIsBlank(value)))
-        {
-        if (textNode != cur) {
-            xmlUnlinkNode(textNode);
-            xmlFreeNode(textNode);
-        } else
-            deleteNode = textNode;
-        textNode = NULL;
-        goto next_sibling;
-        }
-        /*
-        * Convert CDATA-section nodes to text-nodes.
-        * TODO: Can this produce problems?
-        */
-        if (textNode->type != XML_TEXT_NODE) {
-        textNode->type = XML_TEXT_NODE;
-        textNode->name = xmlStringText;
-        }
-        if (internalize &&
-        (textNode->content != NULL) &&
-        (!xmlDictOwns(style->dict, textNode->content)))
-        {
-        /*
-        * Internalize the string.
-        */
-        value = (xmlChar *) xmlDictLookup(style->dict,
-            textNode->content, -1);
-        xmlNodeSetContent(textNode, NULL);
-        textNode->content = value;
-        }
-        textNode = NULL;
-        /*
-        * Note that "disable-output-escaping" of the xsl:text
-        * element will be applied at a later level, when
-        * XSLT elements are processed.
-        */
-    }
-
-next_sibling:
-    if (cur->type == XML_ELEMENT_NODE) {
-        xsltCompilerNodePop(cctxt, cur);
-    }
-    if (cur == node)
-        break;
-    if (cur->next != NULL) {
-        cur = cur->next;
-    } else {
-        cur = cur->parent;
-        inXSLText = 0;
-        goto next_sibling;
-    };
-    }
-    if (deleteNode != NULL) {
-#ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-     "xsltParsePreprocessStylesheetTree: removing node\n");
-#endif
-    xmlUnlinkNode(deleteNode);
-    xmlFreeNode(deleteNode);
     }
     return(0);
 
@@ -3505,13 +3505,13 @@ xsltPreprocessStylesheet(xsltStylesheetPtr style, xmlNodePtr cur)
 
     if ((cur->doc != NULL) && (style->dict != NULL) &&
         (cur->doc->dict == style->dict))
-    internalize = 1;
+        internalize = 1;
     else
         style->internalized = 0;
 
     if ((cur != NULL) && (IS_XSLT_ELEM(cur)) &&
         (IS_XSLT_NAME(cur, "stylesheet"))) {
-    styleelem = cur;
+        styleelem = cur;
     } else {
         styleelem = NULL;
     }
@@ -3523,174 +3523,170 @@ xsltPreprocessStylesheet(xsltStylesheetPtr style, xmlNodePtr cur)
      */
     deleteNode = NULL;
     while (cur != NULL) {
-    if (deleteNode != NULL) {
+        if (deleteNode != NULL) {
 #ifdef WITH_XSLT_DEBUG_BLANKS
+            xsltGenericDebug(xsltGenericDebugContext,
+             "xsltPreprocessStylesheet: removing ignorable blank node\n");
+#endif
+            xmlUnlinkNode(deleteNode);
+            xmlFreeNode(deleteNode);
+            deleteNode = NULL;
+        }
+        if (cur->type == XML_ELEMENT_NODE) {
+            int exclPrefixes;
+            /*
+             * Internalize attributes values.
+             */
+            if ((internalize) && (cur->properties != NULL)) {
+                xmlAttrPtr attr = cur->properties;
+                xmlNodePtr txt;
+
+                while (attr != NULL) {
+                    txt = attr->children;
+                    if ((txt != NULL) && (txt->type == XML_TEXT_NODE) &&
+                        (txt->content != NULL) &&
+                        (!xmlDictOwns(style->dict, txt->content)))
+                    {
+                        xmlChar *tmp;
+
+                        /*
+                         * internalize the text string, goal is to speed
+                         * up operations and minimize used space by compiled
+                         * stylesheets.
+                         */
+                        tmp = (xmlChar *) xmlDictLookup(style->dict,
+                                                        txt->content, -1);
+                        if (tmp != txt->content) {
+                            xmlNodeSetContent(txt, NULL);
+                            txt->content = tmp;
+                        }
+                    }
+                    attr = attr->next;
+                }
+            }
+            if (IS_XSLT_ELEM(cur)) {
+                exclPrefixes = 0;
+                if (IS_XSLT_NAME(cur, "text")) {
+                    for (;exclPrefixes > 0;exclPrefixes--)
+                        exclPrefixPop(style);
+                    goto skip_children;
+                }
+            } else {
+                exclPrefixes = xsltParseStylesheetExcludePrefix(style, cur, 0);
+            }
+
+            if ((cur->nsDef != NULL) && (style->exclPrefixNr > 0)) {
+                xmlNsPtr ns = cur->nsDef, prev = NULL, next;
+                xmlNodePtr root = NULL;
+                int i, moved;
+
+                root = xmlDocGetRootElement(cur->doc);
+                if ((root != NULL) && (root != cur)) {
+                    while (ns != NULL) {
+                        moved = 0;
+                        next = ns->next;
+                        for (i = 0;i < style->exclPrefixNr;i++) {
+                            if ((ns->prefix != NULL) &&
+                                (xmlStrEqual(ns->href,
+                                             style->exclPrefixTab[i]))) {
+                                /*
+                                 * Move the namespace definition on the root
+                                 * element to avoid duplicating it without
+                                 * loosing it.
+                                 */
+                                if (prev == NULL) {
+                                    cur->nsDef = ns->next;
+                                } else {
+                                    prev->next = ns->next;
+                                }
+                                ns->next = root->nsDef;
+                                root->nsDef = ns;
+                                moved = 1;
+                                break;
+                            }
+                        }
+                        if (moved == 0)
+                            prev = ns;
+                        ns = next;
+                    }
+                }
+            }
+            /*
+             * If we have prefixes locally, recurse and pop them up when
+             * going back
+             */
+            if (exclPrefixes > 0) {
+                xsltPreprocessStylesheet(style, cur->children);
+                for (;exclPrefixes > 0;exclPrefixes--)
+                    exclPrefixPop(style);
+                goto skip_children;
+            }
+        } else if (cur->type == XML_TEXT_NODE) {
+            if (IS_BLANK_NODE(cur)) {
+                if (xmlNodeGetSpacePreserve(cur->parent) != 1) {
+                    deleteNode = cur;
+                }
+            } else if ((cur->content != NULL) && (internalize) &&
+                       (!xmlDictOwns(style->dict, cur->content))) {
+                xmlChar *tmp;
+
+                /*
+                 * internalize the text string, goal is to speed
+                 * up operations and minimize used space by compiled
+                 * stylesheets.
+                 */
+                tmp = (xmlChar *) xmlDictLookup(style->dict, cur->content, -1);
+                xmlNodeSetContent(cur, NULL);
+                cur->content = tmp;
+            }
+        } else if ((cur->type != XML_ELEMENT_NODE) &&
+                   (cur->type != XML_CDATA_SECTION_NODE)) {
+            deleteNode = cur;
+            goto skip_children;
+        }
+
+        /*
+         * Skip to next node. In case of a namespaced element children of
+         * the stylesheet and not in the XSLT namespace and not an extension
+         * element, ignore its content.
+         */
+        if ((cur->type == XML_ELEMENT_NODE) && (cur->ns != NULL) &&
+            (styleelem != NULL) && (cur->parent == styleelem) &&
+            (!xmlStrEqual(cur->ns->href, XSLT_NAMESPACE)) &&
+            (!xsltCheckExtURI(style, cur->ns->href))) {
+            goto skip_children;
+        } else if (cur->children != NULL) {
+            cur = cur->children;
+            continue;
+        }
+
+skip_children:
+        if (cur->next != NULL) {
+            cur = cur->next;
+            continue;
+        }
+        do {
+
+            cur = cur->parent;
+            if (cur == NULL)
+                break;
+            if (cur == (xmlNodePtr) style->doc) {
+                cur = NULL;
+                break;
+            }
+            if (cur->next != NULL) {
+                cur = cur->next;
+                break;
+            }
+        } while (cur != NULL);
+    }
+    if (deleteNode != NULL) {
+#ifdef WITH_XSLT_DEBUG_PARSING
         xsltGenericDebug(xsltGenericDebugContext,
          "xsltPreprocessStylesheet: removing ignorable blank node\n");
 #endif
         xmlUnlinkNode(deleteNode);
         xmlFreeNode(deleteNode);
-        deleteNode = NULL;
-    }
-    if (cur->type == XML_ELEMENT_NODE) {
-        int exclPrefixes;
-        /*
-         * Internalize attributes values.
-         */
-        if ((internalize) && (cur->properties != NULL)) {
-            xmlAttrPtr attr = cur->properties;
-        xmlNodePtr txt;
-
-        while (attr != NULL) {
-            txt = attr->children;
-            if ((txt != NULL) && (txt->type == XML_TEXT_NODE) &&
-                (txt->content != NULL) &&
-            (!xmlDictOwns(style->dict, txt->content)))
-            {
-            xmlChar *tmp;
-
-            /*
-             * internalize the text string, goal is to speed
-             * up operations and minimize used space by compiled
-             * stylesheets.
-             */
-            tmp = (xmlChar *) xmlDictLookup(style->dict,
-                                            txt->content, -1);
-            if (tmp != txt->content) {
-                xmlNodeSetContent(txt, NULL);
-                txt->content = tmp;
-            }
-            }
-            attr = attr->next;
-        }
-        }
-        if (IS_XSLT_ELEM(cur)) {
-        exclPrefixes = 0;
-        if (IS_XSLT_NAME(cur, "text")) {
-            for (;exclPrefixes > 0;exclPrefixes--)
-            exclPrefixPop(style);
-            goto skip_children;
-        }
-        } else {
-        exclPrefixes = xsltParseStylesheetExcludePrefix(style, cur, 0);
-        }
-
-        if ((cur->nsDef != NULL) && (style->exclPrefixNr > 0)) {
-        xmlNsPtr ns = cur->nsDef, prev = NULL, next;
-        xmlNodePtr root = NULL;
-        int i, moved;
-
-        root = xmlDocGetRootElement(cur->doc);
-        if ((root != NULL) && (root != cur)) {
-            while (ns != NULL) {
-            moved = 0;
-            next = ns->next;
-            for (i = 0;i < style->exclPrefixNr;i++) {
-                if ((ns->prefix != NULL) &&
-                    (xmlStrEqual(ns->href,
-                         style->exclPrefixTab[i]))) {
-                /*
-                 * Move the namespace definition on the root
-                 * element to avoid duplicating it without
-                 * loosing it.
-                 */
-                if (prev == NULL) {
-                    cur->nsDef = ns->next;
-                } else {
-                    prev->next = ns->next;
-                }
-                ns->next = root->nsDef;
-                root->nsDef = ns;
-                moved = 1;
-                break;
-                }
-            }
-            if (moved == 0)
-                prev = ns;
-            ns = next;
-            }
-        }
-        }
-        /*
-         * If we have prefixes locally, recurse and pop them up when
-         * going back
-         */
-        if (exclPrefixes > 0) {
-        xsltPreprocessStylesheet(style, cur->children);
-        for (;exclPrefixes > 0;exclPrefixes--)
-            exclPrefixPop(style);
-        goto skip_children;
-        }
-    } else if (cur->type == XML_TEXT_NODE) {
-        if (IS_BLANK_NODE(cur)) {
-        if (xmlNodeGetSpacePreserve(cur->parent) != 1) {
-            deleteNode = cur;
-        }
-        } else if ((cur->content != NULL) && (internalize) &&
-                   (!xmlDictOwns(style->dict, cur->content))) {
-        xmlChar *tmp;
-
-        /*
-         * internalize the text string, goal is to speed
-         * up operations and minimize used space by compiled
-         * stylesheets.
-         */
-        tmp = (xmlChar *) xmlDictLookup(style->dict, cur->content, -1);
-        xmlNodeSetContent(cur, NULL);
-        cur->content = tmp;
-        }
-    } else if ((cur->type != XML_ELEMENT_NODE) &&
-           (cur->type != XML_CDATA_SECTION_NODE)) {
-        deleteNode = cur;
-        goto skip_children;
-    }
-
-    /*
-     * Skip to next node. In case of a namespaced element children of
-     * the stylesheet and not in the XSLT namespace and not an extension
-     * element, ignore its content.
-     */
-    if ((cur->type == XML_ELEMENT_NODE) && (cur->ns != NULL) &&
-        (styleelem != NULL) && (cur->parent == styleelem) &&
-        (!xmlStrEqual(cur->ns->href, XSLT_NAMESPACE)) &&
-        (!xsltCheckExtURI(style, cur->ns->href))) {
-        goto skip_children;
-    } else if (cur->children != NULL) {
-        if ((cur->children->type != XML_ENTITY_DECL) &&
-        (cur->children->type != XML_ENTITY_REF_NODE) &&
-        (cur->children->type != XML_ENTITY_NODE)) {
-        cur = cur->children;
-        continue;
-        }
-    }
-
-skip_children:
-    if (cur->next != NULL) {
-        cur = cur->next;
-        continue;
-    }
-    do {
-
-        cur = cur->parent;
-        if (cur == NULL)
-        break;
-        if (cur == (xmlNodePtr) style->doc) {
-        cur = NULL;
-        break;
-        }
-        if (cur->next != NULL) {
-        cur = cur->next;
-        break;
-        }
-    } while (cur != NULL);
-    }
-    if (deleteNode != NULL) {
-#ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-     "xsltPreprocessStylesheet: removing ignorable blank node\n");
-#endif
-    xmlUnlinkNode(deleteNode);
-    xmlFreeNode(deleteNode);
     }
 }
 #endif /* end of else XSLT_REFACTORED */
@@ -3724,65 +3720,65 @@ xsltGatherNamespaces(xsltStylesheetPtr style) {
     */
     cur = xmlDocGetRootElement(style->doc);
     while (cur != NULL) {
-    if (cur->type == XML_ELEMENT_NODE) {
-        xmlNsPtr ns = cur->nsDef;
-        while (ns != NULL) {
-        if (ns->prefix != NULL) {
-            if (style->nsHash == NULL) {
-            style->nsHash = xmlHashCreate(10);
-            if (style->nsHash == NULL) {
-                xsltTransformError(NULL, style, cur,
-         "xsltGatherNamespaces: failed to create hash table\n");
-                style->errors++;
-                return;
-            }
-            }
-            URI = xmlHashLookup(style->nsHash, ns->prefix);
-            if ((URI != NULL) && (!xmlStrEqual(URI, ns->href))) {
-            xsltTransformError(NULL, style, cur,
-         "Namespaces prefix %s used for multiple namespaces\n",ns->prefix);
-            style->warnings++;
-            } else if (URI == NULL) {
-            xmlHashUpdateEntry(style->nsHash, ns->prefix,
-                (void *) ns->href, NULL);
+        if (cur->type == XML_ELEMENT_NODE) {
+            xmlNsPtr ns = cur->nsDef;
+            while (ns != NULL) {
+                if (ns->prefix != NULL) {
+                    if (style->nsHash == NULL) {
+                        style->nsHash = xmlHashCreate(10);
+                        if (style->nsHash == NULL) {
+                            xsltTransformError(NULL, style, cur,
+                 "xsltGatherNamespaces: failed to create hash table\n");
+                            style->errors++;
+                            return;
+                        }
+                    }
+                    URI = xmlHashLookup(style->nsHash, ns->prefix);
+                    if ((URI != NULL) && (!xmlStrEqual(URI, ns->href))) {
+                        xsltTransformError(NULL, style, cur,
+             "Namespaces prefix %s used for multiple namespaces\n",ns->prefix);
+                        style->warnings++;
+                    } else if (URI == NULL) {
+                        xmlHashUpdateEntry(style->nsHash, ns->prefix,
+                            (void *) ns->href, NULL);
 
 #ifdef WITH_XSLT_DEBUG_PARSING
-            xsltGenericDebug(xsltGenericDebugContext,
-         "Added namespace: %s mapped to %s\n", ns->prefix, ns->href);
+                        xsltGenericDebug(xsltGenericDebugContext,
+                 "Added namespace: %s mapped to %s\n", ns->prefix, ns->href);
 #endif
+                    }
+                }
+                ns = ns->next;
             }
         }
-        ns = ns->next;
-        }
-    }
 
-    /*
-     * Skip to next node
-     */
-    if (cur->children != NULL) {
-        if (cur->children->type != XML_ENTITY_DECL) {
-        cur = cur->children;
-        continue;
-        }
-    }
-    if (cur->next != NULL) {
-        cur = cur->next;
-        continue;
-    }
-
-    do {
-        cur = cur->parent;
-        if (cur == NULL)
-        break;
-        if (cur == (xmlNodePtr) style->doc) {
-        cur = NULL;
-        break;
+        /*
+         * Skip to next node
+         */
+        if (cur->children != NULL) {
+            if (cur->children->type != XML_ENTITY_DECL) {
+                cur = cur->children;
+                continue;
+            }
         }
         if (cur->next != NULL) {
-        cur = cur->next;
-        break;
+            cur = cur->next;
+            continue;
         }
-    } while (cur != NULL);
+
+        do {
+            cur = cur->parent;
+            if (cur == NULL)
+                break;
+            if (cur == (xmlNodePtr) style->doc) {
+                cur = NULL;
+                break;
+            }
+            if (cur->next != NULL) {
+                cur = cur->next;
+                break;
+            }
+        } while (cur != NULL);
     }
 }
 
@@ -3790,113 +3786,113 @@ xsltGatherNamespaces(xsltStylesheetPtr style) {
 
 static xsltStyleType
 xsltGetXSLTElementTypeByNode(xsltCompilerCtxtPtr cctxt,
-                 xmlNodePtr node)
+                             xmlNodePtr node)
 {
     if ((node == NULL) || (node->type != XML_ELEMENT_NODE) ||
-    (node->name == NULL))
-    return(0);
+        (node->name == NULL))
+        return(0);
 
     if (node->name[0] == 'a') {
-    if (IS_XSLT_NAME(node, "apply-templates"))
-        return(XSLT_FUNC_APPLYTEMPLATES);
-    else if (IS_XSLT_NAME(node, "attribute"))
-        return(XSLT_FUNC_ATTRIBUTE);
-    else if (IS_XSLT_NAME(node, "apply-imports"))
-        return(XSLT_FUNC_APPLYIMPORTS);
-    else if (IS_XSLT_NAME(node, "attribute-set"))
-        return(0);
+        if (IS_XSLT_NAME(node, "apply-templates"))
+            return(XSLT_FUNC_APPLYTEMPLATES);
+        else if (IS_XSLT_NAME(node, "attribute"))
+            return(XSLT_FUNC_ATTRIBUTE);
+        else if (IS_XSLT_NAME(node, "apply-imports"))
+            return(XSLT_FUNC_APPLYIMPORTS);
+        else if (IS_XSLT_NAME(node, "attribute-set"))
+            return(0);
 
     } else if (node->name[0] == 'c') {
-    if (IS_XSLT_NAME(node, "choose"))
-        return(XSLT_FUNC_CHOOSE);
-    else if (IS_XSLT_NAME(node, "copy"))
-        return(XSLT_FUNC_COPY);
-    else if (IS_XSLT_NAME(node, "copy-of"))
-        return(XSLT_FUNC_COPYOF);
-    else if (IS_XSLT_NAME(node, "call-template"))
-        return(XSLT_FUNC_CALLTEMPLATE);
-    else if (IS_XSLT_NAME(node, "comment"))
-        return(XSLT_FUNC_COMMENT);
+        if (IS_XSLT_NAME(node, "choose"))
+            return(XSLT_FUNC_CHOOSE);
+        else if (IS_XSLT_NAME(node, "copy"))
+            return(XSLT_FUNC_COPY);
+        else if (IS_XSLT_NAME(node, "copy-of"))
+            return(XSLT_FUNC_COPYOF);
+        else if (IS_XSLT_NAME(node, "call-template"))
+            return(XSLT_FUNC_CALLTEMPLATE);
+        else if (IS_XSLT_NAME(node, "comment"))
+            return(XSLT_FUNC_COMMENT);
 
     } else if (node->name[0] == 'd') {
-    if (IS_XSLT_NAME(node, "document"))
-        return(XSLT_FUNC_DOCUMENT);
-    else if (IS_XSLT_NAME(node, "decimal-format"))
-        return(0);
+        if (IS_XSLT_NAME(node, "document"))
+            return(XSLT_FUNC_DOCUMENT);
+        else if (IS_XSLT_NAME(node, "decimal-format"))
+            return(0);
 
     } else if (node->name[0] == 'e') {
-    if (IS_XSLT_NAME(node, "element"))
-        return(XSLT_FUNC_ELEMENT);
+        if (IS_XSLT_NAME(node, "element"))
+            return(XSLT_FUNC_ELEMENT);
 
     } else if (node->name[0] == 'f') {
-    if (IS_XSLT_NAME(node, "for-each"))
-        return(XSLT_FUNC_FOREACH);
-    else if (IS_XSLT_NAME(node, "fallback"))
-        return(XSLT_FUNC_FALLBACK);
+        if (IS_XSLT_NAME(node, "for-each"))
+            return(XSLT_FUNC_FOREACH);
+        else if (IS_XSLT_NAME(node, "fallback"))
+            return(XSLT_FUNC_FALLBACK);
 
     } else if (*(node->name) == 'i') {
-    if (IS_XSLT_NAME(node, "if"))
-        return(XSLT_FUNC_IF);
-    else if (IS_XSLT_NAME(node, "include"))
-        return(0);
-    else if (IS_XSLT_NAME(node, "import"))
-        return(0);
+        if (IS_XSLT_NAME(node, "if"))
+            return(XSLT_FUNC_IF);
+        else if (IS_XSLT_NAME(node, "include"))
+            return(0);
+        else if (IS_XSLT_NAME(node, "import"))
+            return(0);
 
     } else if (*(node->name) == 'k') {
-    if (IS_XSLT_NAME(node, "key"))
-        return(0);
+        if (IS_XSLT_NAME(node, "key"))
+            return(0);
 
     } else if (*(node->name) == 'm') {
-    if (IS_XSLT_NAME(node, "message"))
-        return(XSLT_FUNC_MESSAGE);
+        if (IS_XSLT_NAME(node, "message"))
+            return(XSLT_FUNC_MESSAGE);
 
     } else if (*(node->name) == 'n') {
-    if (IS_XSLT_NAME(node, "number"))
-        return(XSLT_FUNC_NUMBER);
-    else if (IS_XSLT_NAME(node, "namespace-alias"))
-        return(0);
+        if (IS_XSLT_NAME(node, "number"))
+            return(XSLT_FUNC_NUMBER);
+        else if (IS_XSLT_NAME(node, "namespace-alias"))
+            return(0);
 
     } else if (*(node->name) == 'o') {
-    if (IS_XSLT_NAME(node, "otherwise"))
-        return(XSLT_FUNC_OTHERWISE);
-    else if (IS_XSLT_NAME(node, "output"))
-        return(0);
+        if (IS_XSLT_NAME(node, "otherwise"))
+            return(XSLT_FUNC_OTHERWISE);
+        else if (IS_XSLT_NAME(node, "output"))
+            return(0);
 
     } else if (*(node->name) == 'p') {
-    if (IS_XSLT_NAME(node, "param"))
-        return(XSLT_FUNC_PARAM);
-    else if (IS_XSLT_NAME(node, "processing-instruction"))
-        return(XSLT_FUNC_PI);
-    else if (IS_XSLT_NAME(node, "preserve-space"))
-        return(0);
+        if (IS_XSLT_NAME(node, "param"))
+            return(XSLT_FUNC_PARAM);
+        else if (IS_XSLT_NAME(node, "processing-instruction"))
+            return(XSLT_FUNC_PI);
+        else if (IS_XSLT_NAME(node, "preserve-space"))
+            return(0);
 
     } else if (*(node->name) == 's') {
-    if (IS_XSLT_NAME(node, "sort"))
-        return(XSLT_FUNC_SORT);
-    else if (IS_XSLT_NAME(node, "strip-space"))
-        return(0);
-    else if (IS_XSLT_NAME(node, "stylesheet"))
-        return(0);
+        if (IS_XSLT_NAME(node, "sort"))
+            return(XSLT_FUNC_SORT);
+        else if (IS_XSLT_NAME(node, "strip-space"))
+            return(0);
+        else if (IS_XSLT_NAME(node, "stylesheet"))
+            return(0);
 
     } else if (node->name[0] == 't') {
-    if (IS_XSLT_NAME(node, "text"))
-        return(XSLT_FUNC_TEXT);
-    else if (IS_XSLT_NAME(node, "template"))
-        return(0);
-    else if (IS_XSLT_NAME(node, "transform"))
-        return(0);
+        if (IS_XSLT_NAME(node, "text"))
+            return(XSLT_FUNC_TEXT);
+        else if (IS_XSLT_NAME(node, "template"))
+            return(0);
+        else if (IS_XSLT_NAME(node, "transform"))
+            return(0);
 
     } else if (*(node->name) == 'v') {
-    if (IS_XSLT_NAME(node, "value-of"))
-        return(XSLT_FUNC_VALUEOF);
-    else if (IS_XSLT_NAME(node, "variable"))
-        return(XSLT_FUNC_VARIABLE);
+        if (IS_XSLT_NAME(node, "value-of"))
+            return(XSLT_FUNC_VALUEOF);
+        else if (IS_XSLT_NAME(node, "variable"))
+            return(XSLT_FUNC_VARIABLE);
 
     } else if (*(node->name) == 'w') {
-    if (IS_XSLT_NAME(node, "when"))
-        return(XSLT_FUNC_WHEN);
-    if (IS_XSLT_NAME(node, "with-param"))
-        return(XSLT_FUNC_WITHPARAM);
+        if (IS_XSLT_NAME(node, "when"))
+            return(XSLT_FUNC_WHEN);
+        if (IS_XSLT_NAME(node, "with-param"))
+            return(XSLT_FUNC_WITHPARAM);
     }
     return(0);
 }
@@ -3916,18 +3912,18 @@ int
 xsltParseAnyXSLTElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr elem)
 {
     if ((cctxt == NULL) || (elem == NULL) ||
-    (elem->type != XML_ELEMENT_NODE))
-    return(-1);
+        (elem->type != XML_ELEMENT_NODE))
+        return(-1);
 
     elem->psvi = NULL;
 
     if (! (IS_XSLT_ELEM_FAST(elem)))
-    return(-1);
+        return(-1);
     /*
     * Detection of handled content of extension instructions.
     */
     if (cctxt->inode->category == XSLT_ELEMENT_CATEGORY_EXTENSION) {
-    cctxt->inode->extContentHandled = 1;
+        cctxt->inode->extContentHandled = 1;
     }
 
     xsltCompilerNodePush(cctxt, elem);
@@ -3936,15 +3932,15 @@ xsltParseAnyXSLTElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr elem)
     *  textual node-name and namespace comparison.
     */
     if (cctxt->inode->prev->curChildType != 0)
-    cctxt->inode->type = cctxt->inode->prev->curChildType;
+        cctxt->inode->type = cctxt->inode->prev->curChildType;
     else
-    cctxt->inode->type = xsltGetXSLTElementTypeByNode(cctxt, elem);
+        cctxt->inode->type = xsltGetXSLTElementTypeByNode(cctxt, elem);
     /*
     * Update the in-scope namespaces if needed.
     */
     if (elem->nsDef != NULL)
-    cctxt->inode->inScopeNs =
-        xsltCompilerBuildInScopeNsList(cctxt, elem);
+        cctxt->inode->inScopeNs =
+            xsltCompilerBuildInScopeNsList(cctxt, elem);
     /*
     * xsltStylePreCompute():
     *  This will compile the information found on the current
@@ -3960,216 +3956,216 @@ xsltParseAnyXSLTElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr elem)
     * Validate the content model of the XSLT-element.
     */
     switch (cctxt->inode->type) {
-    case XSLT_FUNC_APPLYIMPORTS:
-        /* EMPTY */
-        goto empty_content;
-    case XSLT_FUNC_APPLYTEMPLATES:
-        /* <!-- Content: (xsl:sort | xsl:with-param)* --> */
-        goto apply_templates;
-    case XSLT_FUNC_ATTRIBUTE:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_CALLTEMPLATE:
-        /* <!-- Content: xsl:with-param* --> */
-        goto call_template;
-    case XSLT_FUNC_CHOOSE:
-        /* <!-- Content: (xsl:when+, xsl:otherwise?) --> */
-        goto choose;
-    case XSLT_FUNC_COMMENT:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_COPY:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_COPYOF:
-        /* EMPTY */
-        goto empty_content;
-    case XSLT_FUNC_DOCUMENT: /* Extra one */
-        /* ?? template ?? */
-        goto sequence_constructor;
-    case XSLT_FUNC_ELEMENT:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_FALLBACK:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_FOREACH:
-        /* <!-- Content: (xsl:sort*, template) --> */
-        goto for_each;
-    case XSLT_FUNC_IF:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_OTHERWISE:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_MESSAGE:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_NUMBER:
-        /* EMPTY */
-        goto empty_content;
-    case XSLT_FUNC_PARAM:
-        /*
-        * Check for redefinition.
-        */
-        if ((elem->psvi != NULL) && (cctxt->ivar != NULL)) {
-        xsltVarInfoPtr ivar = cctxt->ivar;
+        case XSLT_FUNC_APPLYIMPORTS:
+            /* EMPTY */
+            goto empty_content;
+        case XSLT_FUNC_APPLYTEMPLATES:
+            /* <!-- Content: (xsl:sort | xsl:with-param)* --> */
+            goto apply_templates;
+        case XSLT_FUNC_ATTRIBUTE:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_CALLTEMPLATE:
+            /* <!-- Content: xsl:with-param* --> */
+            goto call_template;
+        case XSLT_FUNC_CHOOSE:
+            /* <!-- Content: (xsl:when+, xsl:otherwise?) --> */
+            goto choose;
+        case XSLT_FUNC_COMMENT:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_COPY:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_COPYOF:
+            /* EMPTY */
+            goto empty_content;
+        case XSLT_FUNC_DOCUMENT: /* Extra one */
+            /* ?? template ?? */
+            goto sequence_constructor;
+        case XSLT_FUNC_ELEMENT:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_FALLBACK:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_FOREACH:
+            /* <!-- Content: (xsl:sort*, template) --> */
+            goto for_each;
+        case XSLT_FUNC_IF:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_OTHERWISE:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_MESSAGE:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_NUMBER:
+            /* EMPTY */
+            goto empty_content;
+        case XSLT_FUNC_PARAM:
+            /*
+            * Check for redefinition.
+            */
+            if ((elem->psvi != NULL) && (cctxt->ivar != NULL)) {
+                xsltVarInfoPtr ivar = cctxt->ivar;
 
-        do {
-            if ((ivar->name ==
-             ((xsltStyleItemParamPtr) elem->psvi)->name) &&
-            (ivar->nsName ==
-             ((xsltStyleItemParamPtr) elem->psvi)->ns))
-            {
-            elem->psvi = NULL;
-            xsltTransformError(NULL, cctxt->style, elem,
-                "Redefinition of variable or parameter '%s'.\n",
-                ivar->name);
-            cctxt->style->errors++;
-            goto error;
+                do {
+                    if ((ivar->name ==
+                         ((xsltStyleItemParamPtr) elem->psvi)->name) &&
+                        (ivar->nsName ==
+                         ((xsltStyleItemParamPtr) elem->psvi)->ns))
+                    {
+                        elem->psvi = NULL;
+                        xsltTransformError(NULL, cctxt->style, elem,
+                            "Redefinition of variable or parameter '%s'.\n",
+                            ivar->name);
+                        cctxt->style->errors++;
+                        goto error;
+                    }
+                    ivar = ivar->prev;
+                } while (ivar != NULL);
             }
-            ivar = ivar->prev;
-        } while (ivar != NULL);
-        }
-        /*  <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_PI:
-        /*  <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_SORT:
-        /* EMPTY */
-        goto empty_content;
-    case XSLT_FUNC_TEXT:
-        /* <!-- Content: #PCDATA --> */
-        goto text;
-    case XSLT_FUNC_VALUEOF:
-        /* EMPTY */
-        goto empty_content;
-    case XSLT_FUNC_VARIABLE:
-        /*
-        * Check for redefinition.
-        */
-        if ((elem->psvi != NULL) && (cctxt->ivar != NULL)) {
-        xsltVarInfoPtr ivar = cctxt->ivar;
+            /*  <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_PI:
+            /*  <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_SORT:
+            /* EMPTY */
+            goto empty_content;
+        case XSLT_FUNC_TEXT:
+            /* <!-- Content: #PCDATA --> */
+            goto text;
+        case XSLT_FUNC_VALUEOF:
+            /* EMPTY */
+            goto empty_content;
+        case XSLT_FUNC_VARIABLE:
+            /*
+            * Check for redefinition.
+            */
+            if ((elem->psvi != NULL) && (cctxt->ivar != NULL)) {
+                xsltVarInfoPtr ivar = cctxt->ivar;
 
-        do {
-            if ((ivar->name ==
-             ((xsltStyleItemVariablePtr) elem->psvi)->name) &&
-            (ivar->nsName ==
-             ((xsltStyleItemVariablePtr) elem->psvi)->ns))
-            {
-            elem->psvi = NULL;
-            xsltTransformError(NULL, cctxt->style, elem,
-                "Redefinition of variable or parameter '%s'.\n",
-                ivar->name);
-            cctxt->style->errors++;
-            goto error;
+                do {
+                    if ((ivar->name ==
+                         ((xsltStyleItemVariablePtr) elem->psvi)->name) &&
+                        (ivar->nsName ==
+                         ((xsltStyleItemVariablePtr) elem->psvi)->ns))
+                    {
+                        elem->psvi = NULL;
+                        xsltTransformError(NULL, cctxt->style, elem,
+                            "Redefinition of variable or parameter '%s'.\n",
+                            ivar->name);
+                        cctxt->style->errors++;
+                        goto error;
+                    }
+                    ivar = ivar->prev;
+                } while (ivar != NULL);
             }
-            ivar = ivar->prev;
-        } while (ivar != NULL);
-        }
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_WHEN:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    case XSLT_FUNC_WITHPARAM:
-        /* <!-- Content: template --> */
-        goto sequence_constructor;
-    default:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_WHEN:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        case XSLT_FUNC_WITHPARAM:
+            /* <!-- Content: template --> */
+            goto sequence_constructor;
+        default:
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseXSLTNode: Unhandled XSLT element '%s'.\n",
-        elem->name);
+            xsltGenericDebug(xsltGenericDebugContext,
+                "xsltParseXSLTNode: Unhandled XSLT element '%s'.\n",
+                elem->name);
 #endif
-        xsltTransformError(NULL, cctxt->style, elem,
-        "xsltParseXSLTNode: Internal error; "
-        "unhandled XSLT element '%s'.\n", elem->name);
-        cctxt->style->errors++;
-        goto internal_err;
+            xsltTransformError(NULL, cctxt->style, elem,
+                "xsltParseXSLTNode: Internal error; "
+                "unhandled XSLT element '%s'.\n", elem->name);
+            cctxt->style->errors++;
+            goto internal_err;
     }
 
 apply_templates:
     /* <!-- Content: (xsl:sort | xsl:with-param)* --> */
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    do {
-        if (child->type == XML_ELEMENT_NODE) {
-        if (IS_XSLT_ELEM_FAST(child)) {
-            if (xmlStrEqual(child->name, BAD_CAST "with-param")) {
-            cctxt->inode->curChildType = XSLT_FUNC_WITHPARAM;
-            xsltParseAnyXSLTElem(cctxt, child);
-            } else if (xmlStrEqual(child->name, BAD_CAST "sort")) {
-            cctxt->inode->curChildType = XSLT_FUNC_SORT;
-            xsltParseAnyXSLTElem(cctxt, child);
-            } else
-            xsltParseContentError(cctxt->style, child);
-        } else
-            xsltParseContentError(cctxt->style, child);
-        }
-        child = child->next;
-    } while (child != NULL);
+        xmlNodePtr child = elem->children;
+        do {
+            if (child->type == XML_ELEMENT_NODE) {
+                if (IS_XSLT_ELEM_FAST(child)) {
+                    if (xmlStrEqual(child->name, BAD_CAST "with-param")) {
+                        cctxt->inode->curChildType = XSLT_FUNC_WITHPARAM;
+                        xsltParseAnyXSLTElem(cctxt, child);
+                    } else if (xmlStrEqual(child->name, BAD_CAST "sort")) {
+                        cctxt->inode->curChildType = XSLT_FUNC_SORT;
+                        xsltParseAnyXSLTElem(cctxt, child);
+                    } else
+                        xsltParseContentError(cctxt->style, child);
+                } else
+                    xsltParseContentError(cctxt->style, child);
+            }
+            child = child->next;
+        } while (child != NULL);
     }
     goto exit;
 
 call_template:
     /* <!-- Content: xsl:with-param* --> */
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    do {
-        if (child->type == XML_ELEMENT_NODE) {
-        if (IS_XSLT_ELEM_FAST(child)) {
-            xsltStyleType type;
+        xmlNodePtr child = elem->children;
+        do {
+            if (child->type == XML_ELEMENT_NODE) {
+                if (IS_XSLT_ELEM_FAST(child)) {
+                    xsltStyleType type;
 
-            type = xsltGetXSLTElementTypeByNode(cctxt, child);
-            if (type == XSLT_FUNC_WITHPARAM) {
-            cctxt->inode->curChildType = XSLT_FUNC_WITHPARAM;
-            xsltParseAnyXSLTElem(cctxt, child);
-            } else {
-            xsltParseContentError(cctxt->style, child);
+                    type = xsltGetXSLTElementTypeByNode(cctxt, child);
+                    if (type == XSLT_FUNC_WITHPARAM) {
+                        cctxt->inode->curChildType = XSLT_FUNC_WITHPARAM;
+                        xsltParseAnyXSLTElem(cctxt, child);
+                    } else {
+                        xsltParseContentError(cctxt->style, child);
+                    }
+                } else
+                    xsltParseContentError(cctxt->style, child);
             }
-        } else
-            xsltParseContentError(cctxt->style, child);
-        }
-        child = child->next;
-    } while (child != NULL);
+            child = child->next;
+        } while (child != NULL);
     }
     goto exit;
 
 text:
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    do {
-        if ((child->type != XML_TEXT_NODE) &&
-        (child->type != XML_CDATA_SECTION_NODE))
-        {
-        xsltTransformError(NULL, cctxt->style, elem,
-            "The XSLT 'text' element must have only character "
-            "data as content.\n");
-        }
-        child = child->next;
-    } while (child != NULL);
+        xmlNodePtr child = elem->children;
+        do {
+            if ((child->type != XML_TEXT_NODE) &&
+                (child->type != XML_CDATA_SECTION_NODE))
+            {
+                xsltTransformError(NULL, cctxt->style, elem,
+                    "The XSLT 'text' element must have only character "
+                    "data as content.\n");
+            }
+            child = child->next;
+        } while (child != NULL);
     }
     goto exit;
 
 empty_content:
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    /*
-    * Relaxed behaviour: we will allow whitespace-only text-nodes.
-    */
-    do {
-        if (((child->type != XML_TEXT_NODE) &&
-         (child->type != XML_CDATA_SECTION_NODE)) ||
-        (! IS_BLANK_NODE(child)))
-        {
-        xsltTransformError(NULL, cctxt->style, elem,
-            "This XSLT element must have no content.\n");
-        cctxt->style->errors++;
-        break;
-        }
-        child = child->next;
-    } while (child != NULL);
+        xmlNodePtr child = elem->children;
+        /*
+        * Relaxed behaviour: we will allow whitespace-only text-nodes.
+        */
+        do {
+            if (((child->type != XML_TEXT_NODE) &&
+                 (child->type != XML_CDATA_SECTION_NODE)) ||
+                (! IS_BLANK_NODE(child)))
+            {
+                xsltTransformError(NULL, cctxt->style, elem,
+                    "This XSLT element must have no content.\n");
+                cctxt->style->errors++;
+                break;
+            }
+            child = child->next;
+        } while (child != NULL);
     }
     goto exit;
 
@@ -4182,57 +4178,57 @@ choose:
     *  if whitespace-only (regardless of xml:space).
     */
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    int nbWhen = 0, nbOtherwise = 0, err = 0;
-    do {
-        if (child->type == XML_ELEMENT_NODE) {
-        if (IS_XSLT_ELEM_FAST(child)) {
-            xsltStyleType type;
+        xmlNodePtr child = elem->children;
+        int nbWhen = 0, nbOtherwise = 0, err = 0;
+        do {
+            if (child->type == XML_ELEMENT_NODE) {
+                if (IS_XSLT_ELEM_FAST(child)) {
+                    xsltStyleType type;
 
-            type = xsltGetXSLTElementTypeByNode(cctxt, child);
-            if (type == XSLT_FUNC_WHEN) {
-            nbWhen++;
-            if (nbOtherwise) {
-                xsltParseContentError(cctxt->style, child);
-                err = 1;
-                break;
+                    type = xsltGetXSLTElementTypeByNode(cctxt, child);
+                    if (type == XSLT_FUNC_WHEN) {
+                        nbWhen++;
+                        if (nbOtherwise) {
+                            xsltParseContentError(cctxt->style, child);
+                            err = 1;
+                            break;
+                        }
+                        cctxt->inode->curChildType = XSLT_FUNC_WHEN;
+                        xsltParseAnyXSLTElem(cctxt, child);
+                    } else if (type == XSLT_FUNC_OTHERWISE) {
+                        if (! nbWhen) {
+                            xsltParseContentError(cctxt->style, child);
+                            err = 1;
+                            break;
+                        }
+                        if (nbOtherwise) {
+                            xsltTransformError(NULL, cctxt->style, elem,
+                                "The XSLT 'choose' element must not contain "
+                                "more than one XSLT 'otherwise' element.\n");
+                            cctxt->style->errors++;
+                            err = 1;
+                            break;
+                        }
+                        nbOtherwise++;
+                        cctxt->inode->curChildType = XSLT_FUNC_OTHERWISE;
+                        xsltParseAnyXSLTElem(cctxt, child);
+                    } else
+                        xsltParseContentError(cctxt->style, child);
+                } else
+                    xsltParseContentError(cctxt->style, child);
             }
-            cctxt->inode->curChildType = XSLT_FUNC_WHEN;
-            xsltParseAnyXSLTElem(cctxt, child);
-            } else if (type == XSLT_FUNC_OTHERWISE) {
-            if (! nbWhen) {
-                xsltParseContentError(cctxt->style, child);
-                err = 1;
-                break;
-            }
-            if (nbOtherwise) {
-                xsltTransformError(NULL, cctxt->style, elem,
-                "The XSLT 'choose' element must not contain "
-                "more than one XSLT 'otherwise' element.\n");
+            /*
+                else
+                    xsltParseContentError(cctxt, child);
+            */
+            child = child->next;
+        } while (child != NULL);
+        if ((! err) && (! nbWhen)) {
+            xsltTransformError(NULL, cctxt->style, elem,
+                "The XSLT element 'choose' must contain at least one "
+                "XSLT element 'when'.\n");
                 cctxt->style->errors++;
-                err = 1;
-                break;
-            }
-            nbOtherwise++;
-            cctxt->inode->curChildType = XSLT_FUNC_OTHERWISE;
-            xsltParseAnyXSLTElem(cctxt, child);
-            } else
-            xsltParseContentError(cctxt->style, child);
-        } else
-            xsltParseContentError(cctxt->style, child);
         }
-        /*
-        else
-            xsltParseContentError(cctxt, child);
-        */
-        child = child->next;
-    } while (child != NULL);
-    if ((! err) && (! nbWhen)) {
-        xsltTransformError(NULL, cctxt->style, elem,
-        "The XSLT element 'choose' must contain at least one "
-        "XSLT element 'when'.\n");
-        cctxt->style->errors++;
-    }
     }
     goto exit;
 
@@ -4246,30 +4242,30 @@ for_each:
     *   (regardless of xml:space).
     */
     if (elem->children != NULL) {
-    xmlNodePtr child = elem->children;
-    /*
-    * Parse xsl:sort first.
-    */
-    do {
-        if ((child->type == XML_ELEMENT_NODE) &&
-        IS_XSLT_ELEM_FAST(child))
-        {
-        if (xsltGetXSLTElementTypeByNode(cctxt, child) ==
-            XSLT_FUNC_SORT)
-        {
-            cctxt->inode->curChildType = XSLT_FUNC_SORT;
-            xsltParseAnyXSLTElem(cctxt, child);
-        } else
-            break;
-        } else
-        break;
-        child = child->next;
-    } while (child != NULL);
-    /*
-    * Parse the sequece constructor.
-    */
-    if (child != NULL)
-        xsltParseSequenceConstructor(cctxt, child);
+        xmlNodePtr child = elem->children;
+        /*
+        * Parse xsl:sort first.
+        */
+        do {
+            if ((child->type == XML_ELEMENT_NODE) &&
+                IS_XSLT_ELEM_FAST(child))
+            {
+                if (xsltGetXSLTElementTypeByNode(cctxt, child) ==
+                    XSLT_FUNC_SORT)
+                {
+                    cctxt->inode->curChildType = XSLT_FUNC_SORT;
+                    xsltParseAnyXSLTElem(cctxt, child);
+                } else
+                    break;
+            } else
+                break;
+            child = child->next;
+        } while (child != NULL);
+        /*
+        * Parse the sequece constructor.
+        */
+        if (child != NULL)
+            xsltParseSequenceConstructor(cctxt, child);
     }
     goto exit;
 
@@ -4278,23 +4274,23 @@ sequence_constructor:
     * Parse the sequence constructor.
     */
     if (elem->children != NULL)
-    xsltParseSequenceConstructor(cctxt, elem->children);
+        xsltParseSequenceConstructor(cctxt, elem->children);
 
     /*
     * Register information for vars/params. Only needed if there
     * are any following siblings.
     */
     if ((elem->next != NULL) &&
-    ((cctxt->inode->type == XSLT_FUNC_VARIABLE) ||
-     (cctxt->inode->type == XSLT_FUNC_PARAM)))
+        ((cctxt->inode->type == XSLT_FUNC_VARIABLE) ||
+         (cctxt->inode->type == XSLT_FUNC_PARAM)))
     {
-    if ((elem->psvi != NULL) &&
-        (((xsltStyleBasicItemVariablePtr) elem->psvi)->name))
-    {
-        xsltCompilerVarInfoPush(cctxt, elem,
-        ((xsltStyleBasicItemVariablePtr) elem->psvi)->name,
-        ((xsltStyleBasicItemVariablePtr) elem->psvi)->ns);
-    }
+        if ((elem->psvi != NULL) &&
+            (((xsltStyleBasicItemVariablePtr) elem->psvi)->name))
+        {
+            xsltCompilerVarInfoPush(cctxt, elem,
+                ((xsltStyleBasicItemVariablePtr) elem->psvi)->name,
+                ((xsltStyleBasicItemVariablePtr) elem->psvi)->ns);
+        }
     }
 
 error:
@@ -4324,11 +4320,11 @@ xsltForwardsCompatUnkownItemCreate(xsltCompilerCtxtPtr cctxt)
 
     item = (xsltStyleItemUknownPtr) xmlMalloc(sizeof(xsltStyleItemUknown));
     if (item == NULL) {
-    xsltTransformError(NULL, cctxt->style, NULL,
-        "Internal error in xsltForwardsCompatUnkownItemCreate(): "
-        "Failed to allocate memory.\n");
-    cctxt->style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, cctxt->style, NULL,
+            "Internal error in xsltForwardsCompatUnkownItemCreate(): "
+            "Failed to allocate memory.\n");
+        cctxt->style->errors++;
+        return(NULL);
     }
     memset(item, 0, sizeof(xsltStyleItemUknown));
     item->type = XSLT_FUNC_UNKOWN_FORWARDS_COMPAT;
@@ -4356,25 +4352,25 @@ xsltForwardsCompatUnkownItemCreate(xsltCompilerCtxtPtr cctxt)
  */
 static int
 xsltParseUnknownXSLTElem(xsltCompilerCtxtPtr cctxt,
-                xmlNodePtr node)
+                            xmlNodePtr node)
 {
     if ((cctxt == NULL) || (node == NULL) || (node->type != XML_ELEMENT_NODE))
-    return(-1);
+        return(-1);
 
     /*
     * Detection of handled content of extension instructions.
     */
     if (cctxt->inode->category == XSLT_ELEMENT_CATEGORY_EXTENSION) {
-    cctxt->inode->extContentHandled = 1;
+        cctxt->inode->extContentHandled = 1;
     }
     if (cctxt->inode->forwardsCompat == 0) {
-    /*
-    * We are not in forwards-compatible mode, so raise an error.
-    */
-    xsltTransformError(NULL, cctxt->style, node,
-        "Unknown XSLT element '%s'.\n", node->name);
-    cctxt->style->errors++;
-    return(1);
+        /*
+        * We are not in forwards-compatible mode, so raise an error.
+        */
+        xsltTransformError(NULL, cctxt->style, node,
+            "Unknown XSLT element '%s'.\n", node->name);
+        cctxt->style->errors++;
+        return(1);
     }
     /*
     * Forwards-compatible mode.
@@ -4387,43 +4383,43 @@ xsltParseUnknownXSLTElem(xsltCompilerCtxtPtr cctxt,
     *  also be provided by using the XSLT function "element-available".
     */
     if (cctxt->unknownItem == NULL) {
-    /*
-    * Create a singleton for all unknown XSLT instructions.
-    */
-    cctxt->unknownItem = xsltForwardsCompatUnkownItemCreate(cctxt);
-    if (cctxt->unknownItem == NULL) {
-        node->psvi = NULL;
-        return(-1);
-    }
+        /*
+        * Create a singleton for all unknown XSLT instructions.
+        */
+        cctxt->unknownItem = xsltForwardsCompatUnkownItemCreate(cctxt);
+        if (cctxt->unknownItem == NULL) {
+            node->psvi = NULL;
+            return(-1);
+        }
     }
     node->psvi = cctxt->unknownItem;
     if (node->children == NULL)
-    return(0);
+        return(0);
     else {
-    xmlNodePtr child = node->children;
+        xmlNodePtr child = node->children;
 
-    xsltCompilerNodePush(cctxt, node);
-    /*
-    * Update the in-scope namespaces if needed.
-    */
-    if (node->nsDef != NULL)
-        cctxt->inode->inScopeNs =
-        xsltCompilerBuildInScopeNsList(cctxt, node);
-    /*
-    * Parse all xsl:fallback children.
-    */
-    do {
-        if ((child->type == XML_ELEMENT_NODE) &&
-        IS_XSLT_ELEM_FAST(child) &&
-        IS_XSLT_NAME(child, "fallback"))
-        {
-        cctxt->inode->curChildType = XSLT_FUNC_FALLBACK;
-        xsltParseAnyXSLTElem(cctxt, child);
-        }
-        child = child->next;
-    } while (child != NULL);
+        xsltCompilerNodePush(cctxt, node);
+        /*
+        * Update the in-scope namespaces if needed.
+        */
+        if (node->nsDef != NULL)
+            cctxt->inode->inScopeNs =
+                xsltCompilerBuildInScopeNsList(cctxt, node);
+        /*
+        * Parse all xsl:fallback children.
+        */
+        do {
+            if ((child->type == XML_ELEMENT_NODE) &&
+                IS_XSLT_ELEM_FAST(child) &&
+                IS_XSLT_NAME(child, "fallback"))
+            {
+                cctxt->inode->curChildType = XSLT_FUNC_FALLBACK;
+                xsltParseAnyXSLTElem(cctxt, child);
+            }
+            child = child->next;
+        } while (child != NULL);
 
-    xsltCompilerNodePop(cctxt, node);
+        xsltCompilerNodePop(cctxt, node);
     }
     return(0);
 }
@@ -4444,19 +4440,19 @@ xsltParseSequenceConstructor(xsltCompilerCtxtPtr cctxt, xmlNodePtr cur)
     xmlNodePtr deleteNode = NULL;
 
     if (cctxt == NULL) {
-    xmlGenericError(xmlGenericErrorContext,
-        "xsltParseSequenceConstructor: Bad arguments\n");
-    cctxt->style->errors++;
-    return;
+        xmlGenericError(xmlGenericErrorContext,
+            "xsltParseSequenceConstructor: Bad arguments\n");
+        cctxt->style->errors++;
+        return;
     }
     /*
     * Detection of handled content of extension instructions.
     */
     if (cctxt->inode->category == XSLT_ELEMENT_CATEGORY_EXTENSION) {
-    cctxt->inode->extContentHandled = 1;
+        cctxt->inode->extContentHandled = 1;
     }
     if ((cur == NULL) || (cur->type == XML_NAMESPACE_DECL))
-    return;
+        return;
     /*
     * This is the content reffered to as a "template".
     * E.g. an xsl:element has such content model:
@@ -4485,362 +4481,362 @@ xsltParseSequenceConstructor(xsltCompilerCtxtPtr cctxt, xmlNodePtr cur)
     * NOTE that this content model does *not* allow xsl:param.
     */
     while (cur != NULL) {
+        if (deleteNode != NULL) {
+#ifdef WITH_XSLT_DEBUG_BLANKS
+            xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParseSequenceConstructor: removing xsl:text element\n");
+#endif
+            xmlUnlinkNode(deleteNode);
+            xmlFreeNode(deleteNode);
+            deleteNode = NULL;
+        }
+        if (cur->type == XML_ELEMENT_NODE) {
+
+            if (cur->psvi == xsltXSLTTextMarker) {
+                /*
+                * xsl:text elements
+                * --------------------------------------------------------
+                */
+                xmlNodePtr tmp;
+
+                cur->psvi = NULL;
+                /*
+                * Mark the xsl:text element for later deletion.
+                */
+                deleteNode = cur;
+                /*
+                * Validate content.
+                */
+                tmp = cur->children;
+                if (tmp) {
+                    /*
+                    * We don't expect more than one text-node in the
+                    * content, since we already merged adjacent
+                    * text/CDATA-nodes and eliminated PI/comment-nodes.
+                    */
+                    if ((tmp->type == XML_TEXT_NODE) ||
+                        (tmp->next == NULL))
+                    {
+                        /*
+                        * Leave the contained text-node in the tree.
+                        */
+                        xmlUnlinkNode(tmp);
+                        xmlAddPrevSibling(cur, tmp);
+                    } else {
+                        tmp = NULL;
+                        xsltTransformError(NULL, cctxt->style, cur,
+                            "Element 'xsl:text': Invalid type "
+                            "of node found in content.\n");
+                        cctxt->style->errors++;
+                    }
+                }
+                if (cur->properties) {
+                    xmlAttrPtr attr;
+                    /*
+                    * TODO: We need to report errors for
+                    *  invalid attrs.
+                    */
+                    attr = cur->properties;
+                    do {
+                        if ((attr->ns == NULL) &&
+                            (attr->name != NULL) &&
+                            (attr->name[0] == 'd') &&
+                            xmlStrEqual(attr->name,
+                            BAD_CAST "disable-output-escaping"))
+                        {
+                            /*
+                            * Attr "disable-output-escaping".
+                            * XSLT-2: This attribute is deprecated.
+                            */
+                            if ((attr->children != NULL) &&
+                                xmlStrEqual(attr->children->content,
+                                BAD_CAST "yes"))
+                            {
+                                /*
+                                * Disable output escaping for this
+                                * text node.
+                                */
+                                if (tmp)
+                                    tmp->name = xmlStringTextNoenc;
+                            } else if ((attr->children == NULL) ||
+                                (attr->children->content == NULL) ||
+                                (!xmlStrEqual(attr->children->content,
+                                BAD_CAST "no")))
+                            {
+                                xsltTransformError(NULL, cctxt->style,
+                                    cur,
+                                    "Attribute 'disable-output-escaping': "
+                                    "Invalid value. Expected is "
+                                    "'yes' or 'no'.\n");
+                                cctxt->style->errors++;
+                            }
+                            break;
+                        }
+                        attr = attr->next;
+                    } while (attr != NULL);
+                }
+            } else if (IS_XSLT_ELEM_FAST(cur)) {
+                /*
+                * TODO: Using the XSLT-marker is still not stable yet.
+                */
+                /* if (cur->psvi == xsltXSLTElemMarker) { */
+                /*
+                * XSLT instructions
+                * --------------------------------------------------------
+                */
+                cur->psvi = NULL;
+                type = xsltGetXSLTElementTypeByNode(cctxt, cur);
+                switch (type) {
+                    case XSLT_FUNC_APPLYIMPORTS:
+                    case XSLT_FUNC_APPLYTEMPLATES:
+                    case XSLT_FUNC_ATTRIBUTE:
+                    case XSLT_FUNC_CALLTEMPLATE:
+                    case XSLT_FUNC_CHOOSE:
+                    case XSLT_FUNC_COMMENT:
+                    case XSLT_FUNC_COPY:
+                    case XSLT_FUNC_COPYOF:
+                    case XSLT_FUNC_DOCUMENT: /* Extra one */
+                    case XSLT_FUNC_ELEMENT:
+                    case XSLT_FUNC_FALLBACK:
+                    case XSLT_FUNC_FOREACH:
+                    case XSLT_FUNC_IF:
+                    case XSLT_FUNC_MESSAGE:
+                    case XSLT_FUNC_NUMBER:
+                    case XSLT_FUNC_PI:
+                    case XSLT_FUNC_TEXT:
+                    case XSLT_FUNC_VALUEOF:
+                    case XSLT_FUNC_VARIABLE:
+                        /*
+                        * Parse the XSLT element.
+                        */
+                        cctxt->inode->curChildType = type;
+                        xsltParseAnyXSLTElem(cctxt, cur);
+                        break;
+                    default:
+                        xsltParseUnknownXSLTElem(cctxt, cur);
+                        cur = cur->next;
+                        continue;
+                }
+            } else {
+                /*
+                * Non-XSLT elements
+                * -----------------
+                */
+                xsltCompilerNodePush(cctxt, cur);
+                /*
+                * Update the in-scope namespaces if needed.
+                */
+                if (cur->nsDef != NULL)
+                    cctxt->inode->inScopeNs =
+                        xsltCompilerBuildInScopeNsList(cctxt, cur);
+                /*
+                * The current element is either a literal result element
+                * or an extension instruction.
+                *
+                * Process attr "xsl:extension-element-prefixes".
+                * FUTURE TODO: IIRC in XSLT 2.0 this attribute must be
+                * processed by the implementor of the extension function;
+                * i.e., it won't be handled by the XSLT processor.
+                */
+                /* SPEC 1.0:
+                *   "exclude-result-prefixes" is only allowed on literal
+                *   result elements and "xsl:exclude-result-prefixes"
+                *   on xsl:stylesheet/xsl:transform.
+                * SPEC 2.0:
+                *   "There are a number of standard attributes
+                *   that may appear on any XSLT element: specifically
+                *   version, exclude-result-prefixes,
+                *   extension-element-prefixes, xpath-default-namespace,
+                *   default-collation, and use-when."
+                *
+                * SPEC 2.0:
+                *   For literal result elements:
+                *   "xsl:version, xsl:exclude-result-prefixes,
+                *    xsl:extension-element-prefixes,
+                *    xsl:xpath-default-namespace,
+                *    xsl:default-collation, or xsl:use-when."
+                */
+                if (cur->properties)
+                    cctxt->inode->extElemNs =
+                        xsltParseExtElemPrefixes(cctxt,
+                            cur, cctxt->inode->extElemNs,
+                            XSLT_ELEMENT_CATEGORY_LRE);
+                /*
+                * Eval if we have an extension instruction here.
+                */
+                if ((cur->ns != NULL) &&
+                    (cctxt->inode->extElemNs != NULL) &&
+                    (xsltCheckExtPrefix(cctxt->style, cur->ns->href) == 1))
+                {
+                    /*
+                    * Extension instructions
+                    * ----------------------------------------------------
+                    * Mark the node information.
+                    */
+                    cctxt->inode->category = XSLT_ELEMENT_CATEGORY_EXTENSION;
+                    cctxt->inode->extContentHandled = 0;
+                    if (cur->psvi != NULL) {
+                        cur->psvi = NULL;
+                        /*
+                        * TODO: Temporary sanity check.
+                        */
+                        xsltTransformError(NULL, cctxt->style, cur,
+                            "Internal error in xsltParseSequenceConstructor(): "
+                            "Occupied PSVI field.\n");
+                        cctxt->style->errors++;
+                        cur = cur->next;
+                        continue;
+                    }
+                    cur->psvi = (void *)
+                        xsltPreComputeExtModuleElement(cctxt->style, cur);
+
+                    if (cur->psvi == NULL) {
+                        /*
+                        * OLD COMMENT: "Unknown element, maybe registered
+                        *  at the context level. Mark it for later
+                        *  recognition."
+                        * QUESTION: What does the xsltExtMarker mean?
+                        *  ANSWER: It is used in
+                        *   xsltApplySequenceConstructor() at
+                        *   transformation-time to look out for extension
+                        *   registered in the transformation context.
+                        */
+                        cur->psvi = (void *) xsltExtMarker;
+                    }
+                    /*
+                    * BIG NOTE: Now the ugly part. In previous versions
+                    *  of Libxslt (until 1.1.16), all the content of an
+                    *  extension instruction was processed and compiled without
+                    *  the need of the extension-author to explicitely call
+                    *  such a processing;.We now need to mimic this old
+                    *  behaviour in order to avoid breaking old code
+                    *  on the extension-author's side.
+                    * The mechanism:
+                    *  1) If the author does *not* set the
+                    *    compile-time-flag @extContentHandled, then we'll
+                    *    parse the content assuming that it's a "template"
+                    *    (or "sequence constructor in XSLT 2.0 terms).
+                    *    NOTE: If the extension is registered at
+                    *    transformation-time only, then there's no way of
+                    *    knowing that content shall be valid, and we'll
+                    *    process the content the same way.
+                    *  2) If the author *does* set the flag, then we'll assume
+                    *   that the author has handled the parsing him/herself
+                    *   (e.g. called xsltParseSequenceConstructor(), etc.
+                    *   explicitely in his/her code).
+                    */
+                    if ((cur->children != NULL) &&
+                        (cctxt->inode->extContentHandled == 0))
+                    {
+                        /*
+                        * Default parsing of the content using the
+                        * sequence-constructor model.
+                        */
+                        xsltParseSequenceConstructor(cctxt, cur->children);
+                    }
+                } else {
+                    /*
+                    * Literal result element
+                    * ----------------------------------------------------
+                    * Allowed XSLT attributes:
+                    *  xsl:extension-element-prefixes CDATA #IMPLIED
+                    *  xsl:exclude-result-prefixes CDATA #IMPLIED
+                    *  TODO: xsl:use-attribute-sets %qnames; #IMPLIED
+                    *  xsl:version NMTOKEN #IMPLIED
+                    */
+                    cur->psvi = NULL;
+                    cctxt->inode->category = XSLT_ELEMENT_CATEGORY_LRE;
+                    if (cur->properties != NULL) {
+                        xmlAttrPtr attr = cur->properties;
+                        /*
+                        * Attribute "xsl:exclude-result-prefixes".
+                        */
+                        cctxt->inode->exclResultNs =
+                            xsltParseExclResultPrefixes(cctxt, cur,
+                                cctxt->inode->exclResultNs,
+                                XSLT_ELEMENT_CATEGORY_LRE);
+                        /*
+                        * Attribute "xsl:version".
+                        */
+                        xsltParseAttrXSLTVersion(cctxt, cur,
+                            XSLT_ELEMENT_CATEGORY_LRE);
+                        /*
+                        * Report invalid XSLT attributes.
+                        * For XSLT 1.0 only xsl:use-attribute-sets is allowed
+                        * next to xsl:version, xsl:exclude-result-prefixes and
+                        * xsl:extension-element-prefixes.
+                        *
+                        * Mark all XSLT attributes, in order to skip such
+                        * attributes when instantiating the LRE.
+                        */
+                        do {
+                            if ((attr->psvi != xsltXSLTAttrMarker) &&
+                                IS_XSLT_ATTR_FAST(attr))
+                            {
+                                if (! xmlStrEqual(attr->name,
+                                    BAD_CAST "use-attribute-sets"))
+                                {
+                                    xsltTransformError(NULL, cctxt->style,
+                                        cur,
+                                        "Unknown XSLT attribute '%s'.\n",
+                                        attr->name);
+                                    cctxt->style->errors++;
+                                } else {
+                                    /*
+                                    * XSLT attr marker.
+                                    */
+                                    attr->psvi = (void *) xsltXSLTAttrMarker;
+                                }
+                            }
+                            attr = attr->next;
+                        } while (attr != NULL);
+                    }
+                    /*
+                    * Create/reuse info for the literal result element.
+                    */
+                    if (cctxt->inode->nsChanged)
+                        xsltLREInfoCreate(cctxt, cur, 1);
+                    cur->psvi = cctxt->inode->litResElemInfo;
+                    /*
+                    * Apply ns-aliasing on the element and on its attributes.
+                    */
+                    if (cctxt->hasNsAliases)
+                        xsltLREBuildEffectiveNs(cctxt, cur);
+                    /*
+                    * Compile attribute value templates (AVT).
+                    */
+                    if (cur->properties) {
+                        xmlAttrPtr attr = cur->properties;
+
+                        while (attr != NULL) {
+                            xsltCompileAttr(cctxt->style, attr);
+                            attr = attr->next;
+                        }
+                    }
+                    /*
+                    * Parse the content, which is defined to be a "template"
+                    * (or "sequence constructor" in XSLT 2.0 terms).
+                    */
+                    if (cur->children != NULL) {
+                        xsltParseSequenceConstructor(cctxt, cur->children);
+                    }
+                }
+                /*
+                * Leave the non-XSLT element.
+                */
+                xsltCompilerNodePop(cctxt, cur);
+            }
+        }
+        cur = cur->next;
+    }
     if (deleteNode != NULL) {
 #ifdef WITH_XSLT_DEBUG_BLANKS
         xsltGenericDebug(xsltGenericDebugContext,
-         "xsltParseSequenceConstructor: removing xsl:text element\n");
+            "xsltParseSequenceConstructor: removing xsl:text element\n");
 #endif
         xmlUnlinkNode(deleteNode);
         xmlFreeNode(deleteNode);
         deleteNode = NULL;
-    }
-    if (cur->type == XML_ELEMENT_NODE) {
-
-        if (cur->psvi == xsltXSLTTextMarker) {
-        /*
-        * xsl:text elements
-        * --------------------------------------------------------
-        */
-        xmlNodePtr tmp;
-
-        cur->psvi = NULL;
-        /*
-        * Mark the xsl:text element for later deletion.
-        */
-        deleteNode = cur;
-        /*
-        * Validate content.
-        */
-        tmp = cur->children;
-        if (tmp) {
-            /*
-            * We don't expect more than one text-node in the
-            * content, since we already merged adjacent
-            * text/CDATA-nodes and eliminated PI/comment-nodes.
-            */
-            if ((tmp->type == XML_TEXT_NODE) ||
-            (tmp->next == NULL))
-            {
-            /*
-            * Leave the contained text-node in the tree.
-            */
-            xmlUnlinkNode(tmp);
-            xmlAddPrevSibling(cur, tmp);
-            } else {
-            tmp = NULL;
-            xsltTransformError(NULL, cctxt->style, cur,
-                "Element 'xsl:text': Invalid type "
-                "of node found in content.\n");
-            cctxt->style->errors++;
-            }
-        }
-        if (cur->properties) {
-            xmlAttrPtr attr;
-            /*
-            * TODO: We need to report errors for
-            *  invalid attrs.
-            */
-            attr = cur->properties;
-            do {
-            if ((attr->ns == NULL) &&
-                (attr->name != NULL) &&
-                (attr->name[0] == 'd') &&
-                xmlStrEqual(attr->name,
-                BAD_CAST "disable-output-escaping"))
-            {
-                /*
-                * Attr "disable-output-escaping".
-                * XSLT-2: This attribute is deprecated.
-                */
-                if ((attr->children != NULL) &&
-                xmlStrEqual(attr->children->content,
-                BAD_CAST "yes"))
-                {
-                /*
-                * Disable output escaping for this
-                * text node.
-                */
-                if (tmp)
-                    tmp->name = xmlStringTextNoenc;
-                } else if ((attr->children == NULL) ||
-                (attr->children->content == NULL) ||
-                (!xmlStrEqual(attr->children->content,
-                BAD_CAST "no")))
-                {
-                xsltTransformError(NULL, cctxt->style,
-                    cur,
-                    "Attribute 'disable-output-escaping': "
-                    "Invalid value. Expected is "
-                    "'yes' or 'no'.\n");
-                cctxt->style->errors++;
-                }
-                break;
-            }
-            attr = attr->next;
-            } while (attr != NULL);
-        }
-        } else if (IS_XSLT_ELEM_FAST(cur)) {
-        /*
-        * TODO: Using the XSLT-marker is still not stable yet.
-        */
-        /* if (cur->psvi == xsltXSLTElemMarker) { */
-        /*
-        * XSLT instructions
-        * --------------------------------------------------------
-        */
-        cur->psvi = NULL;
-        type = xsltGetXSLTElementTypeByNode(cctxt, cur);
-        switch (type) {
-            case XSLT_FUNC_APPLYIMPORTS:
-            case XSLT_FUNC_APPLYTEMPLATES:
-            case XSLT_FUNC_ATTRIBUTE:
-            case XSLT_FUNC_CALLTEMPLATE:
-            case XSLT_FUNC_CHOOSE:
-            case XSLT_FUNC_COMMENT:
-            case XSLT_FUNC_COPY:
-            case XSLT_FUNC_COPYOF:
-            case XSLT_FUNC_DOCUMENT: /* Extra one */
-            case XSLT_FUNC_ELEMENT:
-            case XSLT_FUNC_FALLBACK:
-            case XSLT_FUNC_FOREACH:
-            case XSLT_FUNC_IF:
-            case XSLT_FUNC_MESSAGE:
-            case XSLT_FUNC_NUMBER:
-            case XSLT_FUNC_PI:
-            case XSLT_FUNC_TEXT:
-            case XSLT_FUNC_VALUEOF:
-            case XSLT_FUNC_VARIABLE:
-            /*
-            * Parse the XSLT element.
-            */
-            cctxt->inode->curChildType = type;
-            xsltParseAnyXSLTElem(cctxt, cur);
-            break;
-            default:
-            xsltParseUnknownXSLTElem(cctxt, cur);
-            cur = cur->next;
-            continue;
-        }
-        } else {
-        /*
-        * Non-XSLT elements
-        * -----------------
-        */
-        xsltCompilerNodePush(cctxt, cur);
-        /*
-        * Update the in-scope namespaces if needed.
-        */
-        if (cur->nsDef != NULL)
-            cctxt->inode->inScopeNs =
-            xsltCompilerBuildInScopeNsList(cctxt, cur);
-        /*
-        * The current element is either a literal result element
-        * or an extension instruction.
-        *
-        * Process attr "xsl:extension-element-prefixes".
-        * FUTURE TODO: IIRC in XSLT 2.0 this attribute must be
-        * processed by the implementor of the extension function;
-        * i.e., it won't be handled by the XSLT processor.
-        */
-        /* SPEC 1.0:
-        *   "exclude-result-prefixes" is only allowed on literal
-        *   result elements and "xsl:exclude-result-prefixes"
-        *   on xsl:stylesheet/xsl:transform.
-        * SPEC 2.0:
-        *   "There are a number of standard attributes
-        *   that may appear on any XSLT element: specifically
-        *   version, exclude-result-prefixes,
-        *   extension-element-prefixes, xpath-default-namespace,
-        *   default-collation, and use-when."
-        *
-        * SPEC 2.0:
-        *   For literal result elements:
-        *   "xsl:version, xsl:exclude-result-prefixes,
-        *    xsl:extension-element-prefixes,
-        *    xsl:xpath-default-namespace,
-        *    xsl:default-collation, or xsl:use-when."
-        */
-        if (cur->properties)
-            cctxt->inode->extElemNs =
-            xsltParseExtElemPrefixes(cctxt,
-                cur, cctxt->inode->extElemNs,
-                XSLT_ELEMENT_CATEGORY_LRE);
-        /*
-        * Eval if we have an extension instruction here.
-        */
-        if ((cur->ns != NULL) &&
-            (cctxt->inode->extElemNs != NULL) &&
-            (xsltCheckExtPrefix(cctxt->style, cur->ns->href) == 1))
-        {
-            /*
-            * Extension instructions
-            * ----------------------------------------------------
-            * Mark the node information.
-            */
-            cctxt->inode->category = XSLT_ELEMENT_CATEGORY_EXTENSION;
-            cctxt->inode->extContentHandled = 0;
-            if (cur->psvi != NULL) {
-            cur->psvi = NULL;
-            /*
-            * TODO: Temporary sanity check.
-            */
-            xsltTransformError(NULL, cctxt->style, cur,
-                "Internal error in xsltParseSequenceConstructor(): "
-                "Occupied PSVI field.\n");
-            cctxt->style->errors++;
-            cur = cur->next;
-            continue;
-            }
-            cur->psvi = (void *)
-            xsltPreComputeExtModuleElement(cctxt->style, cur);
-
-            if (cur->psvi == NULL) {
-            /*
-            * OLD COMMENT: "Unknown element, maybe registered
-            *  at the context level. Mark it for later
-            *  recognition."
-            * QUESTION: What does the xsltExtMarker mean?
-            *  ANSWER: It is used in
-            *   xsltApplySequenceConstructor() at
-            *   transformation-time to look out for extension
-            *   registered in the transformation context.
-            */
-            cur->psvi = (void *) xsltExtMarker;
-            }
-            /*
-            * BIG NOTE: Now the ugly part. In previous versions
-            *  of Libxslt (until 1.1.16), all the content of an
-            *  extension instruction was processed and compiled without
-            *  the need of the extension-author to explicitely call
-            *  such a processing;.We now need to mimic this old
-            *  behaviour in order to avoid breaking old code
-            *  on the extension-author's side.
-            * The mechanism:
-            *  1) If the author does *not* set the
-            *    compile-time-flag @extContentHandled, then we'll
-            *    parse the content assuming that it's a "template"
-            *    (or "sequence constructor in XSLT 2.0 terms).
-            *    NOTE: If the extension is registered at
-            *    transformation-time only, then there's no way of
-            *    knowing that content shall be valid, and we'll
-            *    process the content the same way.
-            *  2) If the author *does* set the flag, then we'll assume
-            *   that the author has handled the parsing him/herself
-            *   (e.g. called xsltParseSequenceConstructor(), etc.
-            *   explicitely in his/her code).
-            */
-            if ((cur->children != NULL) &&
-            (cctxt->inode->extContentHandled == 0))
-            {
-            /*
-            * Default parsing of the content using the
-            * sequence-constructor model.
-            */
-            xsltParseSequenceConstructor(cctxt, cur->children);
-            }
-        } else {
-            /*
-            * Literal result element
-            * ----------------------------------------------------
-            * Allowed XSLT attributes:
-            *  xsl:extension-element-prefixes CDATA #IMPLIED
-            *  xsl:exclude-result-prefixes CDATA #IMPLIED
-            *  TODO: xsl:use-attribute-sets %qnames; #IMPLIED
-            *  xsl:version NMTOKEN #IMPLIED
-            */
-            cur->psvi = NULL;
-            cctxt->inode->category = XSLT_ELEMENT_CATEGORY_LRE;
-            if (cur->properties != NULL) {
-            xmlAttrPtr attr = cur->properties;
-            /*
-            * Attribute "xsl:exclude-result-prefixes".
-            */
-            cctxt->inode->exclResultNs =
-                xsltParseExclResultPrefixes(cctxt, cur,
-                cctxt->inode->exclResultNs,
-                XSLT_ELEMENT_CATEGORY_LRE);
-            /*
-            * Attribute "xsl:version".
-            */
-            xsltParseAttrXSLTVersion(cctxt, cur,
-                XSLT_ELEMENT_CATEGORY_LRE);
-            /*
-            * Report invalid XSLT attributes.
-            * For XSLT 1.0 only xsl:use-attribute-sets is allowed
-            * next to xsl:version, xsl:exclude-result-prefixes and
-            * xsl:extension-element-prefixes.
-            *
-            * Mark all XSLT attributes, in order to skip such
-            * attributes when instantiating the LRE.
-            */
-            do {
-                if ((attr->psvi != xsltXSLTAttrMarker) &&
-                IS_XSLT_ATTR_FAST(attr))
-                {
-                if (! xmlStrEqual(attr->name,
-                    BAD_CAST "use-attribute-sets"))
-                {
-                    xsltTransformError(NULL, cctxt->style,
-                    cur,
-                    "Unknown XSLT attribute '%s'.\n",
-                    attr->name);
-                    cctxt->style->errors++;
-                } else {
-                    /*
-                    * XSLT attr marker.
-                    */
-                    attr->psvi = (void *) xsltXSLTAttrMarker;
-                }
-                }
-                attr = attr->next;
-            } while (attr != NULL);
-            }
-            /*
-            * Create/reuse info for the literal result element.
-            */
-            if (cctxt->inode->nsChanged)
-            xsltLREInfoCreate(cctxt, cur, 1);
-            cur->psvi = cctxt->inode->litResElemInfo;
-            /*
-            * Apply ns-aliasing on the element and on its attributes.
-            */
-            if (cctxt->hasNsAliases)
-            xsltLREBuildEffectiveNs(cctxt, cur);
-            /*
-            * Compile attribute value templates (AVT).
-            */
-            if (cur->properties) {
-            xmlAttrPtr attr = cur->properties;
-
-            while (attr != NULL) {
-                xsltCompileAttr(cctxt->style, attr);
-                attr = attr->next;
-            }
-            }
-            /*
-            * Parse the content, which is defined to be a "template"
-            * (or "sequence constructor" in XSLT 2.0 terms).
-            */
-            if (cur->children != NULL) {
-            xsltParseSequenceConstructor(cctxt, cur->children);
-            }
-        }
-        /*
-        * Leave the non-XSLT element.
-        */
-        xsltCompilerNodePop(cctxt, cur);
-        }
-    }
-    cur = cur->next;
-    }
-    if (deleteNode != NULL) {
-#ifdef WITH_XSLT_DEBUG_BLANKS
-    xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseSequenceConstructor: removing xsl:text element\n");
-#endif
-    xmlUnlinkNode(deleteNode);
-    xmlFreeNode(deleteNode);
-    deleteNode = NULL;
     }
 }
 
@@ -4862,37 +4858,37 @@ void
 xsltParseTemplateContent(xsltStylesheetPtr style, xmlNodePtr templ) {
     if ((style == NULL) || (templ == NULL) ||
         (templ->type == XML_NAMESPACE_DECL))
-    return;
+        return;
 
     /*
     * Detection of handled content of extension instructions.
     */
     if (XSLT_CCTXT(style)->inode->category == XSLT_ELEMENT_CATEGORY_EXTENSION) {
-    XSLT_CCTXT(style)->inode->extContentHandled = 1;
+        XSLT_CCTXT(style)->inode->extContentHandled = 1;
     }
 
     if (templ->children != NULL) {
-    xmlNodePtr child = templ->children;
-    /*
-    * Process xsl:param elements, which can only occur as the
-    * immediate children of xsl:template (well, and of any
-    * user-defined extension instruction if needed).
-    */
-    do {
-        if ((child->type == XML_ELEMENT_NODE) &&
-        IS_XSLT_ELEM_FAST(child) &&
-        IS_XSLT_NAME(child, "param"))
-        {
-        XSLT_CCTXT(style)->inode->curChildType = XSLT_FUNC_PARAM;
-        xsltParseAnyXSLTElem(XSLT_CCTXT(style), child);
-        } else
-        break;
-        child = child->next;
-    } while (child != NULL);
-    /*
-    * Parse the content and register the pattern.
-    */
-    xsltParseSequenceConstructor(XSLT_CCTXT(style), child);
+        xmlNodePtr child = templ->children;
+        /*
+        * Process xsl:param elements, which can only occur as the
+        * immediate children of xsl:template (well, and of any
+        * user-defined extension instruction if needed).
+        */
+        do {
+            if ((child->type == XML_ELEMENT_NODE) &&
+                IS_XSLT_ELEM_FAST(child) &&
+                IS_XSLT_NAME(child, "param"))
+            {
+                XSLT_CCTXT(style)->inode->curChildType = XSLT_FUNC_PARAM;
+                xsltParseAnyXSLTElem(XSLT_CCTXT(style), child);
+            } else
+                break;
+            child = child->next;
+        } while (child != NULL);
+        /*
+        * Parse the content and register the pattern.
+        */
+        xsltParseSequenceConstructor(XSLT_CCTXT(style), child);
     }
 }
 
@@ -4922,8 +4918,162 @@ xsltParseTemplateContent(xsltStylesheetPtr style, xmlNodePtr templ) {
     cur = templ->children;
     delete = NULL;
     while (cur != NULL) {
-    if (delete != NULL) {
+        if (delete != NULL) {
 #ifdef WITH_XSLT_DEBUG_BLANKS
+            xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParseTemplateContent: removing text\n");
+#endif
+            xmlUnlinkNode(delete);
+            xmlFreeNode(delete);
+            delete = NULL;
+        }
+        if (IS_XSLT_ELEM(cur)) {
+            xsltStylePreCompute(style, cur);
+
+            if (IS_XSLT_NAME(cur, "text")) {
+                /*
+                * TODO: Processing of xsl:text should be moved to
+                *   xsltPreprocessStylesheet(), since otherwise this
+                *   will be performed for every multiply included
+                *   stylesheet; i.e. this here is not skipped with
+                *   the use of the style->nopreproc flag.
+                */
+                if (cur->children != NULL) {
+                    xmlChar *prop;
+                    xmlNodePtr text = cur->children, next;
+                    int noesc = 0;
+
+                    prop = xmlGetNsProp(cur,
+                        (const xmlChar *)"disable-output-escaping",
+                        NULL);
+                    if (prop != NULL) {
+#ifdef WITH_XSLT_DEBUG_PARSING
+                        xsltGenericDebug(xsltGenericDebugContext,
+                             "Disable escaping: %s\n", text->content);
+#endif
+                        if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
+                            noesc = 1;
+                        } else if (!xmlStrEqual(prop,
+                                                (const xmlChar *)"no")){
+                            xsltTransformError(NULL, style, cur,
+             "xsl:text: disable-output-escaping allows only yes or no\n");
+                            style->warnings++;
+
+                        }
+                        xmlFree(prop);
+                    }
+
+                    while (text != NULL) {
+                        if (text->type == XML_COMMENT_NODE) {
+                            text = text->next;
+                            continue;
+                        }
+                        if ((text->type != XML_TEXT_NODE) &&
+                             (text->type != XML_CDATA_SECTION_NODE)) {
+                            xsltTransformError(NULL, style, cur,
+                 "xsltParseTemplateContent: xslt:text content problem\n");
+                            style->errors++;
+                            break;
+                        }
+                        if ((noesc) && (text->type != XML_CDATA_SECTION_NODE))
+                            text->name = xmlStringTextNoenc;
+                        text = text->next;
+                    }
+
+                    /*
+                     * replace xsl:text by the list of childs
+                     */
+                    if (text == NULL) {
+                        text = cur->children;
+                        while (text != NULL) {
+                            if ((style->internalized) &&
+                                (text->content != NULL) &&
+                                (!xmlDictOwns(style->dict, text->content))) {
+
+                                /*
+                                 * internalize the text string
+                                 */
+                                if (text->doc->dict != NULL) {
+                                    const xmlChar *tmp;
+
+                                    tmp = xmlDictLookup(text->doc->dict,
+                                                        text->content, -1);
+                                    if (tmp != text->content) {
+                                        xmlNodeSetContent(text, NULL);
+                                        text->content = (xmlChar *) tmp;
+                                    }
+                                }
+                            }
+
+                            next = text->next;
+                            xmlUnlinkNode(text);
+                            xmlAddPrevSibling(cur, text);
+                            text = next;
+                        }
+                    }
+                }
+                delete = cur;
+                goto skip_children;
+            }
+        }
+        else if ((cur->ns != NULL) && (style->nsDefs != NULL) &&
+            (xsltCheckExtPrefix(style, cur->ns->prefix)))
+        {
+            /*
+             * okay this is an extension element compile it too
+             */
+            xsltStylePreCompute(style, cur);
+        }
+        else if (cur->type == XML_ELEMENT_NODE)
+        {
+            /*
+             * This is an element which will be output as part of the
+             * template exectution, precompile AVT if found.
+             */
+            if ((cur->ns == NULL) && (style->defaultAlias != NULL)) {
+                cur->ns = xmlSearchNsByHref(cur->doc, cur,
+                        style->defaultAlias);
+            }
+            if (cur->properties != NULL) {
+                xmlAttrPtr attr = cur->properties;
+
+                while (attr != NULL) {
+                    xsltCompileAttr(style, attr);
+                    attr = attr->next;
+                }
+            }
+        }
+        /*
+         * Skip to next node
+         */
+        if (cur->children != NULL) {
+            if (cur->children->type != XML_ENTITY_DECL) {
+                cur = cur->children;
+                continue;
+            }
+        }
+skip_children:
+        if (cur->next != NULL) {
+            cur = cur->next;
+            continue;
+        }
+
+        do {
+            cur = cur->parent;
+            if (cur == NULL)
+                break;
+            if (cur == templ) {
+                cur = NULL;
+                break;
+            }
+            if (cur->next != NULL) {
+                cur = cur->next;
+                break;
+            }
+        } while (cur != NULL);
+    }
+    if (delete != NULL) {
+#ifdef WITH_XSLT_DEBUG_PARSING
         xsltGenericDebug(xsltGenericDebugContext,
          "xsltParseTemplateContent: removing text\n");
 #endif
@@ -4931,186 +5081,32 @@ xsltParseTemplateContent(xsltStylesheetPtr style, xmlNodePtr templ) {
         xmlFreeNode(delete);
         delete = NULL;
     }
-    if (IS_XSLT_ELEM(cur)) {
-            xsltStylePreCompute(style, cur);
-
-        if (IS_XSLT_NAME(cur, "text")) {
-        /*
-        * TODO: Processing of xsl:text should be moved to
-        *   xsltPreprocessStylesheet(), since otherwise this
-        *   will be performed for every multiply included
-        *   stylesheet; i.e. this here is not skipped with
-        *   the use of the style->nopreproc flag.
-        */
-        if (cur->children != NULL) {
-            xmlChar *prop;
-            xmlNodePtr text = cur->children, next;
-            int noesc = 0;
-
-            prop = xmlGetNsProp(cur,
-            (const xmlChar *)"disable-output-escaping",
-            NULL);
-            if (prop != NULL) {
-#ifdef WITH_XSLT_DEBUG_PARSING
-            xsltGenericDebug(xsltGenericDebugContext,
-                 "Disable escaping: %s\n", text->content);
-#endif
-            if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
-                noesc = 1;
-            } else if (!xmlStrEqual(prop,
-                        (const xmlChar *)"no")){
-                xsltTransformError(NULL, style, cur,
-         "xsl:text: disable-output-escaping allows only yes or no\n");
-                style->warnings++;
-
-            }
-            xmlFree(prop);
-            }
-
-            while (text != NULL) {
-            if (text->type == XML_COMMENT_NODE) {
-                text = text->next;
-                continue;
-            }
-            if ((text->type != XML_TEXT_NODE) &&
-                 (text->type != XML_CDATA_SECTION_NODE)) {
-                xsltTransformError(NULL, style, cur,
-         "xsltParseTemplateContent: xslt:text content problem\n");
-                style->errors++;
-                break;
-            }
-            if ((noesc) && (text->type != XML_CDATA_SECTION_NODE))
-                text->name = xmlStringTextNoenc;
-            text = text->next;
-            }
-
-            /*
-             * replace xsl:text by the list of childs
-             */
-            if (text == NULL) {
-            text = cur->children;
-            while (text != NULL) {
-                if ((style->internalized) &&
-                    (text->content != NULL) &&
-                    (!xmlDictOwns(style->dict, text->content))) {
-
-                /*
-                 * internalize the text string
-                 */
-                if (text->doc->dict != NULL) {
-                    const xmlChar *tmp;
-
-                    tmp = xmlDictLookup(text->doc->dict,
-                                        text->content, -1);
-                    if (tmp != text->content) {
-                        xmlNodeSetContent(text, NULL);
-                    text->content = (xmlChar *) tmp;
-                    }
-                }
-                }
-
-                next = text->next;
-                xmlUnlinkNode(text);
-                xmlAddPrevSibling(cur, text);
-                text = next;
-            }
-            }
-        }
-        delete = cur;
-        goto skip_children;
-        }
-    }
-    else if ((cur->ns != NULL) && (style->nsDefs != NULL) &&
-        (xsltCheckExtPrefix(style, cur->ns->prefix)))
-    {
-        /*
-         * okay this is an extension element compile it too
-         */
-        xsltStylePreCompute(style, cur);
-    }
-    else if (cur->type == XML_ELEMENT_NODE)
-    {
-        /*
-         * This is an element which will be output as part of the
-         * template exectution, precompile AVT if found.
-         */
-        if ((cur->ns == NULL) && (style->defaultAlias != NULL)) {
-        cur->ns = xmlSearchNsByHref(cur->doc, cur,
-            style->defaultAlias);
-        }
-        if (cur->properties != NULL) {
-            xmlAttrPtr attr = cur->properties;
-
-        while (attr != NULL) {
-            xsltCompileAttr(style, attr);
-            attr = attr->next;
-        }
-        }
-    }
-    /*
-     * Skip to next node
-     */
-    if (cur->children != NULL) {
-        if (cur->children->type != XML_ENTITY_DECL) {
-        cur = cur->children;
-        continue;
-        }
-    }
-skip_children:
-    if (cur->next != NULL) {
-        cur = cur->next;
-        continue;
-    }
-
-    do {
-        cur = cur->parent;
-        if (cur == NULL)
-        break;
-        if (cur == templ) {
-        cur = NULL;
-        break;
-        }
-        if (cur->next != NULL) {
-        cur = cur->next;
-        break;
-        }
-    } while (cur != NULL);
-    }
-    if (delete != NULL) {
-#ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-     "xsltParseTemplateContent: removing text\n");
-#endif
-    xmlUnlinkNode(delete);
-    xmlFreeNode(delete);
-    delete = NULL;
-    }
 
     /*
      * Skip the first params
      */
     cur = templ->children;
     while (cur != NULL) {
-    if ((IS_XSLT_ELEM(cur)) && (!(IS_XSLT_NAME(cur, "param"))))
-        break;
-    cur = cur->next;
+        if ((IS_XSLT_ELEM(cur)) && (!(IS_XSLT_NAME(cur, "param"))))
+            break;
+        cur = cur->next;
     }
 
     /*
      * Browse the remainder of the template
      */
     while (cur != NULL) {
-    if ((IS_XSLT_ELEM(cur)) && (IS_XSLT_NAME(cur, "param"))) {
-        xmlNodePtr param = cur;
+        if ((IS_XSLT_ELEM(cur)) && (IS_XSLT_NAME(cur, "param"))) {
+            xmlNodePtr param = cur;
 
-        xsltTransformError(NULL, style, cur,
-        "xsltParseTemplateContent: ignoring misplaced param element\n");
-        if (style != NULL) style->warnings++;
+            xsltTransformError(NULL, style, cur,
+                "xsltParseTemplateContent: ignoring misplaced param element\n");
+            if (style != NULL) style->warnings++;
             cur = cur->next;
-        xmlUnlinkNode(param);
-        xmlFreeNode(param);
-    } else
-        break;
+            xmlUnlinkNode(param);
+            xmlFreeNode(param);
+        } else
+            break;
     }
 }
 
@@ -5136,7 +5132,7 @@ xsltParseStylesheetKey(xsltStylesheetPtr style, xmlNodePtr key) {
     xmlChar *nameURI = NULL;
 
     if ((style == NULL) || (key == NULL) || (key->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     /*
      * Get arguments
@@ -5145,43 +5141,43 @@ xsltParseStylesheetKey(xsltStylesheetPtr style, xmlNodePtr key) {
     if (prop != NULL) {
         const xmlChar *URI;
 
-    /*
-    * TODO: Don't use xsltGetQNameURI().
-    */
-    URI = xsltGetQNameURI(key, &prop);
-    if (prop == NULL) {
-        if (style != NULL) style->errors++;
-        goto error;
-    } else {
-        name = prop;
-        if (URI != NULL)
-        nameURI = xmlStrdup(URI);
-    }
+        /*
+        * TODO: Don't use xsltGetQNameURI().
+        */
+        URI = xsltGetQNameURI(key, &prop);
+        if (prop == NULL) {
+            if (style != NULL) style->errors++;
+            goto error;
+        } else {
+            name = prop;
+            if (URI != NULL)
+                nameURI = xmlStrdup(URI);
+        }
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-         "xsltParseStylesheetKey: name %s\n", name);
+        xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParseStylesheetKey: name %s\n", name);
 #endif
     } else {
-    xsltTransformError(NULL, style, key,
-        "xsl:key : error missing name\n");
-    if (style != NULL) style->errors++;
-    goto error;
+        xsltTransformError(NULL, style, key,
+            "xsl:key : error missing name\n");
+        if (style != NULL) style->errors++;
+        goto error;
     }
 
     match = xmlGetNsProp(key, (const xmlChar *)"match", NULL);
     if (match == NULL) {
-    xsltTransformError(NULL, style, key,
-        "xsl:key : error missing match\n");
-    if (style != NULL) style->errors++;
-    goto error;
+        xsltTransformError(NULL, style, key,
+            "xsl:key : error missing match\n");
+        if (style != NULL) style->errors++;
+        goto error;
     }
 
     use = xmlGetNsProp(key, (const xmlChar *)"use", NULL);
     if (use == NULL) {
-    xsltTransformError(NULL, style, key,
-        "xsl:key : error missing use\n");
-    if (style != NULL) style->errors++;
-    goto error;
+        xsltTransformError(NULL, style, key,
+            "xsl:key : error missing use\n");
+        if (style != NULL) style->errors++;
+        goto error;
     }
 
     /*
@@ -5192,16 +5188,16 @@ xsltParseStylesheetKey(xsltStylesheetPtr style, xmlNodePtr key) {
 
 error:
     if (use != NULL)
-    xmlFree(use);
+        xmlFree(use);
     if (match != NULL)
-    xmlFree(match);
+        xmlFree(match);
     if (name != NULL)
-    xmlFree(name);
+        xmlFree(name);
     if (nameURI != NULL)
-    xmlFree(nameURI);
+        xmlFree(nameURI);
 
     if (key->children != NULL) {
-    xsltParseContentError(style, key->children);
+        xsltParseContentError(style, key->children);
     }
 }
 
@@ -5227,19 +5223,19 @@ xsltParseXSLTTemplate(xsltCompilerCtxtPtr cctxt, xmlNodePtr templNode) {
 
     if ((cctxt == NULL) || (templNode == NULL) ||
         (templNode->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     /*
      * Create and link the structure
      */
     templ = xsltNewTemplate();
     if (templ == NULL)
-    return;
+        return;
 
     xsltCompilerNodePush(cctxt, templNode);
     if (templNode->nsDef != NULL)
-    cctxt->inode->inScopeNs =
-        xsltCompilerBuildInScopeNsList(cctxt, templNode);
+        cctxt->inode->inScopeNs =
+            xsltCompilerBuildInScopeNsList(cctxt, templNode);
 
     templ->next = cctxt->style->templates;
     cctxt->style->templates = templ;
@@ -5252,32 +5248,32 @@ xsltParseXSLTTemplate(xsltCompilerCtxtPtr cctxt, xmlNodePtr templNode) {
     if (prop != NULL) {
         const xmlChar *modeURI;
 
-    /*
-    * TODO: We need a standardized function for extraction
-    *  of namespace names and local names from QNames.
-    *  Don't use xsltGetQNameURI() as it cannot channe�
-    *  reports through the context.
-    */
-    modeURI = xsltGetQNameURI(templNode, &prop);
-    if (prop == NULL) {
-        cctxt->style->errors++;
-        goto error;
-    }
-    templ->mode = xmlDictLookup(cctxt->style->dict, prop, -1);
-    xmlFree(prop);
-    prop = NULL;
-    if (xmlValidateNCName(templ->mode, 0)) {
-        xsltTransformError(NULL, cctxt->style, templNode,
-        "xsl:template: Attribute 'mode': The local part '%s' "
-        "of the value is not a valid NCName.\n", templ->name);
-        cctxt->style->errors++;
-        goto error;
-    }
-    if (modeURI != NULL)
-        templ->modeURI = xmlDictLookup(cctxt->style->dict, modeURI, -1);
+        /*
+        * TODO: We need a standardized function for extraction
+        *  of namespace names and local names from QNames.
+        *  Don't use xsltGetQNameURI() as it cannot channe�
+        *  reports through the context.
+        */
+        modeURI = xsltGetQNameURI(templNode, &prop);
+        if (prop == NULL) {
+            cctxt->style->errors++;
+            goto error;
+        }
+        templ->mode = xmlDictLookup(cctxt->style->dict, prop, -1);
+        xmlFree(prop);
+        prop = NULL;
+        if (xmlValidateNCName(templ->mode, 0)) {
+            xsltTransformError(NULL, cctxt->style, templNode,
+                "xsl:template: Attribute 'mode': The local part '%s' "
+                "of the value is not a valid NCName.\n", templ->name);
+            cctxt->style->errors++;
+            goto error;
+        }
+        if (modeURI != NULL)
+            templ->modeURI = xmlDictLookup(cctxt->style->dict, modeURI, -1);
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-         "xsltParseXSLTTemplate: mode %s\n", templ->mode);
+        xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParseXSLTTemplate: mode %s\n", templ->mode);
 #endif
     }
     /*
@@ -5285,18 +5281,18 @@ xsltParseXSLTTemplate(xsltCompilerCtxtPtr cctxt, xmlNodePtr templNode) {
     */
     prop = xmlGetNsProp(templNode, (const xmlChar *)"match", NULL);
     if (prop != NULL) {
-    templ->match  = prop;
-    prop = NULL;
+        templ->match  = prop;
+        prop = NULL;
     }
     /*
     * Attribute "priority".
     */
     prop = xmlGetNsProp(templNode, (const xmlChar *)"priority", NULL);
     if (prop != NULL) {
-    priority = xmlXPathStringEvalNumber(prop);
-    templ->priority = (float) priority;
-    xmlFree(prop);
-    prop = NULL;
+        priority = xmlXPathStringEvalNumber(prop);
+        templ->priority = (float) priority;
+        xmlFree(prop);
+        prop = NULL;
     }
     /*
     * Attribute "name".
@@ -5304,60 +5300,60 @@ xsltParseXSLTTemplate(xsltCompilerCtxtPtr cctxt, xmlNodePtr templNode) {
     prop = xmlGetNsProp(templNode, (const xmlChar *)"name", NULL);
     if (prop != NULL) {
         const xmlChar *nameURI;
-    xsltTemplatePtr curTempl;
+        xsltTemplatePtr curTempl;
 
-    /*
-    * TODO: Don't use xsltGetQNameURI().
-    */
-    nameURI = xsltGetQNameURI(templNode, &prop);
-    if (prop == NULL) {
-        cctxt->style->errors++;
-        goto error;
-    }
-    templ->name = xmlDictLookup(cctxt->style->dict, prop, -1);
-    xmlFree(prop);
-    prop = NULL;
-    if (xmlValidateNCName(templ->name, 0)) {
-        xsltTransformError(NULL, cctxt->style, templNode,
-        "xsl:template: Attribute 'name': The local part '%s' of "
-        "the value is not a valid NCName.\n", templ->name);
-        cctxt->style->errors++;
-        goto error;
-    }
-    if (nameURI != NULL)
-        templ->nameURI = xmlDictLookup(cctxt->style->dict, nameURI, -1);
-    curTempl = templ->next;
-    while (curTempl != NULL) {
-        if ((nameURI != NULL && xmlStrEqual(curTempl->name, templ->name) &&
-        xmlStrEqual(curTempl->nameURI, nameURI) ) ||
-        (nameURI == NULL && curTempl->nameURI == NULL &&
-        xmlStrEqual(curTempl->name, templ->name)))
-        {
-        xsltTransformError(NULL, cctxt->style, templNode,
-            "xsl:template: error duplicate name '%s'\n", templ->name);
-        cctxt->style->errors++;
-        goto error;
+        /*
+        * TODO: Don't use xsltGetQNameURI().
+        */
+        nameURI = xsltGetQNameURI(templNode, &prop);
+        if (prop == NULL) {
+            cctxt->style->errors++;
+            goto error;
         }
-        curTempl = curTempl->next;
-    }
+        templ->name = xmlDictLookup(cctxt->style->dict, prop, -1);
+        xmlFree(prop);
+        prop = NULL;
+        if (xmlValidateNCName(templ->name, 0)) {
+            xsltTransformError(NULL, cctxt->style, templNode,
+                "xsl:template: Attribute 'name': The local part '%s' of "
+                "the value is not a valid NCName.\n", templ->name);
+            cctxt->style->errors++;
+            goto error;
+        }
+        if (nameURI != NULL)
+            templ->nameURI = xmlDictLookup(cctxt->style->dict, nameURI, -1);
+        curTempl = templ->next;
+        while (curTempl != NULL) {
+            if ((nameURI != NULL && xmlStrEqual(curTempl->name, templ->name) &&
+                xmlStrEqual(curTempl->nameURI, nameURI) ) ||
+                (nameURI == NULL && curTempl->nameURI == NULL &&
+                xmlStrEqual(curTempl->name, templ->name)))
+            {
+                xsltTransformError(NULL, cctxt->style, templNode,
+                    "xsl:template: error duplicate name '%s'\n", templ->name);
+                cctxt->style->errors++;
+                goto error;
+            }
+            curTempl = curTempl->next;
+        }
     }
     if (templNode->children != NULL) {
-    xsltParseTemplateContent(cctxt->style, templNode);
-    /*
-    * MAYBE TODO: Custom behaviour: In order to stay compatible with
-    * Xalan and MSXML(.NET), we could allow whitespace
-    * to appear before an xml:param element; this whitespace
-    * will additionally become part of the "template".
-    * NOTE that this is totally deviates from the spec, but
-    * is the de facto behaviour of Xalan and MSXML(.NET).
-    * Personally I wouldn't allow this, since if we have:
-    * <xsl:template ...xml:space="preserve">
-    *   <xsl:param name="foo"/>
-    *   <xsl:param name="bar"/>
-    *   <xsl:param name="zoo"/>
-    * ... the whitespace between every xsl:param would be
-    * added to the result tree.
-    */
+        xsltParseTemplateContent(cctxt->style, templNode);
+        /*
+        * MAYBE TODO: Custom behaviour: In order to stay compatible with
+        * Xalan and MSXML(.NET), we could allow whitespace
+        * to appear before an xml:param element; this whitespace
+        * will additionally become part of the "template".
+        * NOTE that this is totally deviates from the spec, but
+        * is the de facto behaviour of Xalan and MSXML(.NET).
+        * Personally I wouldn't allow this, since if we have:
+        * <xsl:template ...xml:space="preserve">
+        *   <xsl:param name="foo"/>
+        *   <xsl:param name="bar"/>
+        *   <xsl:param name="zoo"/>
+        * ... the whitespace between every xsl:param would be
+        * added to the result tree.
+        */
     }
 
     templ->elem = templNode;
@@ -5389,14 +5385,14 @@ xsltParseStylesheetTemplate(xsltStylesheetPtr style, xmlNodePtr template) {
 
     if ((style == NULL) || (template == NULL) ||
         (template->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     /*
      * Create and link the structure
      */
     ret = xsltNewTemplate();
     if (ret == NULL)
-    return;
+        return;
     ret->next = style->templates;
     style->templates = ret;
     ret->style = style;
@@ -5417,67 +5413,67 @@ xsltParseStylesheetTemplate(xsltStylesheetPtr style, xmlNodePtr template) {
     if (prop != NULL) {
         const xmlChar *URI;
 
-    /*
-    * TODO: Don't use xsltGetQNameURI().
-    */
-    URI = xsltGetQNameURI(template, &prop);
-    if (prop == NULL) {
-        if (style != NULL) style->errors++;
-        goto error;
-    } else {
-        mode = prop;
-        if (URI != NULL)
-        modeURI = xmlStrdup(URI);
-    }
-    ret->mode = xmlDictLookup(style->dict, mode, -1);
-    ret->modeURI = xmlDictLookup(style->dict, modeURI, -1);
+        /*
+        * TODO: Don't use xsltGetQNameURI().
+        */
+        URI = xsltGetQNameURI(template, &prop);
+        if (prop == NULL) {
+            if (style != NULL) style->errors++;
+            goto error;
+        } else {
+            mode = prop;
+            if (URI != NULL)
+                modeURI = xmlStrdup(URI);
+        }
+        ret->mode = xmlDictLookup(style->dict, mode, -1);
+        ret->modeURI = xmlDictLookup(style->dict, modeURI, -1);
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-         "xsltParseStylesheetTemplate: mode %s\n", mode);
+        xsltGenericDebug(xsltGenericDebugContext,
+             "xsltParseStylesheetTemplate: mode %s\n", mode);
 #endif
         if (mode != NULL) xmlFree(mode);
-    if (modeURI != NULL) xmlFree(modeURI);
+        if (modeURI != NULL) xmlFree(modeURI);
     }
     prop = xmlGetNsProp(template, (const xmlChar *)"match", NULL);
     if (prop != NULL) {
-    if (ret->match != NULL) xmlFree(ret->match);
-    ret->match  = prop;
+        if (ret->match != NULL) xmlFree(ret->match);
+        ret->match  = prop;
     }
 
     prop = xmlGetNsProp(template, (const xmlChar *)"priority", NULL);
     if (prop != NULL) {
-    priority = xmlXPathStringEvalNumber(prop);
-    ret->priority = (float) priority;
-    xmlFree(prop);
+        priority = xmlXPathStringEvalNumber(prop);
+        ret->priority = (float) priority;
+        xmlFree(prop);
     }
 
     prop = xmlGetNsProp(template, (const xmlChar *)"name", NULL);
     if (prop != NULL) {
         const xmlChar *URI;
 
-    /*
-    * TODO: Don't use xsltGetQNameURI().
-    */
-    URI = xsltGetQNameURI(template, &prop);
-    if (prop == NULL) {
-        if (style != NULL) style->errors++;
-        goto error;
-    } else {
-        if (xmlValidateNCName(prop,0)) {
-            xsltTransformError(NULL, style, template,
-                "xsl:template : error invalid name '%s'\n", prop);
-        if (style != NULL) style->errors++;
+        /*
+        * TODO: Don't use xsltGetQNameURI().
+        */
+        URI = xsltGetQNameURI(template, &prop);
+        if (prop == NULL) {
+            if (style != NULL) style->errors++;
+            goto error;
+        } else {
+            if (xmlValidateNCName(prop,0)) {
+                xsltTransformError(NULL, style, template,
+                    "xsl:template : error invalid name '%s'\n", prop);
+                if (style != NULL) style->errors++;
                 xmlFree(prop);
-        goto error;
+                goto error;
+            }
+            ret->name = xmlDictLookup(style->dict, BAD_CAST prop, -1);
+            xmlFree(prop);
+            prop = NULL;
+            if (URI != NULL)
+                ret->nameURI = xmlDictLookup(style->dict, BAD_CAST URI, -1);
+            else
+                ret->nameURI = NULL;
         }
-        ret->name = xmlDictLookup(style->dict, BAD_CAST prop, -1);
-        xmlFree(prop);
-        prop = NULL;
-        if (URI != NULL)
-        ret->nameURI = xmlDictLookup(style->dict, BAD_CAST URI, -1);
-        else
-        ret->nameURI = NULL;
-    }
     }
 
     /*
@@ -5508,15 +5504,15 @@ xsltCompileXSLTIncludeElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr node) {
     xsltStyleItemIncludePtr item;
 
     if ((cctxt == NULL) || (node == NULL) || (node->type != XML_ELEMENT_NODE))
-    return(NULL);
+        return(NULL);
 
     node->psvi = NULL;
     item = (xsltStyleItemIncludePtr) xmlMalloc(sizeof(xsltStyleItemInclude));
     if (item == NULL) {
-    xsltTransformError(NULL, cctxt->style, node,
-        "xsltIncludeComp : malloc failed\n");
-    cctxt->style->errors++;
-    return(NULL);
+        xsltTransformError(NULL, cctxt->style, node,
+                "xsltIncludeComp : malloc failed\n");
+        cctxt->style->errors++;
+        return(NULL);
     }
     memset(item, 0, sizeof(xsltStyleItemInclude));
 
@@ -5535,31 +5531,31 @@ xsltCompileXSLTIncludeElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr node) {
  */
 static int
 xsltParseFindTopLevelElem(xsltCompilerCtxtPtr cctxt,
-                  xmlNodePtr cur,
-                  const xmlChar *name,
-                  const xmlChar *namespaceURI,
-                  int breakOnOtherElem,
-                  xmlNodePtr *resultNode)
+                              xmlNodePtr cur,
+                              const xmlChar *name,
+                              const xmlChar *namespaceURI,
+                              int breakOnOtherElem,
+                              xmlNodePtr *resultNode)
 {
     if (name == NULL)
-    return(-1);
+        return(-1);
 
     *resultNode = NULL;
     while (cur != NULL) {
-    if (cur->type == XML_ELEMENT_NODE) {
-        if ((cur->ns != NULL) && (cur->name != NULL)) {
-        if ((*(cur->name) == *name) &&
-            xmlStrEqual(cur->name, name) &&
-            xmlStrEqual(cur->ns->href, namespaceURI))
-        {
-            *resultNode = cur;
-            return(1);
+        if (cur->type == XML_ELEMENT_NODE) {
+            if ((cur->ns != NULL) && (cur->name != NULL)) {
+                if ((*(cur->name) == *name) &&
+                    xmlStrEqual(cur->name, name) &&
+                    xmlStrEqual(cur->ns->href, namespaceURI))
+                {
+                    *resultNode = cur;
+                    return(1);
+                }
+            }
+            if (breakOnOtherElem)
+                break;
         }
-        }
-        if (breakOnOtherElem)
-        break;
-    }
-    cur = cur->next;
+        cur = cur->next;
     }
     *resultNode = cur;
     return(0);
@@ -5567,8 +5563,8 @@ xsltParseFindTopLevelElem(xsltCompilerCtxtPtr cctxt,
 
 static int
 xsltParseTopLevelXSLTElem(xsltCompilerCtxtPtr cctxt,
-              xmlNodePtr node,
-              xsltStyleType type)
+                          xmlNodePtr node,
+                          xsltStyleType type)
 {
     int ret = 0;
 
@@ -5583,46 +5579,46 @@ xsltParseTopLevelXSLTElem(xsltCompilerCtxtPtr cctxt,
     */
     xsltCompilerNodePush(cctxt, node);
     if (node->nsDef != NULL)
-    cctxt->inode->inScopeNs =
-        xsltCompilerBuildInScopeNsList(cctxt, node);
+        cctxt->inode->inScopeNs =
+            xsltCompilerBuildInScopeNsList(cctxt, node);
     cctxt->inode->type = type;
 
     switch (type) {
-    case XSLT_FUNC_INCLUDE:
-        {
-        int oldIsInclude;
+        case XSLT_FUNC_INCLUDE:
+            {
+                int oldIsInclude;
 
-        if (xsltCompileXSLTIncludeElem(cctxt, node) == NULL)
-            goto exit;
-        /*
-        * Mark this stylesheet tree as being currently included.
-        */
-        oldIsInclude = cctxt->isInclude;
-        cctxt->isInclude = 1;
+                if (xsltCompileXSLTIncludeElem(cctxt, node) == NULL)
+                    goto exit;
+                /*
+                * Mark this stylesheet tree as being currently included.
+                */
+                oldIsInclude = cctxt->isInclude;
+                cctxt->isInclude = 1;
 
-        if (xsltParseStylesheetInclude(cctxt->style, node) != 0) {
+                if (xsltParseStylesheetInclude(cctxt->style, node) != 0) {
+                    cctxt->style->errors++;
+                }
+                cctxt->isInclude = oldIsInclude;
+            }
+            break;
+        case XSLT_FUNC_PARAM:
+            xsltStylePreCompute(cctxt->style, node);
+            xsltParseGlobalParam(cctxt->style, node);
+            break;
+        case XSLT_FUNC_VARIABLE:
+            xsltStylePreCompute(cctxt->style, node);
+            xsltParseGlobalVariable(cctxt->style, node);
+            break;
+        case XSLT_FUNC_ATTRSET:
+            xsltParseStylesheetAttributeSet(cctxt->style, node);
+            break;
+        default:
+            xsltTransformError(NULL, cctxt->style, node,
+                "Internal error: (xsltParseTopLevelXSLTElem) "
+                "Cannot handle this top-level declaration.\n");
             cctxt->style->errors++;
-        }
-        cctxt->isInclude = oldIsInclude;
-        }
-        break;
-    case XSLT_FUNC_PARAM:
-        xsltStylePreCompute(cctxt->style, node);
-        xsltParseGlobalParam(cctxt->style, node);
-        break;
-    case XSLT_FUNC_VARIABLE:
-        xsltStylePreCompute(cctxt->style, node);
-        xsltParseGlobalVariable(cctxt->style, node);
-        break;
-    case XSLT_FUNC_ATTRSET:
-        xsltParseStylesheetAttributeSet(cctxt->style, node);
-        break;
-    default:
-        xsltTransformError(NULL, cctxt->style, node,
-        "Internal error: (xsltParseTopLevelXSLTElem) "
-        "Cannot handle this top-level declaration.\n");
-        cctxt->style->errors++;
-        ret = -1;
+            ret = -1;
     }
 
 exit:
@@ -5636,27 +5632,27 @@ static int
 xsltParseRemoveWhitespace(xmlNodePtr node)
 {
     if ((node == NULL) || (node->children == NULL))
-    return(0);
+        return(0);
     else {
-    xmlNodePtr delNode = NULL, child = node->children;
+        xmlNodePtr delNode = NULL, child = node->children;
 
-    do {
+        do {
+            if (delNode) {
+                xmlUnlinkNode(delNode);
+                xmlFreeNode(delNode);
+                delNode = NULL;
+            }
+            if (((child->type == XML_TEXT_NODE) ||
+                 (child->type == XML_CDATA_SECTION_NODE)) &&
+                (IS_BLANK_NODE(child)))
+                delNode = child;
+            child = child->next;
+        } while (child != NULL);
         if (delNode) {
-        xmlUnlinkNode(delNode);
-        xmlFreeNode(delNode);
-        delNode = NULL;
+            xmlUnlinkNode(delNode);
+            xmlFreeNode(delNode);
+            delNode = NULL;
         }
-        if (((child->type == XML_TEXT_NODE) ||
-         (child->type == XML_CDATA_SECTION_NODE)) &&
-        (IS_BLANK_NODE(child)))
-        delNode = child;
-        child = child->next;
-    } while (child != NULL);
-    if (delNode) {
-        xmlUnlinkNode(delNode);
-        xmlFreeNode(delNode);
-        delNode = NULL;
-    }
     }
     return(0);
 }
@@ -5672,8 +5668,8 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     xsltStylesheetPtr style;
 
     if ((cctxt == NULL) || (node == NULL) ||
-    (node->type != XML_ELEMENT_NODE))
-    return(-1);
+        (node->type != XML_ELEMENT_NODE))
+        return(-1);
 
     style = cctxt->style;
     /*
@@ -5683,33 +5679,33 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     */
     if (IS_XSLT_ELEM_FAST(node) && IS_XSLT_NAME(node, "include"))
     {
-    xsltDocumentPtr include;
-    /*
-    * URGENT TODO: Make this work with simplified stylesheets!
-    *   I.e., when we won't find an xsl:stylesheet element.
-    */
-    /*
-    * This is as include declaration.
-    */
-    include = ((xsltStyleItemIncludePtr) node->psvi)->include;
-    if (include == NULL) {
-        /* TODO: raise error? */
-        return(-1);
-    }
-    /*
-    * TODO: Actually an xsl:include should locate an embedded
-    *  stylesheet as well; so the document-element won't always
-    *  be the element where the actual stylesheet is rooted at.
-    *  But such embedded stylesheets are not supported by Libxslt yet.
-    */
-    node = xmlDocGetRootElement(include->doc);
-    if (node == NULL) {
-        return(-1);
-    }
+        xsltDocumentPtr include;
+        /*
+        * URGENT TODO: Make this work with simplified stylesheets!
+        *   I.e., when we won't find an xsl:stylesheet element.
+        */
+        /*
+        * This is as include declaration.
+        */
+        include = ((xsltStyleItemIncludePtr) node->psvi)->include;
+        if (include == NULL) {
+            /* TODO: raise error? */
+            return(-1);
+        }
+        /*
+        * TODO: Actually an xsl:include should locate an embedded
+        *  stylesheet as well; so the document-element won't always
+        *  be the element where the actual stylesheet is rooted at.
+        *  But such embedded stylesheets are not supported by Libxslt yet.
+        */
+        node = xmlDocGetRootElement(include->doc);
+        if (node == NULL) {
+            return(-1);
+        }
     }
 
     if (node->children == NULL)
-    return(0);
+        return(0);
     /*
     * Push the xsl:stylesheet/xsl:transform element.
     */
@@ -5729,7 +5725,7 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     * this is an embedded stylesheet).
     */
     cctxt->inode->inScopeNs =
-    xsltCompilerBuildInScopeNsList(cctxt, node);
+        xsltCompilerBuildInScopeNsList(cctxt, node);
 
     /*
     * Process attributes of xsl:stylesheet/xsl:transform.
@@ -5741,26 +5737,26 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     *  version = number (mandatory)
     */
     if (xsltParseAttrXSLTVersion(cctxt, node,
-    XSLT_ELEMENT_CATEGORY_XSLT) == 0)
+        XSLT_ELEMENT_CATEGORY_XSLT) == 0)
     {
-    /*
-    * Attribute "version".
-    * XSLT 1.0: "An xsl:stylesheet element *must* have a version
-    *  attribute, indicating the version of XSLT that the
-    *  stylesheet requires".
-    * The root element of a simplified stylesheet must also have
-    * this attribute.
-    */
+        /*
+        * Attribute "version".
+        * XSLT 1.0: "An xsl:stylesheet element *must* have a version
+        *  attribute, indicating the version of XSLT that the
+        *  stylesheet requires".
+        * The root element of a simplified stylesheet must also have
+        * this attribute.
+        */
 #ifdef XSLT_REFACTORED_MANDATORY_VERSION
-    if (isXsltElem)
-        xsltTransformError(NULL, cctxt->style, node,
-        "The attribute 'version' is missing.\n");
-    cctxt->style->errors++;
+        if (isXsltElem)
+            xsltTransformError(NULL, cctxt->style, node,
+                "The attribute 'version' is missing.\n");
+        cctxt->style->errors++;
 #else
-    /* OLD behaviour. */
-    xsltTransformError(NULL, cctxt->style, node,
-        "xsl:version is missing: document may not be a stylesheet\n");
-    cctxt->style->warnings++;
+        /* OLD behaviour. */
+        xsltTransformError(NULL, cctxt->style, node,
+            "xsl:version is missing: document may not be a stylesheet\n");
+        cctxt->style->warnings++;
 #endif
     }
     /*
@@ -5773,19 +5769,19 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     * Attribute "extension-element-prefixes".
     */
     cctxt->inode->extElemNs =
-    xsltParseExtElemPrefixes(cctxt, node, NULL,
-        XSLT_ELEMENT_CATEGORY_XSLT);
+        xsltParseExtElemPrefixes(cctxt, node, NULL,
+            XSLT_ELEMENT_CATEGORY_XSLT);
     /*
     * Attribute "exclude-result-prefixes".
     */
     cctxt->inode->exclResultNs =
-    xsltParseExclResultPrefixes(cctxt, node, NULL,
-        XSLT_ELEMENT_CATEGORY_XSLT);
+        xsltParseExclResultPrefixes(cctxt, node, NULL,
+            XSLT_ELEMENT_CATEGORY_XSLT);
     /*
     * Create/reuse info for the literal result element.
     */
     if (cctxt->inode->nsChanged)
-    xsltLREInfoCreate(cctxt, node, 0);
+        xsltLREInfoCreate(cctxt, node, 0);
     /*
     * Processed top-level elements:
     * ----------------------------
@@ -5810,16 +5806,16 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     */
     cur = node->children;
     while (cur != NULL) {
-    if (cur->type == XML_TEXT_NODE) {
-        xsltTransformError(NULL, style, cur,
-        "Misplaced text node (content: '%s').\n",
-        (cur->content != NULL) ? cur->content : BAD_CAST "");
-        style->errors++;
-    } else if (cur->type != XML_ELEMENT_NODE) {
-        xsltTransformError(NULL, style, cur, "Misplaced node.\n");
-        style->errors++;
-    }
-    cur = cur->next;
+        if (cur->type == XML_TEXT_NODE) {
+            xsltTransformError(NULL, style, cur,
+                "Misplaced text node (content: '%s').\n",
+                (cur->content != NULL) ? cur->content : BAD_CAST "");
+            style->errors++;
+        } else if (cur->type != XML_ELEMENT_NODE) {
+            xsltTransformError(NULL, style, cur, "Misplaced node.\n");
+            style->errors++;
+        }
+        cur = cur->next;
     }
     /*
     * Skip xsl:import elements; they have been processed
@@ -5827,172 +5823,172 @@ xsltParseXSLTStylesheetElemCore(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     */
     cur = node->children;
     while ((cur != NULL) && xsltParseFindTopLevelElem(cctxt, cur,
-        BAD_CAST "import", XSLT_NAMESPACE, 1, &cur) == 1)
-    cur = cur->next;
+            BAD_CAST "import", XSLT_NAMESPACE, 1, &cur) == 1)
+        cur = cur->next;
     if (cur == NULL)
-    goto exit;
+        goto exit;
 
     start = cur;
     /*
     * Process all top-level xsl:param elements.
     */
     while ((cur != NULL) &&
-    xsltParseFindTopLevelElem(cctxt, cur,
-    BAD_CAST "param", XSLT_NAMESPACE, 0, &cur) == 1)
+        xsltParseFindTopLevelElem(cctxt, cur,
+        BAD_CAST "param", XSLT_NAMESPACE, 0, &cur) == 1)
     {
-    xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_PARAM);
-    cur = cur->next;
+        xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_PARAM);
+        cur = cur->next;
     }
     /*
     * Process all top-level xsl:variable elements.
     */
     cur = start;
     while ((cur != NULL) &&
-    xsltParseFindTopLevelElem(cctxt, cur,
-    BAD_CAST "variable", XSLT_NAMESPACE, 0, &cur) == 1)
+        xsltParseFindTopLevelElem(cctxt, cur,
+        BAD_CAST "variable", XSLT_NAMESPACE, 0, &cur) == 1)
     {
-    xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_VARIABLE);
-    cur = cur->next;
+        xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_VARIABLE);
+        cur = cur->next;
     }
     /*
     * Process all the rest of top-level elements.
     */
     cur = start;
     while (cur != NULL) {
-    /*
-    * Process element nodes.
-    */
-    if (cur->type == XML_ELEMENT_NODE) {
-        if (cur->ns == NULL) {
-        xsltTransformError(NULL, style, cur,
-            "Unexpected top-level element in no namespace.\n");
-        style->errors++;
-        cur = cur->next;
-        continue;
-        }
         /*
-        * Process all XSLT elements.
+        * Process element nodes.
         */
-        if (IS_XSLT_ELEM_FAST(cur)) {
-        /*
-        * xsl:import is only allowed at the beginning.
-        */
-        if (IS_XSLT_NAME(cur, "import")) {
-            xsltTransformError(NULL, style, cur,
-            "Misplaced xsl:import element.\n");
-            style->errors++;
-            cur = cur->next;
-            continue;
-        }
-        /*
-        * TODO: Change the return type of the parsing functions
-        *  to int.
-        */
-        if (IS_XSLT_NAME(cur, "template")) {
-#ifdef WITH_XSLT_DEBUG_PARSING
-            templates++;
-#endif
-            /*
-            * TODO: Is the position of xsl:template in the
-            *  tree significant? If not it would be easier to
-            *  parse them at a later stage.
-            */
-            xsltParseXSLTTemplate(cctxt, cur);
-        } else if (IS_XSLT_NAME(cur, "variable")) {
-            /* NOP; done already */
-        } else if (IS_XSLT_NAME(cur, "param")) {
-            /* NOP; done already */
-        } else if (IS_XSLT_NAME(cur, "include")) {
-            if (cur->psvi != NULL)
-            xsltParseXSLTStylesheetElemCore(cctxt, cur);
-            else {
-            xsltTransformError(NULL, style, cur,
-                "Internal error: "
-                "(xsltParseXSLTStylesheetElemCore) "
-                "The xsl:include element was not compiled.\n");
-            style->errors++;
+        if (cur->type == XML_ELEMENT_NODE) {
+            if (cur->ns == NULL) {
+                xsltTransformError(NULL, style, cur,
+                    "Unexpected top-level element in no namespace.\n");
+                style->errors++;
+                cur = cur->next;
+                continue;
             }
-        } else if (IS_XSLT_NAME(cur, "strip-space")) {
-            /* No node info needed. */
-            xsltParseStylesheetStripSpace(style, cur);
-        } else if (IS_XSLT_NAME(cur, "preserve-space")) {
-            /* No node info needed. */
-            xsltParseStylesheetPreserveSpace(style, cur);
-        } else if (IS_XSLT_NAME(cur, "output")) {
-            /* No node-info needed. */
-            xsltParseStylesheetOutput(style, cur);
-        } else if (IS_XSLT_NAME(cur, "key")) {
-            /* TODO: node-info needed for expressions ? */
-            xsltParseStylesheetKey(style, cur);
-        } else if (IS_XSLT_NAME(cur, "decimal-format")) {
-            /* No node-info needed. */
-            xsltParseStylesheetDecimalFormat(style, cur);
-        } else if (IS_XSLT_NAME(cur, "attribute-set")) {
-            xsltParseTopLevelXSLTElem(cctxt, cur,
-            XSLT_FUNC_ATTRSET);
-        } else if (IS_XSLT_NAME(cur, "namespace-alias")) {
-            /* NOP; done already */
-        } else {
-            if (cctxt->inode->forwardsCompat) {
             /*
-            * Forwards-compatible mode:
-            *
-            * XSLT-1: "if it is a top-level element and
-            *  XSLT 1.0 does not allow such elements as top-level
-            *  elements, then the element must be ignored along
-            *  with its content;"
+            * Process all XSLT elements.
             */
-            /*
-            * TODO: I don't think we should generate a warning.
-            */
-            xsltTransformError(NULL, style, cur,
-                "Forwards-compatible mode: Ignoring unknown XSLT "
-                "element '%s'.\n", cur->name);
-            style->warnings++;
+            if (IS_XSLT_ELEM_FAST(cur)) {
+                /*
+                * xsl:import is only allowed at the beginning.
+                */
+                if (IS_XSLT_NAME(cur, "import")) {
+                    xsltTransformError(NULL, style, cur,
+                        "Misplaced xsl:import element.\n");
+                    style->errors++;
+                    cur = cur->next;
+                    continue;
+                }
+                /*
+                * TODO: Change the return type of the parsing functions
+                *  to int.
+                */
+                if (IS_XSLT_NAME(cur, "template")) {
+#ifdef WITH_XSLT_DEBUG_PARSING
+                    templates++;
+#endif
+                    /*
+                    * TODO: Is the position of xsl:template in the
+                    *  tree significant? If not it would be easier to
+                    *  parse them at a later stage.
+                    */
+                    xsltParseXSLTTemplate(cctxt, cur);
+                } else if (IS_XSLT_NAME(cur, "variable")) {
+                    /* NOP; done already */
+                } else if (IS_XSLT_NAME(cur, "param")) {
+                    /* NOP; done already */
+                } else if (IS_XSLT_NAME(cur, "include")) {
+                    if (cur->psvi != NULL)
+                        xsltParseXSLTStylesheetElemCore(cctxt, cur);
+                    else {
+                        xsltTransformError(NULL, style, cur,
+                            "Internal error: "
+                            "(xsltParseXSLTStylesheetElemCore) "
+                            "The xsl:include element was not compiled.\n");
+                        style->errors++;
+                    }
+                } else if (IS_XSLT_NAME(cur, "strip-space")) {
+                    /* No node info needed. */
+                    xsltParseStylesheetStripSpace(style, cur);
+                } else if (IS_XSLT_NAME(cur, "preserve-space")) {
+                    /* No node info needed. */
+                    xsltParseStylesheetPreserveSpace(style, cur);
+                } else if (IS_XSLT_NAME(cur, "output")) {
+                    /* No node-info needed. */
+                    xsltParseStylesheetOutput(style, cur);
+                } else if (IS_XSLT_NAME(cur, "key")) {
+                    /* TODO: node-info needed for expressions ? */
+                    xsltParseStylesheetKey(style, cur);
+                } else if (IS_XSLT_NAME(cur, "decimal-format")) {
+                    /* No node-info needed. */
+                    xsltParseStylesheetDecimalFormat(style, cur);
+                } else if (IS_XSLT_NAME(cur, "attribute-set")) {
+                    xsltParseTopLevelXSLTElem(cctxt, cur,
+                        XSLT_FUNC_ATTRSET);
+                } else if (IS_XSLT_NAME(cur, "namespace-alias")) {
+                    /* NOP; done already */
+                } else {
+                    if (cctxt->inode->forwardsCompat) {
+                        /*
+                        * Forwards-compatible mode:
+                        *
+                        * XSLT-1: "if it is a top-level element and
+                        *  XSLT 1.0 does not allow such elements as top-level
+                        *  elements, then the element must be ignored along
+                        *  with its content;"
+                        */
+                        /*
+                        * TODO: I don't think we should generate a warning.
+                        */
+                        xsltTransformError(NULL, style, cur,
+                            "Forwards-compatible mode: Ignoring unknown XSLT "
+                            "element '%s'.\n", cur->name);
+                        style->warnings++;
+                    } else {
+                        xsltTransformError(NULL, style, cur,
+                            "Unknown XSLT element '%s'.\n", cur->name);
+                        style->errors++;
+                    }
+                }
             } else {
-            xsltTransformError(NULL, style, cur,
-                "Unknown XSLT element '%s'.\n", cur->name);
-            style->errors++;
+                xsltTopLevelFunction function;
+
+                /*
+                * Process non-XSLT elements, which are in a
+                *  non-NULL namespace.
+                */
+                /*
+                * QUESTION: What does xsltExtModuleTopLevelLookup()
+                *  do exactly?
+                */
+                function = xsltExtModuleTopLevelLookup(cur->name,
+                    cur->ns->href);
+                if (function != NULL)
+                    function(style, cur);
+#ifdef WITH_XSLT_DEBUG_PARSING
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltParseXSLTStylesheetElemCore : User-defined "
+                    "data element '%s'.\n", cur->name);
+#endif
             }
         }
-        } else {
-        xsltTopLevelFunction function;
-
-        /*
-        * Process non-XSLT elements, which are in a
-        *  non-NULL namespace.
-        */
-        /*
-        * QUESTION: What does xsltExtModuleTopLevelLookup()
-        *  do exactly?
-        */
-        function = xsltExtModuleTopLevelLookup(cur->name,
-            cur->ns->href);
-        if (function != NULL)
-            function(style, cur);
-#ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsltParseXSLTStylesheetElemCore : User-defined "
-            "data element '%s'.\n", cur->name);
-#endif
-        }
-    }
-    cur = cur->next;
+        cur = cur->next;
     }
 
 exit:
 
 #ifdef WITH_XSLT_DEBUG_PARSING
     xsltGenericDebug(xsltGenericDebugContext,
-    "### END of parsing top-level elements of doc '%s'.\n",
-    node->doc->URL);
+        "### END of parsing top-level elements of doc '%s'.\n",
+        node->doc->URL);
     xsltGenericDebug(xsltGenericDebugContext,
-    "### Templates: %d\n", templates);
+        "### Templates: %d\n", templates);
 #ifdef XSLT_REFACTORED
     xsltGenericDebug(xsltGenericDebugContext,
-    "### Max inodes: %d\n", cctxt->maxNodeInfos);
+        "### Max inodes: %d\n", cctxt->maxNodeInfos);
     xsltGenericDebug(xsltGenericDebugContext,
-    "### Max LREs  : %d\n", cctxt->maxLREs);
+        "### Max LREs  : %d\n", cctxt->maxLREs);
 #endif /* XSLT_REFACTORED */
 #endif /* WITH_XSLT_DEBUG_PARSING */
 
@@ -6028,10 +6024,10 @@ xsltParseXSLTStylesheetElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     xmlNodePtr cur, start;
 
     if ((cctxt == NULL) || (node == NULL) || (node->type != XML_ELEMENT_NODE))
-    return(-1);
+        return(-1);
 
     if (node->children == NULL)
-    goto exit;
+        goto exit;
 
     /*
     * Process top-level elements:
@@ -6046,27 +6042,27 @@ xsltParseXSLTStylesheetElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     *  including any xsl:include element children."
     */
     while ((cur != NULL) &&
-    xsltParseFindTopLevelElem(cctxt, cur,
-        BAD_CAST "import", XSLT_NAMESPACE, 1, &cur) == 1)
+        xsltParseFindTopLevelElem(cctxt, cur,
+            BAD_CAST "import", XSLT_NAMESPACE, 1, &cur) == 1)
     {
-    if (xsltParseStylesheetImport(cctxt->style, cur) != 0) {
-        cctxt->style->errors++;
-    }
-    cur = cur->next;
+        if (xsltParseStylesheetImport(cctxt->style, cur) != 0) {
+            cctxt->style->errors++;
+        }
+        cur = cur->next;
     }
     if (cur == NULL)
-    goto exit;
+        goto exit;
     start = cur;
     /*
     * Pre-process all xsl:include elements.
     */
     cur = start;
     while ((cur != NULL) &&
-    xsltParseFindTopLevelElem(cctxt, cur,
-        BAD_CAST "include", XSLT_NAMESPACE, 0, &cur) == 1)
+        xsltParseFindTopLevelElem(cctxt, cur,
+            BAD_CAST "include", XSLT_NAMESPACE, 0, &cur) == 1)
     {
-    xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_INCLUDE);
-    cur = cur->next;
+        xsltParseTopLevelXSLTElem(cctxt, cur, XSLT_FUNC_INCLUDE);
+        cur = cur->next;
     }
     /*
     * Pre-process all xsl:namespace-alias elements.
@@ -6075,19 +6071,19 @@ xsltParseXSLTStylesheetElem(xsltCompilerCtxtPtr cctxt, xmlNodePtr node)
     */
     cur = start;
     while ((cur != NULL) &&
-    xsltParseFindTopLevelElem(cctxt, cur,
-        BAD_CAST "namespace-alias", XSLT_NAMESPACE, 0, &cur) == 1)
+        xsltParseFindTopLevelElem(cctxt, cur,
+            BAD_CAST "namespace-alias", XSLT_NAMESPACE, 0, &cur) == 1)
     {
-    xsltNamespaceAlias(cctxt->style, cur);
-    cur = cur->next;
+        xsltNamespaceAlias(cctxt->style, cur);
+        cur = cur->next;
     }
 
     if (cctxt->isInclude) {
-    /*
-    * If this stylesheet is intended for inclusion, then
-    * we will process only imports and includes.
-    */
-    goto exit;
+        /*
+        * If this stylesheet is intended for inclusion, then
+        * we will process only imports and includes.
+        */
+        goto exit;
     }
     /*
     * Now parse the rest of the top-level elements.
@@ -6116,24 +6112,24 @@ xsltParseStylesheetTop(xsltStylesheetPtr style, xmlNodePtr top) {
 #endif
 
     if ((top == NULL) || (top->type != XML_ELEMENT_NODE))
-    return;
+        return;
 
     prop = xmlGetNsProp(top, (const xmlChar *)"version", NULL);
     if (prop == NULL) {
-    xsltTransformError(NULL, style, top,
-        "xsl:version is missing: document may not be a stylesheet\n");
-    if (style != NULL) style->warnings++;
-    } else {
-    if ((!xmlStrEqual(prop, (const xmlChar *)"1.0")) &&
-            (!xmlStrEqual(prop, (const xmlChar *)"1.1"))) {
         xsltTransformError(NULL, style, top,
-        "xsl:version: only 1.1 features are supported\n");
-        if (style != NULL) {
+            "xsl:version is missing: document may not be a stylesheet\n");
+        if (style != NULL) style->warnings++;
+    } else {
+        if ((!xmlStrEqual(prop, (const xmlChar *)"1.0")) &&
+            (!xmlStrEqual(prop, (const xmlChar *)"1.1"))) {
+            xsltTransformError(NULL, style, top,
+                "xsl:version: only 1.1 features are supported\n");
+            if (style != NULL) {
                 style->forwards_compatible = 1;
                 style->warnings++;
             }
-    }
-    xmlFree(prop);
+        }
+        xmlFree(prop);
     }
 
     /*
@@ -6141,102 +6137,102 @@ xsltParseStylesheetTop(xsltStylesheetPtr style, xmlNodePtr top) {
      */
     cur = top->children;
     while (cur != NULL) {
-        if (IS_BLANK_NODE(cur)) {
+            if (IS_BLANK_NODE(cur)) {
+                    cur = cur->next;
+                    continue;
+            }
+            if (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "import")) {
+                    if (xsltParseStylesheetImport(style, cur) != 0)
+                            if (style != NULL) style->errors++;
+            } else
+                    break;
             cur = cur->next;
-            continue;
-        }
-        if (IS_XSLT_ELEM(cur) && IS_XSLT_NAME(cur, "import")) {
-            if (xsltParseStylesheetImport(style, cur) != 0)
-                if (style != NULL) style->errors++;
-        } else
-            break;
-        cur = cur->next;
     }
 
     /*
      * process other top-level elements
      */
     while (cur != NULL) {
-    if (IS_BLANK_NODE(cur)) {
-        cur = cur->next;
-        continue;
-    }
-    if (cur->type == XML_TEXT_NODE) {
-        if (cur->content != NULL) {
-        xsltTransformError(NULL, style, cur,
-            "misplaced text node: '%s'\n", cur->content);
-        }
-        if (style != NULL) style->errors++;
+        if (IS_BLANK_NODE(cur)) {
             cur = cur->next;
-        continue;
-    }
-    if ((cur->type == XML_ELEMENT_NODE) && (cur->ns == NULL)) {
-        xsltGenericError(xsltGenericErrorContext,
-             "Found a top-level element %s with null namespace URI\n",
-             cur->name);
-        if (style != NULL) style->errors++;
-        cur = cur->next;
-        continue;
-    }
-    if ((cur->type == XML_ELEMENT_NODE) && (!(IS_XSLT_ELEM(cur)))) {
-        xsltTopLevelFunction function;
+            continue;
+        }
+        if (cur->type == XML_TEXT_NODE) {
+            if (cur->content != NULL) {
+                xsltTransformError(NULL, style, cur,
+                    "misplaced text node: '%s'\n", cur->content);
+            }
+            if (style != NULL) style->errors++;
+            cur = cur->next;
+            continue;
+        }
+        if ((cur->type == XML_ELEMENT_NODE) && (cur->ns == NULL)) {
+            xsltGenericError(xsltGenericErrorContext,
+                     "Found a top-level element %s with null namespace URI\n",
+                     cur->name);
+            if (style != NULL) style->errors++;
+            cur = cur->next;
+            continue;
+        }
+        if ((cur->type == XML_ELEMENT_NODE) && (!(IS_XSLT_ELEM(cur)))) {
+            xsltTopLevelFunction function;
 
-        function = xsltExtModuleTopLevelLookup(cur->name,
-                           cur->ns->href);
-        if (function != NULL)
-        function(style, cur);
+            function = xsltExtModuleTopLevelLookup(cur->name,
+                                                   cur->ns->href);
+            if (function != NULL)
+                function(style, cur);
 
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsltParseStylesheetTop : found foreign element %s\n",
-            cur->name);
+            xsltGenericDebug(xsltGenericDebugContext,
+                    "xsltParseStylesheetTop : found foreign element %s\n",
+                    cur->name);
 #endif
             cur = cur->next;
-        continue;
-    }
-    if (IS_XSLT_NAME(cur, "import")) {
-        xsltTransformError(NULL, style, cur,
-            "xsltParseStylesheetTop: ignoring misplaced import element\n");
-        if (style != NULL) style->errors++;
+            continue;
+        }
+        if (IS_XSLT_NAME(cur, "import")) {
+            xsltTransformError(NULL, style, cur,
+                        "xsltParseStylesheetTop: ignoring misplaced import element\n");
+            if (style != NULL) style->errors++;
         } else if (IS_XSLT_NAME(cur, "include")) {
-        if (xsltParseStylesheetInclude(style, cur) != 0)
-        if (style != NULL) style->errors++;
+            if (xsltParseStylesheetInclude(style, cur) != 0)
+                if (style != NULL) style->errors++;
         } else if (IS_XSLT_NAME(cur, "strip-space")) {
-        xsltParseStylesheetStripSpace(style, cur);
+            xsltParseStylesheetStripSpace(style, cur);
         } else if (IS_XSLT_NAME(cur, "preserve-space")) {
-        xsltParseStylesheetPreserveSpace(style, cur);
+            xsltParseStylesheetPreserveSpace(style, cur);
         } else if (IS_XSLT_NAME(cur, "output")) {
-        xsltParseStylesheetOutput(style, cur);
+            xsltParseStylesheetOutput(style, cur);
         } else if (IS_XSLT_NAME(cur, "key")) {
-        xsltParseStylesheetKey(style, cur);
+            xsltParseStylesheetKey(style, cur);
         } else if (IS_XSLT_NAME(cur, "decimal-format")) {
-        xsltParseStylesheetDecimalFormat(style, cur);
+            xsltParseStylesheetDecimalFormat(style, cur);
         } else if (IS_XSLT_NAME(cur, "attribute-set")) {
-        xsltParseStylesheetAttributeSet(style, cur);
+            xsltParseStylesheetAttributeSet(style, cur);
         } else if (IS_XSLT_NAME(cur, "variable")) {
-        xsltParseGlobalVariable(style, cur);
+            xsltParseGlobalVariable(style, cur);
         } else if (IS_XSLT_NAME(cur, "param")) {
-        xsltParseGlobalParam(style, cur);
+            xsltParseGlobalParam(style, cur);
         } else if (IS_XSLT_NAME(cur, "template")) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        templates++;
+            templates++;
 #endif
-        xsltParseStylesheetTemplate(style, cur);
+            xsltParseStylesheetTemplate(style, cur);
         } else if (IS_XSLT_NAME(cur, "namespace-alias")) {
-        xsltNamespaceAlias(style, cur);
-    } else {
+            xsltNamespaceAlias(style, cur);
+        } else {
             if ((style != NULL) && (style->forwards_compatible == 0)) {
-            xsltTransformError(NULL, style, cur,
-            "xsltParseStylesheetTop: unknown %s element\n",
-            cur->name);
-            if (style != NULL) style->errors++;
+                xsltTransformError(NULL, style, cur,
+                        "xsltParseStylesheetTop: unknown %s element\n",
+                        cur->name);
+                if (style != NULL) style->errors++;
+            }
         }
-    }
-    cur = cur->next;
+        cur = cur->next;
     }
 #ifdef WITH_XSLT_DEBUG_PARSING
     xsltGenericDebug(xsltGenericDebugContext,
-            "parsed %d templates\n", templates);
+                    "parsed %d templates\n", templates);
 #endif
 }
 
@@ -6255,30 +6251,30 @@ xsltParseStylesheetTop(xsltStylesheetPtr style, xmlNodePtr top) {
  */
 static int
 xsltParseSimplifiedStylesheetTree(xsltCompilerCtxtPtr cctxt,
-                  xmlDocPtr doc,
-                  xmlNodePtr node)
+                                  xmlDocPtr doc,
+                                  xmlNodePtr node)
 {
     xsltTemplatePtr templ;
 
     if ((cctxt == NULL) || (node == NULL))
-    return(-1);
+        return(-1);
 
     if (xsltParseAttrXSLTVersion(cctxt, node, 0) == XSLT_ELEMENT_CATEGORY_LRE)
     {
-    /*
-    * TODO: Adjust report, since this might be an
-    * embedded stylesheet.
-    */
-    xsltTransformError(NULL, cctxt->style, node,
-        "The attribute 'xsl:version' is missing; cannot identify "
-        "this document as an XSLT stylesheet document.\n");
-    cctxt->style->errors++;
-    return(1);
+        /*
+        * TODO: Adjust report, since this might be an
+        * embedded stylesheet.
+        */
+        xsltTransformError(NULL, cctxt->style, node,
+            "The attribute 'xsl:version' is missing; cannot identify "
+            "this document as an XSLT stylesheet document.\n");
+        cctxt->style->errors++;
+        return(1);
     }
 
 #ifdef WITH_XSLT_DEBUG_PARSING
     xsltGenericDebug(xsltGenericDebugContext,
-    "xsltParseSimplifiedStylesheetTree: document is stylesheet\n");
+        "xsltParseSimplifiedStylesheetTree: document is stylesheet\n");
 #endif
 
     /*
@@ -6286,7 +6282,7 @@ xsltParseSimplifiedStylesheetTree(xsltCompilerCtxtPtr cctxt,
     */
     templ = xsltNewTemplate();
     if (templ == NULL) {
-    return(-1);
+        return(-1);
     }
     templ->next = cctxt->style->templates;
     cctxt->style->templates = templ;
@@ -6304,7 +6300,7 @@ xsltParseSimplifiedStylesheetTree(xsltCompilerCtxtPtr cctxt,
     * this is an embedded stylesheet).
     */
     cctxt->inode->inScopeNs =
-    xsltCompilerBuildInScopeNsList(cctxt, node);
+        xsltCompilerBuildInScopeNsList(cctxt, node);
     /*
     * Parse the content and register the match-pattern.
     */
@@ -6332,18 +6328,18 @@ int
 xsltRestoreDocumentNamespaces(xsltNsMapPtr ns, xmlDocPtr doc)
 {
     if (doc == NULL)
-    return(-1);
+        return(-1);
     /*
     * Revert the changes we have applied to the namespace-URIs of
     * ns-decls.
     */
     while (ns != NULL) {
-    if ((ns->doc == doc) && (ns->ns != NULL)) {
-        ns->ns->href = ns->origNsName;
-        ns->origNsName = NULL;
-        ns->ns = NULL;
-    }
-    ns = ns->next;
+        if ((ns->doc == doc) && (ns->ns != NULL)) {
+            ns->ns->href = ns->origNsName;
+            ns->origNsName = NULL;
+            ns->ns = NULL;
+        }
+        ns = ns->next;
     }
     return(0);
 }
@@ -6372,30 +6368,30 @@ xsltParseStylesheetProcess(xsltStylesheetPtr style, xmlDocPtr doc)
     xsltInitGlobals();
 
     if ((style == NULL) || (doc == NULL))
-    return(NULL);
+        return(NULL);
 
     cctxt = XSLT_CCTXT(style);
 
     cur = xmlDocGetRootElement(doc);
     if (cur == NULL) {
-    xsltTransformError(NULL, style, (xmlNodePtr) doc,
-        "xsltParseStylesheetProcess : empty stylesheet\n");
-    return(NULL);
+        xsltTransformError(NULL, style, (xmlNodePtr) doc,
+                "xsltParseStylesheetProcess : empty stylesheet\n");
+        return(NULL);
     }
     oldIsSimplifiedStylesheet = cctxt->simplified;
 
     if ((IS_XSLT_ELEM(cur)) &&
-    ((IS_XSLT_NAME(cur, "stylesheet")) ||
-     (IS_XSLT_NAME(cur, "transform")))) {
+        ((IS_XSLT_NAME(cur, "stylesheet")) ||
+         (IS_XSLT_NAME(cur, "transform")))) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseStylesheetProcess : found stylesheet\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+                "xsltParseStylesheetProcess : found stylesheet\n");
 #endif
-    cctxt->simplified = 0;
-    style->literal_result = 0;
+        cctxt->simplified = 0;
+        style->literal_result = 0;
     } else {
-    cctxt->simplified = 1;
-    style->literal_result = 1;
+        cctxt->simplified = 1;
+        style->literal_result = 1;
     }
     /*
     * Pre-process the stylesheet if not already done before.
@@ -6403,16 +6399,16 @@ xsltParseStylesheetProcess(xsltStylesheetPtr style, xmlDocPtr doc)
     *  text nodes, internalize strings, etc.
     */
     if (! style->nopreproc)
-    xsltParsePreprocessStylesheetTree(cctxt, cur);
+        xsltParsePreprocessStylesheetTree(cctxt, cur);
     /*
     * Parse and compile the stylesheet.
     */
     if (style->literal_result == 0) {
-    if (xsltParseXSLTStylesheetElem(cctxt, cur) != 0)
-        return(NULL);
+        if (xsltParseXSLTStylesheetElem(cctxt, cur) != 0)
+            return(NULL);
     } else {
-    if (xsltParseSimplifiedStylesheetTree(cctxt, doc, cur) != 0)
-        return(NULL);
+        if (xsltParseSimplifiedStylesheetTree(cctxt, doc, cur) != 0)
+            return(NULL);
     }
 
     cctxt->simplified = oldIsSimplifiedStylesheet;
@@ -6442,9 +6438,9 @@ xsltParseStylesheetProcess(xsltStylesheetPtr ret, xmlDocPtr doc) {
     xsltInitGlobals();
 
     if (doc == NULL)
-    return(NULL);
+        return(NULL);
     if (ret == NULL)
-    return(ret);
+        return(ret);
 
     /*
      * First steps, remove blank nodes,
@@ -6453,78 +6449,78 @@ xsltParseStylesheetProcess(xsltStylesheetPtr ret, xmlDocPtr doc) {
      */
     cur = xmlDocGetRootElement(doc);
     if (cur == NULL) {
-    xsltTransformError(NULL, ret, (xmlNodePtr) doc,
-        "xsltParseStylesheetProcess : empty stylesheet\n");
-    return(NULL);
+        xsltTransformError(NULL, ret, (xmlNodePtr) doc,
+                "xsltParseStylesheetProcess : empty stylesheet\n");
+        return(NULL);
     }
 
     if ((IS_XSLT_ELEM(cur)) &&
-    ((IS_XSLT_NAME(cur, "stylesheet")) ||
-     (IS_XSLT_NAME(cur, "transform")))) {
+        ((IS_XSLT_NAME(cur, "stylesheet")) ||
+         (IS_XSLT_NAME(cur, "transform")))) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseStylesheetProcess : found stylesheet\n");
+        xsltGenericDebug(xsltGenericDebugContext,
+                "xsltParseStylesheetProcess : found stylesheet\n");
 #endif
-    ret->literal_result = 0;
-    xsltParseStylesheetExcludePrefix(ret, cur, 1);
-    xsltParseStylesheetExtPrefix(ret, cur, 1);
+        ret->literal_result = 0;
+        xsltParseStylesheetExcludePrefix(ret, cur, 1);
+        xsltParseStylesheetExtPrefix(ret, cur, 1);
     } else {
-    xsltParseStylesheetExcludePrefix(ret, cur, 0);
-    xsltParseStylesheetExtPrefix(ret, cur, 0);
-    ret->literal_result = 1;
+        xsltParseStylesheetExcludePrefix(ret, cur, 0);
+        xsltParseStylesheetExtPrefix(ret, cur, 0);
+        ret->literal_result = 1;
     }
     if (!ret->nopreproc) {
-    xsltPreprocessStylesheet(ret, cur);
+        xsltPreprocessStylesheet(ret, cur);
     }
     if (ret->literal_result == 0) {
-    xsltParseStylesheetTop(ret, cur);
+        xsltParseStylesheetTop(ret, cur);
     } else {
-    xmlChar *prop;
-    xsltTemplatePtr template;
+        xmlChar *prop;
+        xsltTemplatePtr template;
 
-    /*
-     * the document itself might be the template, check xsl:version
-     */
-    prop = xmlGetNsProp(cur, (const xmlChar *)"version", XSLT_NAMESPACE);
-    if (prop == NULL) {
-        xsltTransformError(NULL, ret, cur,
-        "xsltParseStylesheetProcess : document is not a stylesheet\n");
-        return(NULL);
-    }
+        /*
+         * the document itself might be the template, check xsl:version
+         */
+        prop = xmlGetNsProp(cur, (const xmlChar *)"version", XSLT_NAMESPACE);
+        if (prop == NULL) {
+            xsltTransformError(NULL, ret, cur,
+                "xsltParseStylesheetProcess : document is not a stylesheet\n");
+            return(NULL);
+        }
 
 #ifdef WITH_XSLT_DEBUG_PARSING
         xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseStylesheetProcess : document is stylesheet\n");
+                "xsltParseStylesheetProcess : document is stylesheet\n");
 #endif
 
-    if ((!xmlStrEqual(prop, (const xmlChar *)"1.0")) &&
+        if ((!xmlStrEqual(prop, (const xmlChar *)"1.0")) &&
             (!xmlStrEqual(prop, (const xmlChar *)"1.1"))) {
-        xsltTransformError(NULL, ret, cur,
-        "xsl:version: only 1.1 features are supported\n");
+            xsltTransformError(NULL, ret, cur,
+                "xsl:version: only 1.1 features are supported\n");
             ret->forwards_compatible = 1;
-        ret->warnings++;
-    }
-    xmlFree(prop);
+            ret->warnings++;
+        }
+        xmlFree(prop);
 
-    /*
-     * Create and link the template
-     */
-    template = xsltNewTemplate();
-    if (template == NULL) {
-        return(NULL);
-    }
-    template->next = ret->templates;
-    ret->templates = template;
-    template->match = xmlStrdup((const xmlChar *)"/");
+        /*
+         * Create and link the template
+         */
+        template = xsltNewTemplate();
+        if (template == NULL) {
+            return(NULL);
+        }
+        template->next = ret->templates;
+        ret->templates = template;
+        template->match = xmlStrdup((const xmlChar *)"/");
 
-    /*
-     * parse the content and register the pattern
-     */
-    xsltParseTemplateContent(ret, (xmlNodePtr) doc);
-    template->elem = (xmlNodePtr) doc;
-    template->content = doc->children;
-    xsltAddTemplate(ret, template, NULL, NULL);
-    ret->literal_result = 1;
+        /*
+         * parse the content and register the pattern
+         */
+        xsltParseTemplateContent(ret, (xmlNodePtr) doc);
+        template->elem = (xmlNodePtr) doc;
+        template->content = doc->children;
+        xsltAddTemplate(ret, template, NULL, NULL);
+        ret->literal_result = 1;
     }
 
     return(ret);
@@ -6545,15 +6541,15 @@ xsltParseStylesheetProcess(xsltStylesheetPtr ret, xmlDocPtr doc) {
 
 xsltStylesheetPtr
 xsltParseStylesheetImportedDoc(xmlDocPtr doc,
-                   xsltStylesheetPtr parentStyle) {
+                               xsltStylesheetPtr parentStyle) {
     xsltStylesheetPtr retStyle;
 
     if (doc == NULL)
-    return(NULL);
+        return(NULL);
 
     retStyle = xsltNewStylesheetInternal(parentStyle);
     if (retStyle == NULL)
-    return(NULL);
+        return(NULL);
 
     if (xsltParseStylesheetUser(retStyle, doc) != 0) {
         xsltFreeStylesheet(retStyle);
@@ -6575,20 +6571,20 @@ xsltParseStylesheetImportedDoc(xmlDocPtr doc,
 int
 xsltParseStylesheetUser(xsltStylesheetPtr style, xmlDocPtr doc) {
     if ((style == NULL) || (doc == NULL))
-    return(-1);
+        return(-1);
 
     /*
     * Adjust the string dict.
     */
     if (doc->dict != NULL) {
         xmlDictFree(style->dict);
-    style->dict = doc->dict;
+        style->dict = doc->dict;
 #ifdef WITH_XSLT_DEBUG
         xsltGenericDebug(xsltGenericDebugContext,
-        "reusing dictionary from %s for stylesheet\n",
-        doc->URL);
+            "reusing dictionary from %s for stylesheet\n",
+            doc->URL);
 #endif
-    xmlDictReference(style->dict);
+        xmlDictReference(style->dict);
     }
 
     /*
@@ -6599,70 +6595,70 @@ xsltParseStylesheetUser(xsltStylesheetPtr style, xmlDocPtr doc) {
 
 #ifdef XSLT_REFACTORED
     {
-    xsltCompilerCtxtPtr cctxt;
-    xsltStylesheetPtr oldCurSheet;
+        xsltCompilerCtxtPtr cctxt;
+        xsltStylesheetPtr oldCurSheet;
 
-    if (style->parent == NULL) {
-        xsltPrincipalStylesheetDataPtr principalData;
-        /*
-        * Create extra data for the principal stylesheet.
-        */
-        principalData = xsltNewPrincipalStylesheetData();
-        if (principalData == NULL) {
-        return(-1);
+        if (style->parent == NULL) {
+            xsltPrincipalStylesheetDataPtr principalData;
+            /*
+            * Create extra data for the principal stylesheet.
+            */
+            principalData = xsltNewPrincipalStylesheetData();
+            if (principalData == NULL) {
+                return(-1);
+            }
+            style->principalData = principalData;
+            /*
+            * Create the compilation context
+            * ------------------------------
+            * (only once; for the principal stylesheet).
+            * This is currently the only function where the
+            * compilation context is created.
+            */
+            cctxt = xsltCompilationCtxtCreate(style);
+            if (cctxt == NULL) {
+                return(-1);
+            }
+            style->compCtxt = (void *) cctxt;
+            cctxt->style = style;
+            cctxt->dict = style->dict;
+            cctxt->psData = principalData;
+            /*
+            * Push initial dummy node info.
+            */
+            cctxt->depth = -1;
+            xsltCompilerNodePush(cctxt, (xmlNodePtr) doc);
+        } else {
+            /*
+            * Imported stylesheet.
+            */
+            cctxt = style->parent->compCtxt;
+            style->compCtxt = cctxt;
         }
-        style->principalData = principalData;
         /*
-        * Create the compilation context
-        * ------------------------------
-        * (only once; for the principal stylesheet).
-        * This is currently the only function where the
-        * compilation context is created.
+        * Save the old and set the current stylesheet structure in the
+        * compilation context.
         */
-        cctxt = xsltCompilationCtxtCreate(style);
-        if (cctxt == NULL) {
-        return(-1);
-        }
-        style->compCtxt = (void *) cctxt;
+        oldCurSheet = cctxt->style;
         cctxt->style = style;
-        cctxt->dict = style->dict;
-        cctxt->psData = principalData;
-        /*
-        * Push initial dummy node info.
-        */
-        cctxt->depth = -1;
-        xsltCompilerNodePush(cctxt, (xmlNodePtr) doc);
-    } else {
-        /*
-        * Imported stylesheet.
-        */
-        cctxt = style->parent->compCtxt;
-        style->compCtxt = cctxt;
-    }
-    /*
-    * Save the old and set the current stylesheet structure in the
-    * compilation context.
-    */
-    oldCurSheet = cctxt->style;
-    cctxt->style = style;
 
-    style->doc = doc;
-    xsltParseStylesheetProcess(style, doc);
+        style->doc = doc;
+        xsltParseStylesheetProcess(style, doc);
 
-    cctxt->style = oldCurSheet;
-    if (style->parent == NULL) {
-        /*
-        * Pop the initial dummy node info.
-        */
-        xsltCompilerNodePop(cctxt, (xmlNodePtr) doc);
-    } else {
-        /*
-        * Clear the compilation context of imported
-        * stylesheets.
-        * TODO: really?
-        */
-        /* style->compCtxt = NULL; */
-    }
+        cctxt->style = oldCurSheet;
+        if (style->parent == NULL) {
+            /*
+            * Pop the initial dummy node info.
+            */
+            xsltCompilerNodePop(cctxt, (xmlNodePtr) doc);
+        } else {
+            /*
+            * Clear the compilation context of imported
+            * stylesheets.
+            * TODO: really?
+            */
+            /* style->compCtxt = NULL; */
+        }
 
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
         if (style->errors != 0) {
@@ -6749,11 +6745,11 @@ xsltParseStylesheetFile(const xmlChar* filename) {
     xsltInitGlobals();
 
     if (filename == NULL)
-    return(NULL);
+        return(NULL);
 
 #ifdef WITH_XSLT_DEBUG_PARSING
     xsltGenericDebug(xsltGenericDebugContext,
-        "xsltParseStylesheetFile : parse %s\n", filename);
+            "xsltParseStylesheetFile : parse %s\n", filename);
 #endif
 
     /*
@@ -6761,44 +6757,44 @@ xsltParseStylesheetFile(const xmlChar* filename) {
      */
     sec = xsltGetDefaultSecurityPrefs();
     if (sec != NULL) {
-    int res;
+        int res;
 
-    res = xsltCheckRead(sec, NULL, filename);
-    if (res <= 0) {
+        res = xsltCheckRead(sec, NULL, filename);
+        if (res <= 0) {
             if (res == 0)
                 xsltTransformError(NULL, NULL, NULL,
                      "xsltParseStylesheetFile: read rights for %s denied\n",
                                  filename);
-        return(NULL);
-    }
+            return(NULL);
+        }
     }
 
     doc = xsltDocDefaultLoader(filename, NULL, XSLT_PARSE_OPTIONS,
                                NULL, XSLT_LOAD_START);
     if (doc == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltParseStylesheetFile : cannot parse %s\n", filename);
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+                "xsltParseStylesheetFile : cannot parse %s\n", filename);
+        return(NULL);
     }
     ret = xsltParseStylesheetDoc(doc);
     if (ret == NULL) {
-    xmlFreeDoc(doc);
-    return(NULL);
+        xmlFreeDoc(doc);
+        return(NULL);
     }
 
     return(ret);
 }
 
 /************************************************************************
- *                                  *
- *          Handling of Stylesheet PI           *
- *                                  *
+ *                                                                      *
+ *                      Handling of Stylesheet PI                       *
+ *                                                                      *
  ************************************************************************/
 
 #define CUR (*cur)
 #define SKIP(val) cur += (val)
 #define NXT(val) cur[(val)]
-#define SKIP_BLANKS                     \
+#define SKIP_BLANKS                                             \
     while (IS_BLANK(CUR)) NEXT
 #define NEXT ((*cur) ?  cur++ : cur)
 
@@ -6822,68 +6818,68 @@ xsltParseStylesheetPI(const xmlChar *value) {
     int isXml = 0;
 
     if (value == NULL)
-    return(NULL);
+        return(NULL);
 
     cur = value;
     while (CUR != 0) {
-    SKIP_BLANKS;
-    if ((CUR == 't') && (NXT(1) == 'y') && (NXT(2) == 'p') &&
-        (NXT(3) == 'e')) {
-        SKIP(4);
         SKIP_BLANKS;
-        if (CUR != '=')
-        continue;
-        NEXT;
-        if ((CUR != '\'') && (CUR != '"'))
-        continue;
-        tmp = CUR;
-        NEXT;
-        start = cur;
-        while ((CUR != 0) && (CUR != tmp))
-        NEXT;
-        if (CUR != tmp)
-        continue;
-        val = xmlStrndup(start, cur - start);
-        NEXT;
-        if (val == NULL)
-        return(NULL);
-        if ((xmlStrcasecmp(val, BAD_CAST "text/xml")) &&
-        (xmlStrcasecmp(val, BAD_CAST "text/xsl"))) {
+        if ((CUR == 't') && (NXT(1) == 'y') && (NXT(2) == 'p') &&
+            (NXT(3) == 'e')) {
+            SKIP(4);
+            SKIP_BLANKS;
+            if (CUR != '=')
+                continue;
+            NEXT;
+            if ((CUR != '\'') && (CUR != '"'))
+                continue;
+            tmp = CUR;
+            NEXT;
+            start = cur;
+            while ((CUR != 0) && (CUR != tmp))
+                NEXT;
+            if (CUR != tmp)
+                continue;
+            val = xmlStrndup(start, cur - start);
+            NEXT;
+            if (val == NULL)
+                return(NULL);
+            if ((xmlStrcasecmp(val, BAD_CAST "text/xml")) &&
+                (xmlStrcasecmp(val, BAD_CAST "text/xsl"))) {
                 xmlFree(val);
-        break;
+                break;
+            }
+            isXml = 1;
+            xmlFree(val);
+        } else if ((CUR == 'h') && (NXT(1) == 'r') && (NXT(2) == 'e') &&
+            (NXT(3) == 'f')) {
+            SKIP(4);
+            SKIP_BLANKS;
+            if (CUR != '=')
+                continue;
+            NEXT;
+            if ((CUR != '\'') && (CUR != '"'))
+                continue;
+            tmp = CUR;
+            NEXT;
+            start = cur;
+            while ((CUR != 0) && (CUR != tmp))
+                NEXT;
+            if (CUR != tmp)
+                continue;
+            if (href == NULL)
+                href = xmlStrndup(start, cur - start);
+            NEXT;
+        } else {
+            while ((CUR != 0) && (!IS_BLANK(CUR)))
+                NEXT;
         }
-        isXml = 1;
-        xmlFree(val);
-    } else if ((CUR == 'h') && (NXT(1) == 'r') && (NXT(2) == 'e') &&
-        (NXT(3) == 'f')) {
-        SKIP(4);
-        SKIP_BLANKS;
-        if (CUR != '=')
-        continue;
-        NEXT;
-        if ((CUR != '\'') && (CUR != '"'))
-        continue;
-        tmp = CUR;
-        NEXT;
-        start = cur;
-        while ((CUR != 0) && (CUR != tmp))
-        NEXT;
-        if (CUR != tmp)
-        continue;
-        if (href == NULL)
-        href = xmlStrndup(start, cur - start);
-        NEXT;
-    } else {
-        while ((CUR != 0) && (!IS_BLANK(CUR)))
-        NEXT;
-    }
 
     }
 
     if (!isXml) {
-    if (href != NULL)
-        xmlFree(href);
-    href = NULL;
+        if (href != NULL)
+            xmlFree(href);
+        href = NULL;
     }
     return(href);
 }
@@ -6912,20 +6908,20 @@ xsltLoadStylesheetPI(xmlDocPtr doc) {
     xsltInitGlobals();
 
     if (doc == NULL)
-    return(NULL);
+        return(NULL);
 
     /*
      * Find the text/xml stylesheet PI id any before the root
      */
     child = doc->children;
     while ((child != NULL) && (child->type != XML_ELEMENT_NODE)) {
-    if ((child->type == XML_PI_NODE) &&
-        (xmlStrEqual(child->name, BAD_CAST "xml-stylesheet"))) {
-        href = xsltParseStylesheetPI(child->content);
-        if (href != NULL)
-        break;
-    }
-    child = child->next;
+        if ((child->type == XML_PI_NODE) &&
+            (xmlStrEqual(child->name, BAD_CAST "xml-stylesheet"))) {
+            href = xsltParseStylesheetPI(child->content);
+            if (href != NULL)
+                break;
+        }
+        child = child->next;
     }
 
     /*
@@ -6933,115 +6929,115 @@ xsltLoadStylesheetPI(xmlDocPtr doc) {
      */
     if (href != NULL) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-    xsltGenericDebug(xsltGenericDebugContext,
-        "xsltLoadStylesheetPI : found PI href=%s\n", href);
+        xsltGenericDebug(xsltGenericDebugContext,
+                "xsltLoadStylesheetPI : found PI href=%s\n", href);
 #endif
-    URI = xmlParseURI((const char *) href);
-    if (URI == NULL) {
-        xsltTransformError(NULL, NULL, child,
-            "xml-stylesheet : href %s is not valid\n", href);
-        xmlFree(href);
-        return(NULL);
-    }
-    if ((URI->fragment != NULL) && (URI->scheme == NULL) &&
+        URI = xmlParseURI((const char *) href);
+        if (URI == NULL) {
+            xsltTransformError(NULL, NULL, child,
+                    "xml-stylesheet : href %s is not valid\n", href);
+            xmlFree(href);
+            return(NULL);
+        }
+        if ((URI->fragment != NULL) && (URI->scheme == NULL) &&
             (URI->opaque == NULL) && (URI->authority == NULL) &&
             (URI->server == NULL) && (URI->user == NULL) &&
             (URI->path == NULL) && (URI->query == NULL)) {
-        xmlAttrPtr ID;
+            xmlAttrPtr ID;
 
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsltLoadStylesheetPI : Reference to ID %s\n", href);
-#endif
-        if (URI->fragment[0] == '#')
-        ID = xmlGetID(doc, (const xmlChar *) &(URI->fragment[1]));
-        else
-        ID = xmlGetID(doc, (const xmlChar *) URI->fragment);
-        if (ID == NULL) {
-        xsltTransformError(NULL, NULL, child,
-            "xml-stylesheet : no ID %s found\n", URI->fragment);
-        } else {
-        xmlDocPtr fake;
-        xmlNodePtr subtree, newtree;
-        xmlNsPtr ns;
-
-#ifdef WITH_XSLT_DEBUG
-        xsltGenericDebug(xsltGenericDebugContext,
-            "creating new document from %s for embedded stylesheet\n",
-            doc->URL);
-#endif
-        /*
-         * move the subtree in a new document passed to
-         * the stylesheet analyzer
-         */
-        subtree = ID->parent;
-        fake = xmlNewDoc(NULL);
-        if (fake != NULL) {
-            /*
-            * Should the dictionary still be shared even though
-            * the nodes are being copied rather than moved?
-            */
-            fake->dict = doc->dict;
-            xmlDictReference(doc->dict);
-#ifdef WITH_XSLT_DEBUG
             xsltGenericDebug(xsltGenericDebugContext,
-            "reusing dictionary from %s for embedded stylesheet\n",
-            doc->URL);
+                    "xsltLoadStylesheetPI : Reference to ID %s\n", href);
 #endif
+            if (URI->fragment[0] == '#')
+                ID = xmlGetID(doc, (const xmlChar *) &(URI->fragment[1]));
+            else
+                ID = xmlGetID(doc, (const xmlChar *) URI->fragment);
+            if (ID == NULL) {
+                xsltTransformError(NULL, NULL, child,
+                    "xml-stylesheet : no ID %s found\n", URI->fragment);
+            } else {
+                xmlDocPtr fake;
+                xmlNodePtr subtree, newtree;
+                xmlNsPtr ns;
 
-            newtree = xmlDocCopyNode(subtree, fake, 1);
-
-            fake->URL = xmlNodeGetBase(doc, subtree->parent);
 #ifdef WITH_XSLT_DEBUG
-            xsltGenericDebug(xsltGenericDebugContext,
-            "set base URI for embedded stylesheet as %s\n",
-            fake->URL);
+                xsltGenericDebug(xsltGenericDebugContext,
+                    "creating new document from %s for embedded stylesheet\n",
+                    doc->URL);
 #endif
+                /*
+                 * move the subtree in a new document passed to
+                 * the stylesheet analyzer
+                 */
+                subtree = ID->parent;
+                fake = xmlNewDoc(NULL);
+                if (fake != NULL) {
+                    /*
+                    * Should the dictionary still be shared even though
+                    * the nodes are being copied rather than moved?
+                    */
+                    fake->dict = doc->dict;
+                    xmlDictReference(doc->dict);
+#ifdef WITH_XSLT_DEBUG
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "reusing dictionary from %s for embedded stylesheet\n",
+                        doc->URL);
+#endif
+
+                    newtree = xmlDocCopyNode(subtree, fake, 1);
+
+                    fake->URL = xmlNodeGetBase(doc, subtree->parent);
+#ifdef WITH_XSLT_DEBUG
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "set base URI for embedded stylesheet as %s\n",
+                        fake->URL);
+#endif
+
+                    /*
+                    * Add all namespaces in scope of embedded stylesheet to
+                    * root element of newly created stylesheet document
+                    */
+                    while ((subtree = subtree->parent) != (xmlNodePtr)doc) {
+                        for (ns = subtree->ns; ns; ns = ns->next) {
+                            xmlNewNs(newtree,  ns->href, ns->prefix);
+                        }
+                    }
+
+                    xmlAddChild((xmlNodePtr)fake, newtree);
+                    ret = xsltParseStylesheetDoc(fake);
+                    if (ret == NULL)
+                        xmlFreeDoc(fake);
+                }
+            }
+        } else {
+            xmlChar *URL, *base;
 
             /*
-            * Add all namespaces in scope of embedded stylesheet to
-            * root element of newly created stylesheet document
-            */
-            while ((subtree = subtree->parent) != (xmlNodePtr)doc) {
-            for (ns = subtree->ns; ns; ns = ns->next) {
-                xmlNewNs(newtree,  ns->href, ns->prefix);
-            }
-            }
+             * Reference to an external stylesheet
+             */
 
-            xmlAddChild((xmlNodePtr)fake, newtree);
-            ret = xsltParseStylesheetDoc(fake);
-            if (ret == NULL)
-            xmlFreeDoc(fake);
-        }
-        }
-    } else {
-        xmlChar *URL, *base;
-
-        /*
-         * Reference to an external stylesheet
-         */
-
-        base = xmlNodeGetBase(doc, (xmlNodePtr) doc);
-        URL = xmlBuildURI(href, base);
-        if (URL != NULL) {
+            base = xmlNodeGetBase(doc, (xmlNodePtr) doc);
+            URL = xmlBuildURI(href, base);
+            if (URL != NULL) {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsltLoadStylesheetPI : fetching %s\n", URL);
+                xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltLoadStylesheetPI : fetching %s\n", URL);
 #endif
-        ret = xsltParseStylesheetFile(URL);
-        xmlFree(URL);
-        } else {
+                ret = xsltParseStylesheetFile(URL);
+                xmlFree(URL);
+            } else {
 #ifdef WITH_XSLT_DEBUG_PARSING
-        xsltGenericDebug(xsltGenericDebugContext,
-            "xsltLoadStylesheetPI : fetching %s\n", href);
+                xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltLoadStylesheetPI : fetching %s\n", href);
 #endif
-        ret = xsltParseStylesheetFile(href);
+                ret = xsltParseStylesheetFile(href);
+            }
+            if (base != NULL)
+                xmlFree(base);
         }
-        if (base != NULL)
-        xmlFree(base);
-    }
-    xmlFreeURI(URI);
-    xmlFree(href);
+        xmlFreeURI(URI);
+        xmlFree(href);
     }
     return(ret);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xslt.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xslt.h
@@ -94,13 +94,13 @@ XSLTPUBVAR const int xsltLibxmlVersion;
  */
 
 XSLTPUBFUN void XSLTCALL
-        xsltInit        (void);
+                xsltInit                (void);
 
 /*
  * Global cleanup function.
  */
 XSLTPUBFUN void XSLTCALL
-        xsltCleanupGlobals  (void);
+                xsltCleanupGlobals      (void);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltInternals.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltInternals.h
@@ -223,11 +223,11 @@ struct _xsltPointerList {
 typedef struct _xsltRuntimeExtra xsltRuntimeExtra;
 typedef xsltRuntimeExtra *xsltRuntimeExtraPtr;
 struct _xsltRuntimeExtra {
-    void       *info;       /* pointer to the extra data */
-    xmlFreeFunc deallocate; /* pointer to the deallocation routine */
-    union {         /* dual-purpose field */
-        void   *ptr;        /* data not needing deallocation */
-    int    ival;        /* integer value storage */
+    void       *info;           /* pointer to the extra data */
+    xmlFreeFunc deallocate;     /* pointer to the deallocation routine */
+    union {                     /* dual-purpose field */
+        void   *ptr;            /* data not needing deallocation */
+        int    ival;            /* integer value storage */
     } val;
 };
 
@@ -266,8 +266,8 @@ typedef xsltTemplate *xsltTemplatePtr;
 struct _xsltTemplate {
     struct _xsltTemplate *next;/* chained list sorted by priority */
     struct _xsltStylesheet *style;/* the containing stylesheet */
-    xmlChar *match; /* the matching string */
-    float priority; /* as given from the stylesheet, not computed */
+    xmlChar *match;     /* the matching string */
+    float priority;     /* as given from the stylesheet, not computed */
     const xmlChar *name; /* the local part of the name QName */
     const xmlChar *nameURI; /* the URI part of the name QName */
     const xmlChar *mode;/* the local part of the mode QName */
@@ -287,10 +287,13 @@ struct _xsltTemplate {
     unsigned long time; /* the time spent in this template */
     void *params;       /* xsl:param instructions */
 
-    int              templNr;       /* Nb of templates in the stack */
-    int              templMax;      /* Size of the templtes stack */
+    int              templNr;           /* Nb of templates in the stack */
+    int              templMax;          /* Size of the templtes stack */
     xsltTemplatePtr *templCalledTab;    /* templates called */
     int             *templCountTab;  /* .. and how often */
+
+    /* Conflict resolution */
+    int position;
 };
 
 /**
@@ -328,11 +331,11 @@ typedef struct _xsltDocument xsltDocument;
 typedef xsltDocument *xsltDocumentPtr;
 struct _xsltDocument {
     struct _xsltDocument *next; /* documents are kept in a chained list */
-    int main;           /* is this the main document */
-    xmlDocPtr doc;      /* the parsed document */
-    void *keys;         /* key tables storage */
+    int main;                   /* is this the main document */
+    xmlDocPtr doc;              /* the parsed document */
+    void *keys;                 /* key tables storage */
     struct _xsltDocument *includes; /* subsidiary includes */
-    int preproc;        /* pre-processing already done */
+    int preproc;                /* pre-processing already done */
     int nbKeysComputed;
 };
 
@@ -402,9 +405,9 @@ typedef xsltElemPreComp *xsltElemPreCompPtr;
  * stylesheet language like xsl:if or xsl:apply-templates.
  */
 typedef void (*xsltTransformFunction) (xsltTransformContextPtr ctxt,
-                                   xmlNodePtr node,
-                       xmlNodePtr inst,
-                           xsltElemPreCompPtr comp);
+                                       xmlNodePtr node,
+                                       xmlNodePtr inst,
+                                       xsltElemPreCompPtr comp);
 
 /**
  * xsltSortFunc:
@@ -415,7 +418,7 @@ typedef void (*xsltTransformFunction) (xsltTransformContextPtr ctxt,
  * Signature of the function to use during sorting
  */
 typedef void (*xsltSortFunc) (xsltTransformContextPtr ctxt, xmlNodePtr *sorts,
-                  int nbsorts);
+                              int nbsorts);
 
 typedef enum {
     XSLT_FUNC_COPY=1,
@@ -469,12 +472,12 @@ typedef void (*xsltElemPreCompDeallocator) (xsltElemPreCompPtr comp);
  *   derived stylesheet-structs do not have.
  */
 struct _xsltElemPreComp {
-    xsltElemPreCompPtr next;        /* next item in the global chained
-                       list held by xsltStylesheet. */
-    xsltStyleType type;     /* type of the element */
+    xsltElemPreCompPtr next;            /* next item in the global chained
+                                           list held by xsltStylesheet. */
+    xsltStyleType type;         /* type of the element */
     xsltTransformFunction func; /* handling function */
-    xmlNodePtr inst;            /* the node in the stylesheet's tree
-                       corresponding to this item */
+    xmlNodePtr inst;                    /* the node in the stylesheet's tree
+                                           corresponding to this item */
 
     /* end of common part */
     xsltElemPreCompDeallocator free;    /* the deallocator */
@@ -498,20 +501,20 @@ typedef xsltStylePreComp *xsltStylePreCompPtr;
 * Some pointer-list utility functions.
 */
 XSLTPUBFUN xsltPointerListPtr XSLTCALL
-        xsltPointerListCreate       (int initialSize);
+                xsltPointerListCreate           (int initialSize);
 XSLTPUBFUN void XSLTCALL
-        xsltPointerListFree     (xsltPointerListPtr list);
+                xsltPointerListFree             (xsltPointerListPtr list);
 XSLTPUBFUN void XSLTCALL
-        xsltPointerListClear        (xsltPointerListPtr list);
+                xsltPointerListClear            (xsltPointerListPtr list);
 XSLTPUBFUN int XSLTCALL
-        xsltPointerListAddSize      (xsltPointerListPtr list,
-                         void *item,
-                         int initialSize);
+                xsltPointerListAddSize          (xsltPointerListPtr list,
+                                                 void *item,
+                                                 int initialSize);
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  * Refactored structures                                                *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 typedef struct _xsltNsListContainer xsltNsListContainer;
@@ -582,11 +585,11 @@ struct _xsltNsListContainer {
  */
 struct _xsltStylePreComp {
     xsltElemPreCompPtr next;    /* next item in the global chained
-                   list held by xsltStylesheet */
+                                   list held by xsltStylesheet */
     xsltStyleType type;         /* type of the item */
     xsltTransformFunction func; /* handling function */
-    xmlNodePtr inst;        /* the node in the stylesheet's tree
-                   corresponding to this item. */
+    xmlNodePtr inst;            /* the node in the stylesheet's tree
+                                   corresponding to this item. */
     /* Currently no navigational fields. */
     xsltNsListContainerPtr inScopeNs;
 };
@@ -623,9 +626,9 @@ struct _xsltStyleBasicExpressionItem {
 };
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  * XSLT-instructions/declarations                                       *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -690,7 +693,7 @@ typedef xsltStyleItemText *xsltStyleItemTextPtr;
 
 struct _xsltStyleItemText {
     XSLT_ITEM_COMMON_FIELDS
-    int      noescape;      /* text */
+    int      noescape;          /* text */
 };
 
 /**
@@ -747,9 +750,9 @@ typedef xsltStyleItemApplyTemplates *xsltStyleItemApplyTemplatesPtr;
 struct _xsltStyleItemApplyTemplates {
     XSLT_ITEM_COMMON_FIELDS
 
-    const xmlChar *mode;    /* apply-templates */
-    const xmlChar *modeURI; /* apply-templates */
-    const xmlChar *select;  /* sort, copy-of, value-of, apply-templates */
+    const xmlChar *mode;        /* apply-templates */
+    const xmlChar *modeURI;     /* apply-templates */
+    const xmlChar *select;      /* sort, copy-of, value-of, apply-templates */
     xmlXPathCompExprPtr comp;   /* a precompiled XPath expression */
     /* TODO: with-params */
 };
@@ -769,11 +772,11 @@ typedef xsltStyleItemCallTemplate *xsltStyleItemCallTemplatePtr;
 struct _xsltStyleItemCallTemplate {
     XSLT_ITEM_COMMON_FIELDS
 
-    xsltTemplatePtr templ;  /* call-template */
-    const xmlChar *name;    /* element, attribute, pi */
-    int      has_name;      /* element, attribute, pi */
-    const xmlChar *ns;      /* element */
-    int      has_ns;        /* element */
+    xsltTemplatePtr templ;      /* call-template */
+    const xmlChar *name;        /* element, attribute, pi */
+    int      has_name;          /* element, attribute, pi */
+    const xmlChar *ns;          /* element */
+    int      has_ns;            /* element */
     /* TODO: with-params */
 };
 
@@ -791,8 +794,8 @@ typedef xsltStyleItemCopy *xsltStyleItemCopyPtr;
 
 struct _xsltStyleItemCopy {
    XSLT_ITEM_COMMON_FIELDS
-    const xmlChar *use;     /* copy, element */
-    int      has_use;       /* copy, element */
+    const xmlChar *use;         /* copy, element */
+    int      has_use;           /* copy, element */
 };
 
 /**
@@ -810,7 +813,7 @@ typedef xsltStyleItemIf *xsltStyleItemIfPtr;
 struct _xsltStyleItemIf {
     XSLT_ITEM_COMMON_FIELDS
 
-    const xmlChar *test;    /* if */
+    const xmlChar *test;        /* if */
     xmlXPathCompExprPtr comp;   /* a precompiled XPath expression */
 };
 
@@ -864,7 +867,7 @@ typedef xsltStyleItemNumber *xsltStyleItemNumberPtr;
 
 struct _xsltStyleItemNumber {
     XSLT_ITEM_COMMON_FIELDS
-    xsltNumberData numdata; /* number */
+    xsltNumberData numdata;     /* number */
 };
 
 /**
@@ -928,7 +931,7 @@ typedef xsltStyleItemDocument *xsltStyleItemDocumentPtr;
 
 struct _xsltStyleItemDocument {
     XSLT_ITEM_COMMON_FIELDS
-    int      ver11;     /* assigned: in xsltDocumentComp;
+    int      ver11;             /* assigned: in xsltDocumentComp;
                                   read: nowhere;
                                   TODO: Check if we need. */
     const xmlChar *filename;    /* document URL */
@@ -936,9 +939,9 @@ struct _xsltStyleItemDocument {
 };
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  * Non-instructions (actually properties of instructions/declarations)  *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1037,21 +1040,21 @@ struct _xsltStyleItemSort {
     XSLT_ITEM_COMMON_FIELDS
 
     const xmlChar *stype;       /* sort */
-    int      has_stype;     /* sort */
-    int      number;        /* sort */
-    const xmlChar *order;   /* sort */
-    int      has_order;     /* sort */
-    int      descending;    /* sort */
-    const xmlChar *lang;    /* sort */
-    int      has_lang;      /* sort */
-    xsltLocale locale;      /* sort */
+    int      has_stype;         /* sort */
+    int      number;            /* sort */
+    const xmlChar *order;       /* sort */
+    int      has_order;         /* sort */
+    int      descending;        /* sort */
+    const xmlChar *lang;        /* sort */
+    int      has_lang;          /* sort */
+    xsltLocale locale;          /* sort */
     const xmlChar *case_order;  /* sort */
-    int      lower_first;   /* sort */
+    int      lower_first;       /* sort */
 
     const xmlChar *use;
     int      has_use;
 
-    const xmlChar *select;  /* sort, copy-of, value-of, apply-templates */
+    const xmlChar *select;      /* sort, copy-of, value-of, apply-templates */
 
     xmlXPathCompExprPtr comp;   /* a precompiled XPath expression */
 };
@@ -1100,9 +1103,9 @@ struct _xsltStyleItemInclude {
 };
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  XSLT elements in forwards-compatible mode                           *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 typedef struct _xsltStyleItemUknown xsltStyleItemUknown;
@@ -1113,9 +1116,9 @@ struct _xsltStyleItemUknown {
 
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  Extension elements                                                  *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 /*
@@ -1146,9 +1149,9 @@ struct _xsltStyleItemExtElement {
 };
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  Literal result elements                                             *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 typedef struct _xsltEffectiveNs xsltEffectiveNs;
@@ -1216,9 +1219,9 @@ struct _xsltNsMap {
 #endif
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  Compile-time structures for *internal* use only                     *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 typedef struct _xsltPrincipalStylesheetData xsltPrincipalStylesheetData;
@@ -1259,7 +1262,7 @@ struct _xsltCompilerNodeInfo {
     xmlNodePtr node;
     int depth;
     xsltTemplatePtr templ;   /* The owning template */
-    int category;        /* XSLT element, LR-element or
+    int category;            /* XSLT element, LR-element or
                                 extension element */
     xsltStyleType type;
     xsltElemPreCompPtr item; /* The compiled information */
@@ -1309,9 +1312,9 @@ struct _xsltCompilerCtxt {
     /*
     * used for error/warning reports; e.g. XSLT_ERROR_SEVERITY_WARNING */
     xsltErrorSeverityType errSeverity;
-    int warnings;       /* TODO: number of warnings found at
+    int warnings;               /* TODO: number of warnings found at
                                    compilation */
-    int errors;         /* TODO: number of errors found at
+    int errors;                 /* TODO: number of errors found at
                                    compilation */
     xmlDictPtr dict;
     xsltStylesheetPtr style;
@@ -1328,7 +1331,7 @@ struct _xsltCompilerCtxt {
     */
     int isInclude;
     int hasForwardsCompat; /* whether forwards-compatible mode was used
-                 in a parsing episode */
+                             in a parsing episode */
     int maxNodeInfos; /* TEMP TODO: just for the interest */
     int maxLREs;  /* TEMP TODO: just for the interest */
     /*
@@ -1358,54 +1361,54 @@ struct _xsltCompilerCtxt {
  */
 struct _xsltStylePreComp {
     xsltElemPreCompPtr next;    /* chained list */
-    xsltStyleType type;     /* type of the element */
+    xsltStyleType type;         /* type of the element */
     xsltTransformFunction func; /* handling function */
-    xmlNodePtr inst;        /* the instruction */
+    xmlNodePtr inst;            /* the instruction */
 
     /*
      * Pre computed values.
      */
 
     const xmlChar *stype;       /* sort */
-    int      has_stype;     /* sort */
-    int      number;        /* sort */
-    const xmlChar *order;   /* sort */
-    int      has_order;     /* sort */
-    int      descending;    /* sort */
-    const xmlChar *lang;    /* sort */
-    int      has_lang;      /* sort */
-    xsltLocale locale;      /* sort */
+    int      has_stype;         /* sort */
+    int      number;            /* sort */
+    const xmlChar *order;       /* sort */
+    int      has_order;         /* sort */
+    int      descending;        /* sort */
+    const xmlChar *lang;        /* sort */
+    int      has_lang;          /* sort */
+    xsltLocale locale;          /* sort */
     const xmlChar *case_order;  /* sort */
-    int      lower_first;   /* sort */
+    int      lower_first;       /* sort */
 
-    const xmlChar *use;     /* copy, element */
-    int      has_use;       /* copy, element */
+    const xmlChar *use;         /* copy, element */
+    int      has_use;           /* copy, element */
 
-    int      noescape;      /* text */
+    int      noescape;          /* text */
 
-    const xmlChar *name;    /* element, attribute, pi */
-    int      has_name;      /* element, attribute, pi */
-    const xmlChar *ns;      /* element */
-    int      has_ns;        /* element */
+    const xmlChar *name;        /* element, attribute, pi */
+    int      has_name;          /* element, attribute, pi */
+    const xmlChar *ns;          /* element */
+    int      has_ns;            /* element */
 
-    const xmlChar *mode;    /* apply-templates */
-    const xmlChar *modeURI; /* apply-templates */
+    const xmlChar *mode;        /* apply-templates */
+    const xmlChar *modeURI;     /* apply-templates */
 
-    const xmlChar *test;    /* if */
+    const xmlChar *test;        /* if */
 
-    xsltTemplatePtr templ;  /* call-template */
+    xsltTemplatePtr templ;      /* call-template */
 
-    const xmlChar *select;  /* sort, copy-of, value-of, apply-templates */
+    const xmlChar *select;      /* sort, copy-of, value-of, apply-templates */
 
-    int      ver11;     /* document */
+    int      ver11;             /* document */
     const xmlChar *filename;    /* document URL */
-    int      has_filename;  /* document */
+    int      has_filename;      /* document */
 
-    xsltNumberData numdata; /* number */
+    xsltNumberData numdata;     /* number */
 
     xmlXPathCompExprPtr comp;   /* a precompiled XPath expression */
-    xmlNsPtr *nsList;       /* the namespaces in scope */
-    int nsNr;           /* the number of namespaces in scope */
+    xmlNsPtr *nsList;           /* the namespaces in scope */
+    int nsNr;                   /* the number of namespaces in scope */
 };
 
 #endif /* XSLT_REFACTORED */
@@ -1420,15 +1423,15 @@ typedef xsltStackElem *xsltStackElemPtr;
 struct _xsltStackElem {
     struct _xsltStackElem *next;/* chained list */
     xsltStylePreCompPtr comp;   /* the compiled form */
-    int computed;       /* was the evaluation done */
-    const xmlChar *name;    /* the local part of the name QName */
-    const xmlChar *nameURI; /* the URI part of the name QName */
-    const xmlChar *select;  /* the eval string */
-    xmlNodePtr tree;        /* the sequence constructor if no eval
-                    string or the location */
+    int computed;               /* was the evaluation done */
+    const xmlChar *name;        /* the local part of the name QName */
+    const xmlChar *nameURI;     /* the URI part of the name QName */
+    const xmlChar *select;      /* the eval string */
+    xmlNodePtr tree;            /* the sequence constructor if no eval
+                                    string or the location */
     xmlXPathObjectPtr value;    /* The value if computed */
-    xmlDocPtr fragment;     /* The Result Tree Fragments (needed for XSLT 1.0)
-                   which are bound to the variable's lifetime. */
+    xmlDocPtr fragment;         /* The Result Tree Fragments (needed for XSLT 1.0)
+                                   which are bound to the variable's lifetime. */
     int level;                  /* the depth in the tree;
                                    -1 if persistent (e.g. a given xsl:with-param) */
     xsltTransformContextPtr context; /* The transformation context; needed to cache
@@ -1481,14 +1484,14 @@ struct _xsltStylesheet {
     struct _xsltStylesheet *next;
     struct _xsltStylesheet *imports;
 
-    xsltDocumentPtr docList;        /* the include document list */
+    xsltDocumentPtr docList;            /* the include document list */
 
     /*
      * General data on the style sheet document.
      */
-    xmlDocPtr doc;      /* the parsed XML stylesheet */
+    xmlDocPtr doc;              /* the parsed XML stylesheet */
     xmlHashTablePtr stripSpaces;/* the hash table of the strip-space and
-                   preserve space elements */
+                                   preserve space elements */
     int             stripAll;   /* strip-space * (1) preserve-space * (-1) */
     xmlHashTablePtr cdataSection;/* the hash table of the cdata-section */
 
@@ -1500,17 +1503,18 @@ struct _xsltStylesheet {
     /*
      * Template descriptions.
      */
-    xsltTemplatePtr templates;  /* the ordered list of templates */
-    void *templatesHash;    /* hash table or wherever compiled templates
-                   information is stored */
-    void *rootMatch;        /* template based on / */
-    void *keyMatch;     /* template based on key() */
-    void *elemMatch;        /* template based on * */
-    void *attrMatch;        /* template based on @* */
-    void *parentMatch;      /* template based on .. */
-    void *textMatch;        /* template based on text() */
-    void *piMatch;      /* template based on processing-instruction() */
-    void *commentMatch;     /* template based on comment() */
+    xsltTemplatePtr templates;           /* the ordered list of templates */
+    xmlHashTablePtr templatesHash;       /* hash table or wherever compiled
+                                            templates information is stored */
+    struct _xsltCompMatch *rootMatch;    /* template based on / */
+    struct _xsltCompMatch *keyMatch;     /* template based on key() */
+    struct _xsltCompMatch *elemMatch;    /* template based on * */
+    struct _xsltCompMatch *attrMatch;    /* template based on @* */
+    struct _xsltCompMatch *parentMatch;  /* template based on .. */
+    struct _xsltCompMatch *textMatch;    /* template based on text() */
+    struct _xsltCompMatch *piMatch;      /* template based on
+                                            processing-instruction() */
+    struct _xsltCompMatch *commentMatch; /* template based on comment() */
 
     /*
      * Namespace aliases.
@@ -1532,25 +1536,25 @@ struct _xsltStylesheet {
                                    execution of XPath expressions; unfortunately
                                    it restricts the stylesheet to have distinct
                                    prefixes.
-                   TODO: We need to get rid of this.
-                 */
+                                   TODO: We need to get rid of this.
+                                 */
     void           *nsDefs;     /* ATTENTION TODO: This is currently used to store
-                   xsltExtDefPtr (in extensions.c) and
+                                   xsltExtDefPtr (in extensions.c) and
                                    *not* xmlNsPtr.
-                 */
+                                 */
 
     /*
      * Key definitions.
      */
-    void *keys;         /* key definitions */
+    void *keys;                 /* key definitions */
 
     /*
      * Output related stuff.
      */
-    xmlChar *method;        /* the output method */
-    xmlChar *methodURI;     /* associated namespace if any */
-    xmlChar *version;       /* version string */
-    xmlChar *encoding;      /* encoding string */
+    xmlChar *method;            /* the output method */
+    xmlChar *methodURI;         /* associated namespace if any */
+    xmlChar *version;           /* version string */
+    xmlChar *encoding;          /* encoding string */
     int omitXmlDeclaration;     /* omit-xml-declaration = "yes" | "no" */
 
     /*
@@ -1560,28 +1564,28 @@ struct _xsltStylesheet {
     int standalone;             /* standalone = "yes" | "no" */
     xmlChar *doctypePublic;     /* doctype-public string */
     xmlChar *doctypeSystem;     /* doctype-system string */
-    int indent;         /* should output being indented */
-    xmlChar *mediaType;     /* media-type string */
+    int indent;                 /* should output being indented */
+    xmlChar *mediaType;         /* media-type string */
 
     /*
      * Precomputed blocks.
      */
     xsltElemPreCompPtr preComps;/* list of precomputed blocks */
-    int warnings;       /* number of warnings found at compilation */
-    int errors;         /* number of errors found at compilation */
+    int warnings;               /* number of warnings found at compilation */
+    int errors;                 /* number of errors found at compilation */
 
-    xmlChar  *exclPrefix;   /* last excluded prefixes */
+    xmlChar  *exclPrefix;       /* last excluded prefixes */
     xmlChar **exclPrefixTab;    /* array of excluded prefixes */
-    int       exclPrefixNr; /* number of excluded prefixes in scope */
+    int       exclPrefixNr;     /* number of excluded prefixes in scope */
     int       exclPrefixMax;    /* size of the array */
 
-    void     *_private;     /* user defined data */
+    void     *_private;         /* user defined data */
 
     /*
      * Extensions.
      */
     xmlHashTablePtr extInfos;   /* the extension data */
-    int         extrasNr;   /* the number of extras required */
+    int             extrasNr;   /* the number of extras required */
 
     /*
      * For keeping track of nested includes
@@ -1666,101 +1670,101 @@ typedef enum {
 } xsltTransformState;
 
 struct _xsltTransformContext {
-    xsltStylesheetPtr style;        /* the stylesheet used */
-    xsltOutputType type;        /* the type of output */
+    xsltStylesheetPtr style;            /* the stylesheet used */
+    xsltOutputType type;                /* the type of output */
 
-    xsltTemplatePtr  templ;     /* the current template */
-    int              templNr;       /* Nb of templates in the stack */
-    int              templMax;      /* Size of the templtes stack */
-    xsltTemplatePtr *templTab;      /* the template stack */
+    xsltTemplatePtr  templ;             /* the current template */
+    int              templNr;           /* Nb of templates in the stack */
+    int              templMax;          /* Size of the templtes stack */
+    xsltTemplatePtr *templTab;          /* the template stack */
 
-    xsltStackElemPtr  vars;     /* the current variable list */
-    int               varsNr;       /* Nb of variable list in the stack */
-    int               varsMax;      /* Size of the variable list stack */
-    xsltStackElemPtr *varsTab;      /* the variable list stack */
-    int               varsBase;     /* the var base for current templ */
+    xsltStackElemPtr  vars;             /* the current variable list */
+    int               varsNr;           /* Nb of variable list in the stack */
+    int               varsMax;          /* Size of the variable list stack */
+    xsltStackElemPtr *varsTab;          /* the variable list stack */
+    int               varsBase;         /* the var base for current templ */
 
     /*
      * Extensions
      */
-    xmlHashTablePtr   extFunctions; /* the extension functions */
-    xmlHashTablePtr   extElements;  /* the extension elements */
-    xmlHashTablePtr   extInfos;     /* the extension data */
+    xmlHashTablePtr   extFunctions;     /* the extension functions */
+    xmlHashTablePtr   extElements;      /* the extension elements */
+    xmlHashTablePtr   extInfos;         /* the extension data */
 
-    const xmlChar *mode;        /* the current mode */
-    const xmlChar *modeURI;     /* the current mode URI */
+    const xmlChar *mode;                /* the current mode */
+    const xmlChar *modeURI;             /* the current mode URI */
 
-    xsltDocumentPtr docList;        /* the document list */
+    xsltDocumentPtr docList;            /* the document list */
 
-    xsltDocumentPtr document;       /* the current source document; can be NULL if an RTF */
-    xmlNodePtr node;            /* the current node being processed */
-    xmlNodeSetPtr nodeList;     /* the current node list */
-    /* xmlNodePtr current;          the node */
+    xsltDocumentPtr document;           /* the current source document; can be NULL if an RTF */
+    xmlNodePtr node;                    /* the current node being processed */
+    xmlNodeSetPtr nodeList;             /* the current node list */
+    /* xmlNodePtr current;                      the node */
 
-    xmlDocPtr output;           /* the resulting document */
-    xmlNodePtr insert;          /* the insertion node */
+    xmlDocPtr output;                   /* the resulting document */
+    xmlNodePtr insert;                  /* the insertion node */
 
-    xmlXPathContextPtr xpathCtxt;   /* the XPath context */
-    xsltTransformState state;       /* the current state */
+    xmlXPathContextPtr xpathCtxt;       /* the XPath context */
+    xsltTransformState state;           /* the current state */
 
     /*
      * Global variables
      */
-    xmlHashTablePtr   globalVars;   /* the global variables and params */
+    xmlHashTablePtr   globalVars;       /* the global variables and params */
 
-    xmlNodePtr inst;            /* the instruction in the stylesheet */
+    xmlNodePtr inst;                    /* the instruction in the stylesheet */
 
-    int xinclude;           /* should XInclude be processed */
+    int xinclude;                       /* should XInclude be processed */
 
-    const char *      outputFile;   /* the output URI if known */
+    const char *      outputFile;       /* the output URI if known */
 
     int profile;                        /* is this run profiled */
-    long             prof;      /* the current profiled value */
-    int              profNr;        /* Nb of templates in the stack */
-    int              profMax;       /* Size of the templtaes stack */
-    long            *profTab;       /* the profile template stack */
+    long             prof;              /* the current profiled value */
+    int              profNr;            /* Nb of templates in the stack */
+    int              profMax;           /* Size of the templtaes stack */
+    long            *profTab;           /* the profile template stack */
 
-    void            *_private;      /* user defined data */
+    void            *_private;          /* user defined data */
 
-    int              extrasNr;      /* the number of extras used */
-    int              extrasMax;     /* the number of extras allocated */
-    xsltRuntimeExtraPtr extras;     /* extra per runtime information */
+    int              extrasNr;          /* the number of extras used */
+    int              extrasMax;         /* the number of extras allocated */
+    xsltRuntimeExtraPtr extras;         /* extra per runtime information */
 
-    xsltDocumentPtr  styleList;     /* the stylesheet docs list */
-    void                 * sec;     /* the security preferences if any */
+    xsltDocumentPtr  styleList;         /* the stylesheet docs list */
+    void                 * sec;         /* the security preferences if any */
 
-    xmlGenericErrorFunc  error;     /* a specific error handler */
-    void              * errctx;     /* context for the error handler */
+    xmlGenericErrorFunc  error;         /* a specific error handler */
+    void              * errctx;         /* context for the error handler */
 
-    xsltSortFunc      sortfunc;     /* a ctxt specific sort routine */
+    xsltSortFunc      sortfunc;         /* a ctxt specific sort routine */
 
     /*
      * handling of temporary Result Value Tree
      * (XSLT 1.0 term: "Result Tree Fragment")
      */
-    xmlDocPtr       tmpRVT;     /* list of RVT without persistance */
-    xmlDocPtr       persistRVT;     /* list of persistant RVTs */
+    xmlDocPtr       tmpRVT;             /* list of RVT without persistance */
+    xmlDocPtr       persistRVT;         /* list of persistant RVTs */
     int             ctxtflags;          /* context processing flags */
 
     /*
      * Speed optimization when coalescing text nodes
      */
-    const xmlChar  *lasttext;       /* last text node content */
-    int             lasttsize;      /* last text node size */
-    int             lasttuse;       /* last text node use */
+    const xmlChar  *lasttext;           /* last text node content */
+    int             lasttsize;          /* last text node size */
+    int             lasttuse;           /* last text node use */
     /*
      * Per Context Debugging
      */
-    int debugStatus;            /* the context level debug status */
-    unsigned long* traceCode;       /* pointer to the variable holding the mask */
+    int debugStatus;                    /* the context level debug status */
+    unsigned long* traceCode;           /* pointer to the variable holding the mask */
 
-    int parserOptions;          /* parser options xmlParserOption */
+    int parserOptions;                  /* parser options xmlParserOption */
 
     /*
      * dictionary: shared between stylesheet, context and documents.
      */
     xmlDictPtr dict;
-    xmlDocPtr       tmpDoc; /* Obsolete; not used in the library. */
+    xmlDocPtr           tmpDoc; /* Obsolete; not used in the library. */
     /*
      * all document text strings are internalized
      */
@@ -1773,7 +1777,7 @@ struct _xsltTransformContext {
     xsltTransformCachePtr cache;
     void *contextVariable; /* the current variable item */
     xmlDocPtr localRVT; /* list of local tree fragments; will be freed when
-               the instruction which created the fragment
+                           the instruction which created the fragment
                            exits */
     xmlDocPtr localRVTBase; /* Obsolete */
     int keyInitLevel;   /* Needed to catch recursive keys issues */
@@ -1833,143 +1837,143 @@ struct _xsltTransformContext {
 /*
  * Functions associated to the internal types
 xsltDecimalFormatPtr    xsltDecimalFormatGetByName(xsltStylesheetPtr sheet,
-                           xmlChar *name);
+                                                   xmlChar *name);
  */
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltNewStylesheet   (void);
+                        xsltNewStylesheet       (void);
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltParseStylesheetFile (const xmlChar* filename);
+                        xsltParseStylesheetFile (const xmlChar* filename);
 XSLTPUBFUN void XSLTCALL
-            xsltFreeStylesheet  (xsltStylesheetPtr style);
+                        xsltFreeStylesheet      (xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-            xsltIsBlank     (xmlChar *str);
+                        xsltIsBlank             (xmlChar *str);
 XSLTPUBFUN void XSLTCALL
-            xsltFreeStackElemList   (xsltStackElemPtr elem);
+                        xsltFreeStackElemList   (xsltStackElemPtr elem);
 XSLTPUBFUN xsltDecimalFormatPtr XSLTCALL
-            xsltDecimalFormatGetByName(xsltStylesheetPtr style,
-                         xmlChar *name);
+                        xsltDecimalFormatGetByName(xsltStylesheetPtr style,
+                                                 xmlChar *name);
 XSLTPUBFUN xsltDecimalFormatPtr XSLTCALL
-            xsltDecimalFormatGetByQName(xsltStylesheetPtr style,
-                         const xmlChar *nsUri,
+                        xsltDecimalFormatGetByQName(xsltStylesheetPtr style,
+                                                 const xmlChar *nsUri,
                                                  const xmlChar *name);
 
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltParseStylesheetProcess(xsltStylesheetPtr ret,
-                         xmlDocPtr doc);
+                        xsltParseStylesheetProcess(xsltStylesheetPtr ret,
+                                                 xmlDocPtr doc);
 XSLTPUBFUN void XSLTCALL
-            xsltParseStylesheetOutput(xsltStylesheetPtr style,
-                         xmlNodePtr cur);
+                        xsltParseStylesheetOutput(xsltStylesheetPtr style,
+                                                 xmlNodePtr cur);
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltParseStylesheetDoc  (xmlDocPtr doc);
+                        xsltParseStylesheetDoc  (xmlDocPtr doc);
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltParseStylesheetImportedDoc(xmlDocPtr doc,
-                        xsltStylesheetPtr style);
+                        xsltParseStylesheetImportedDoc(xmlDocPtr doc,
+                                                xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-            xsltParseStylesheetUser(xsltStylesheetPtr style,
-                        xmlDocPtr doc);
+                        xsltParseStylesheetUser(xsltStylesheetPtr style,
+                                                xmlDocPtr doc);
 XSLTPUBFUN xsltStylesheetPtr XSLTCALL
-            xsltLoadStylesheetPI    (xmlDocPtr doc);
+                        xsltLoadStylesheetPI    (xmlDocPtr doc);
 XSLTPUBFUN void XSLTCALL
-            xsltNumberFormat    (xsltTransformContextPtr ctxt,
-                         xsltNumberDataPtr data,
-                         xmlNodePtr node);
+                        xsltNumberFormat        (xsltTransformContextPtr ctxt,
+                                                 xsltNumberDataPtr data,
+                                                 xmlNodePtr node);
 XSLTPUBFUN xmlXPathError XSLTCALL
-            xsltFormatNumberConversion(xsltDecimalFormatPtr self,
-                         xmlChar *format,
-                         double number,
-                         xmlChar **result);
+                        xsltFormatNumberConversion(xsltDecimalFormatPtr self,
+                                                 xmlChar *format,
+                                                 double number,
+                                                 xmlChar **result);
 
 XSLTPUBFUN void XSLTCALL
-            xsltParseTemplateContent(xsltStylesheetPtr style,
-                         xmlNodePtr templ);
+                        xsltParseTemplateContent(xsltStylesheetPtr style,
+                                                 xmlNodePtr templ);
 XSLTPUBFUN int XSLTCALL
-            xsltAllocateExtra   (xsltStylesheetPtr style);
+                        xsltAllocateExtra       (xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-            xsltAllocateExtraCtxt   (xsltTransformContextPtr ctxt);
+                        xsltAllocateExtraCtxt   (xsltTransformContextPtr ctxt);
 /*
  * Extra functions for Result Value Trees
  */
 XSLTPUBFUN xmlDocPtr XSLTCALL
-            xsltCreateRVT       (xsltTransformContextPtr ctxt);
+                        xsltCreateRVT           (xsltTransformContextPtr ctxt);
 XSLTPUBFUN int XSLTCALL
-            xsltRegisterTmpRVT  (xsltTransformContextPtr ctxt,
-                         xmlDocPtr RVT);
+                        xsltRegisterTmpRVT      (xsltTransformContextPtr ctxt,
+                                                 xmlDocPtr RVT);
 XSLTPUBFUN int XSLTCALL
-            xsltRegisterLocalRVT    (xsltTransformContextPtr ctxt,
-                         xmlDocPtr RVT);
+                        xsltRegisterLocalRVT    (xsltTransformContextPtr ctxt,
+                                                 xmlDocPtr RVT);
 XSLTPUBFUN int XSLTCALL
-            xsltRegisterPersistRVT  (xsltTransformContextPtr ctxt,
-                         xmlDocPtr RVT);
+                        xsltRegisterPersistRVT  (xsltTransformContextPtr ctxt,
+                                                 xmlDocPtr RVT);
 XSLTPUBFUN int XSLTCALL
-            xsltExtensionInstructionResultRegister(
-                         xsltTransformContextPtr ctxt,
-                         xmlXPathObjectPtr obj);
+                        xsltExtensionInstructionResultRegister(
+                                                 xsltTransformContextPtr ctxt,
+                                                 xmlXPathObjectPtr obj);
 XSLTPUBFUN int XSLTCALL
-            xsltExtensionInstructionResultFinalize(
-                         xsltTransformContextPtr ctxt);
+                        xsltExtensionInstructionResultFinalize(
+                                                 xsltTransformContextPtr ctxt);
 XSLTPUBFUN int XSLTCALL
-            xsltFlagRVTs(
-                         xsltTransformContextPtr ctxt,
-                         xmlXPathObjectPtr obj,
-                         void *val);
+                        xsltFlagRVTs(
+                                                 xsltTransformContextPtr ctxt,
+                                                 xmlXPathObjectPtr obj,
+                                                 void *val);
 XSLTPUBFUN void XSLTCALL
-            xsltFreeRVTs        (xsltTransformContextPtr ctxt);
+                        xsltFreeRVTs            (xsltTransformContextPtr ctxt);
 XSLTPUBFUN void XSLTCALL
-            xsltReleaseRVT      (xsltTransformContextPtr ctxt,
-                         xmlDocPtr RVT);
+                        xsltReleaseRVT          (xsltTransformContextPtr ctxt,
+                                                 xmlDocPtr RVT);
 /*
  * Extra functions for Attribute Value Templates
  */
 XSLTPUBFUN void XSLTCALL
-            xsltCompileAttr     (xsltStylesheetPtr style,
-                         xmlAttrPtr attr);
+                        xsltCompileAttr         (xsltStylesheetPtr style,
+                                                 xmlAttrPtr attr);
 XSLTPUBFUN xmlChar * XSLTCALL
-            xsltEvalAVT     (xsltTransformContextPtr ctxt,
-                         void *avt,
-                         xmlNodePtr node);
+                        xsltEvalAVT             (xsltTransformContextPtr ctxt,
+                                                 void *avt,
+                                                 xmlNodePtr node);
 XSLTPUBFUN void XSLTCALL
-            xsltFreeAVTList     (void *avt);
+                        xsltFreeAVTList         (void *avt);
 
 /*
  * Extra function for successful xsltCleanupGlobals / xsltInit sequence.
  */
 
 XSLTPUBFUN void XSLTCALL
-            xsltUninit      (void);
+                        xsltUninit              (void);
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  Compile-time functions for *internal* use only                      *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef XSLT_REFACTORED
 XSLTPUBFUN void XSLTCALL
-            xsltParseSequenceConstructor(
-                         xsltCompilerCtxtPtr cctxt,
-                         xmlNodePtr start);
+                        xsltParseSequenceConstructor(
+                                                 xsltCompilerCtxtPtr cctxt,
+                                                 xmlNodePtr start);
 XSLTPUBFUN int XSLTCALL
-            xsltParseAnyXSLTElem    (xsltCompilerCtxtPtr cctxt,
-                         xmlNodePtr elem);
+                        xsltParseAnyXSLTElem    (xsltCompilerCtxtPtr cctxt,
+                                                 xmlNodePtr elem);
 #ifdef XSLT_REFACTORED_XSLT_NSCOMP
 XSLTPUBFUN int XSLTCALL
-            xsltRestoreDocumentNamespaces(
-                         xsltNsMapPtr ns,
-                         xmlDocPtr doc);
+                        xsltRestoreDocumentNamespaces(
+                                                 xsltNsMapPtr ns,
+                                                 xmlDocPtr doc);
 #endif
 #endif /* XSLT_REFACTORED */
 
 /************************************************************************
- *                                  *
+ *                                                                      *
  *  Transformation-time functions for *internal* use only               *
- *                                  *
+ *                                                                      *
  ************************************************************************/
 XSLTPUBFUN int XSLTCALL
-            xsltInitCtxtKey     (xsltTransformContextPtr ctxt,
-                         xsltDocumentPtr doc,
-                         xsltKeyDefPtr keyd);
+                        xsltInitCtxtKey         (xsltTransformContextPtr ctxt,
+                                                 xsltDocumentPtr doc,
+                                                 xsltKeyDefPtr keyd);
 XSLTPUBFUN int XSLTCALL
-            xsltInitAllDocKeys  (xsltTransformContextPtr ctxt);
+                        xsltInitAllDocKeys      (xsltTransformContextPtr ctxt);
 #ifdef __cplusplus
 }
 #endif

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltconfig.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltconfig.h
@@ -20,21 +20,21 @@ extern "C" {
  *
  * the version string like "1.2.3"
  */
-#define LIBXSLT_DOTTED_VERSION "1.1.34"
+#define LIBXSLT_DOTTED_VERSION "1.1.35"
 
 /**
  * LIBXSLT_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXSLT_VERSION 10134
+#define LIBXSLT_VERSION 10135
 
 /**
  * LIBXSLT_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXSLT_VERSION_STRING "10134"
+#define LIBXSLT_VERSION_STRING "10135"
 
 /**
  * LIBXSLT_VERSION_EXTRA:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltlocale.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltlocale.c
@@ -24,10 +24,10 @@
 #define ISALPHA(c) ((unsigned)(TOUPPER(c) - 'A') < 26)
 
 /*without terminating null character*/
-#define XSLTMAX_ISO639LANGLEN       8
-#define XSLTMAX_ISO3166CNTRYLEN     8
-                    /* <lang>-<cntry> */
-#define XSLTMAX_LANGTAGLEN      (XSLTMAX_ISO639LANGLEN+1+XSLTMAX_ISO3166CNTRYLEN)
+#define XSLTMAX_ISO639LANGLEN           8
+#define XSLTMAX_ISO3166CNTRYLEN         8
+                                        /* <lang>-<cntry> */
+#define XSLTMAX_LANGTAGLEN              (XSLTMAX_ISO639LANGLEN+1+XSLTMAX_ISO3166CNTRYLEN)
 
 static const xmlChar* xsltDefaultRegion(const xmlChar *localeName);
 
@@ -52,7 +52,7 @@ xslt_locale_WINAPI(const xmlChar *languageTag) {
     xsltRFC1766Info *p = xsltLocaleList;
 
     for (k=0; k<xsltLocaleListSize; k++, p++)
-    if (xmlStrcmp(p->tag, languageTag) == 0) return p->lcid;
+        if (xmlStrcmp(p->tag, languageTag) == 0) return p->lcid;
     return((xsltLocale)0);
 }
 
@@ -96,26 +96,26 @@ xsltNewLocale(const xmlChar *languageTag) {
     /* Convert something like "pt-br" to "pt_BR.utf8" */
 
     if (languageTag == NULL)
-    return(NULL);
+        return(NULL);
 
     for (i=0; i<XSLTMAX_ISO639LANGLEN && ISALPHA(*p); ++i)
-    *q++ = TOLOWER(*p++);
+        *q++ = TOLOWER(*p++);
 
     if (i == 0)
-    return(NULL);
+        return(NULL);
 
     llen = i;
 
     if (*p) {
-    if (*p++ != '-')
-        return(NULL);
+        if (*p++ != '-')
+            return(NULL);
         *q++ = '_';
 
-    for (i=0; i<XSLTMAX_ISO3166CNTRYLEN && ISALPHA(*p); ++i)
-        *q++ = TOUPPER(*p++);
+        for (i=0; i<XSLTMAX_ISO3166CNTRYLEN && ISALPHA(*p); ++i)
+            *q++ = TOUPPER(*p++);
 
-    if (i == 0 || *p)
-        return(NULL);
+        if (i == 0 || *p)
+            return(NULL);
 
         memcpy(q, ".utf8", 6);
         locale = newlocale(LC_COLLATE_MASK, localeName, NULL);
@@ -167,21 +167,21 @@ xsltNewLocale(const xmlChar *languageTag) {
     xsltEnumSupportedLocales();
 
     for (i=0; i<XSLTMAX_ISO639LANGLEN && ISALPHA(*p); ++i)
-    *q++ = TOLOWER(*p++);
+        *q++ = TOLOWER(*p++);
     if (i == 0) goto end;
 
     llen = i;
     *q++ = '-';
     if (*p) { /*if country tag is given*/
-    if (*p++ != '-') goto end;
+        if (*p++ != '-') goto end;
 
-    for (i=0; i<XSLTMAX_ISO3166CNTRYLEN && ISALPHA(*p); ++i)
-        *q++ = TOUPPER(*p++);
-    if (i == 0 || *p) goto end;
+        for (i=0; i<XSLTMAX_ISO3166CNTRYLEN && ISALPHA(*p); ++i)
+            *q++ = TOUPPER(*p++);
+        if (i == 0 || *p) goto end;
 
-    *q = '\0';
-    locale = xslt_locale_WINAPI(localeName);
-    if (locale != (xsltLocale)0) goto end;
+        *q = '\0';
+        locale = xslt_locale_WINAPI(localeName);
+        if (locale != (xsltLocale)0) goto end;
     }
     /* Try to find most common country for language */
     region = xsltDefaultRegion(localeName);
@@ -346,7 +346,8 @@ xsltDefaultRegion(const xmlChar *localeName) {
 void
 xsltFreeLocale(xsltLocale locale) {
 #ifdef XSLT_LOCALE_POSIX
-    freelocale(locale);
+    if (locale != NULL)
+        freelocale(locale);
 #endif
 }
 
@@ -373,9 +374,9 @@ xsltStrxfrm(xsltLocale locale, const xmlChar *string)
     xstrlen = strxfrm_l(NULL, (const char *)string, 0, locale) + 1;
     xstr = (xsltLocaleChar *) xmlMalloc(xstrlen);
     if (xstr == NULL) {
-    xsltTransformError(NULL, NULL, NULL,
-        "xsltStrxfrm : out of memory error\n");
-    return(NULL);
+        xsltTransformError(NULL, NULL, NULL,
+            "xsltStrxfrm : out of memory error\n");
+        return(NULL);
     }
 
     r = strxfrm_l((char *)xstr, (const char *)string, xstrlen, locale);
@@ -402,7 +403,7 @@ xsltStrxfrm(xsltLocale locale, const xmlChar *string)
 #endif /* XSLT_LOCALE_WINAPI */
 
     if (r >= xstrlen) {
-    xsltTransformError(NULL, NULL, NULL, "xsltStrxfrm : strxfrm failed\n");
+        xsltTransformError(NULL, NULL, NULL, "xsltStrxfrm : strxfrm failed\n");
         xmlFree(xstr);
         return(NULL);
     }
@@ -487,13 +488,13 @@ xsltIterateSupportedLocales(LPSTR lcid) {
     if (--l < 1) goto end;
 
     {  /*fill results*/
-    xmlChar    *q = p->tag;
-    memcpy(q, iso639lang, k);
-    q += k;
-    *q++ = '-';
-    memcpy(q, iso3136ctry, l);
-    q += l;
-    *q = '\0';
+        xmlChar    *q = p->tag;
+        memcpy(q, iso639lang, k);
+        q += k;
+        *q++ = '-';
+        memcpy(q, iso3136ctry, l);
+        q += l;
+        *q = '\0';
     }
     ++count;
 end:
@@ -505,14 +506,14 @@ static void
 xsltEnumSupportedLocales(void) {
     xmlRMutexLock(xsltLocaleMutex);
     if (xsltLocaleListSize <= 0) {
-    size_t len;
+        size_t len;
 
-    EnumSystemLocalesA(xsltCountSupportedLocales, LCID_SUPPORTED);
+        EnumSystemLocalesA(xsltCountSupportedLocales, LCID_SUPPORTED);
 
-    len = xsltLocaleListSize * sizeof(xsltRFC1766Info);
-    xsltLocaleList = xmlMalloc(len);
-    memset(xsltLocaleList, 0, len);
-    EnumSystemLocalesA(xsltIterateSupportedLocales, LCID_SUPPORTED);
+        len = xsltLocaleListSize * sizeof(xsltRFC1766Info);
+        xsltLocaleList = xmlMalloc(len);
+        memset(xsltLocaleList, 0, len);
+        EnumSystemLocalesA(xsltIterateSupportedLocales, LCID_SUPPORTED);
     }
     xmlRMutexUnlock(xsltLocaleMutex);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltlocale.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltlocale.h
@@ -60,17 +60,17 @@ typedef xmlChar xsltLocaleChar;
 #endif
 
 XSLTPUBFUN xsltLocale XSLTCALL
-    xsltNewLocale           (const xmlChar *langName);
+        xsltNewLocale                   (const xmlChar *langName);
 XSLTPUBFUN void XSLTCALL
-    xsltFreeLocale          (xsltLocale locale);
+        xsltFreeLocale                  (xsltLocale locale);
 XSLTPUBFUN xsltLocaleChar * XSLTCALL
-    xsltStrxfrm         (xsltLocale locale,
-                     const xmlChar *string);
+        xsltStrxfrm                     (xsltLocale locale,
+                                         const xmlChar *string);
 XSLTPUBFUN int XSLTCALL
-    xsltLocaleStrcmp        (xsltLocale locale,
-                     const xsltLocaleChar *str1,
-                     const xsltLocaleChar *str2);
+        xsltLocaleStrcmp                (xsltLocale locale,
+                                         const xsltLocaleChar *str1,
+                                         const xsltLocaleChar *str2);
 XSLTPUBFUN void XSLTCALL
-    xsltFreeLocales         (void);
+        xsltFreeLocales                 (void);
 
 #endif /* __XML_XSLTLOCALE_H__ */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltutils.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltutils.c
@@ -47,9 +47,9 @@
 #endif
 
 /************************************************************************
- *                                  *
- *          Convenience function                *
- *                                  *
+ *                                                                      *
+ *                      Convenience function                            *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -82,7 +82,7 @@ xsltGetCNsProp(xsltStylesheetPtr style, xmlNodePtr node,
     const xmlChar *ret;
 
     if ((node == NULL) || (style == NULL) || (style->dict == NULL))
-    return(NULL);
+        return(NULL);
 
     if (nameSpace == NULL)
         return xmlGetProp(node, name);
@@ -90,31 +90,31 @@ xsltGetCNsProp(xsltStylesheetPtr style, xmlNodePtr node,
     if (node->type == XML_NAMESPACE_DECL)
         return(NULL);
     if (node->type == XML_ELEMENT_NODE)
-    prop = node->properties;
+        prop = node->properties;
     else
-    prop = NULL;
+        prop = NULL;
     while (prop != NULL) {
-    /*
-     * One need to have
-     *   - same attribute names
-     *   - and the attribute carrying that namespace
-     */
+        /*
+         * One need to have
+         *   - same attribute names
+         *   - and the attribute carrying that namespace
+         */
         if ((xmlStrEqual(prop->name, name)) &&
-        (((prop->ns == NULL) && (node->ns != NULL) &&
-          (xmlStrEqual(node->ns->href, nameSpace))) ||
-         ((prop->ns != NULL) &&
-          (xmlStrEqual(prop->ns->href, nameSpace))))) {
+            (((prop->ns == NULL) && (node->ns != NULL) &&
+              (xmlStrEqual(node->ns->href, nameSpace))) ||
+             ((prop->ns != NULL) &&
+              (xmlStrEqual(prop->ns->href, nameSpace))))) {
 
-        tmp = xmlNodeListGetString(node->doc, prop->children, 1);
-        if (tmp == NULL)
-            ret = xmlDictLookup(style->dict, BAD_CAST "", 0);
-        else {
-            ret = xmlDictLookup(style->dict, tmp, -1);
-        xmlFree(tmp);
+            tmp = xmlNodeListGetString(node->doc, prop->children, 1);
+            if (tmp == NULL)
+                ret = xmlDictLookup(style->dict, BAD_CAST "", 0);
+            else {
+                ret = xmlDictLookup(style->dict, tmp, -1);
+                xmlFree(tmp);
+            }
+            return ret;
         }
-        return ret;
-        }
-    prop = prop->next;
+        prop = prop->next;
     }
     tmp = NULL;
     /*
@@ -124,22 +124,22 @@ xsltGetCNsProp(xsltStylesheetPtr style, xmlNodePtr node,
     doc =  node->doc;
     if (doc != NULL) {
         if (doc->intSubset != NULL) {
-        xmlAttributePtr attrDecl;
+            xmlAttributePtr attrDecl;
 
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, node->name, name);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, node->name, name);
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset, node->name, name);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset, node->name, name);
 
-        if ((attrDecl != NULL) && (attrDecl->prefix != NULL)) {
-            /*
-         * The DTD declaration only allows a prefix search
-         */
-        ns = xmlSearchNs(doc, node, attrDecl->prefix);
-        if ((ns != NULL) && (xmlStrEqual(ns->href, nameSpace)))
-            return(xmlDictLookup(style->dict,
-                                 attrDecl->defaultValue, -1));
+            if ((attrDecl != NULL) && (attrDecl->prefix != NULL)) {
+                /*
+                 * The DTD declaration only allows a prefix search
+                 */
+                ns = xmlSearchNs(doc, node, attrDecl->prefix);
+                if ((ns != NULL) && (xmlStrEqual(ns->href, nameSpace)))
+                    return(xmlDictLookup(style->dict,
+                                         attrDecl->defaultValue, -1));
+            }
         }
-    }
     }
     return(NULL);
 }
@@ -169,7 +169,7 @@ xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace) {
     xmlNsPtr ns;
 
     if (node == NULL)
-    return(NULL);
+        return(NULL);
 
     if (nameSpace == NULL)
         return xmlGetProp(node, name);
@@ -177,9 +177,9 @@ xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace) {
     if (node->type == XML_NAMESPACE_DECL)
         return(NULL);
     if (node->type == XML_ELEMENT_NODE)
-    prop = node->properties;
+        prop = node->properties;
     else
-    prop = NULL;
+        prop = NULL;
     /*
     * TODO: Substitute xmlGetProp() for xmlGetNsProp(), since the former
     * is not namespace-aware and will return an attribute with equal
@@ -190,23 +190,23 @@ xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace) {
     *   in the XSLT was requested.
     */
     while (prop != NULL) {
-    /*
-     * One need to have
-     *   - same attribute names
-     *   - and the attribute carrying that namespace
-     */
+        /*
+         * One need to have
+         *   - same attribute names
+         *   - and the attribute carrying that namespace
+         */
         if ((xmlStrEqual(prop->name, name)) &&
-        (((prop->ns == NULL) && (node->ns != NULL) &&
-          (xmlStrEqual(node->ns->href, nameSpace))) ||
-         ((prop->ns != NULL) &&
-          (xmlStrEqual(prop->ns->href, nameSpace))))) {
-        xmlChar *ret;
+            (((prop->ns == NULL) && (node->ns != NULL) &&
+              (xmlStrEqual(node->ns->href, nameSpace))) ||
+             ((prop->ns != NULL) &&
+              (xmlStrEqual(prop->ns->href, nameSpace))))) {
+            xmlChar *ret;
 
-        ret = xmlNodeListGetString(node->doc, prop->children, 1);
-        if (ret == NULL) return(xmlStrdup((xmlChar *)""));
-        return(ret);
+            ret = xmlNodeListGetString(node->doc, prop->children, 1);
+            if (ret == NULL) return(xmlStrdup((xmlChar *)""));
+            return(ret);
         }
-    prop = prop->next;
+        prop = prop->next;
     }
 
     /*
@@ -216,21 +216,21 @@ xsltGetNsProp(xmlNodePtr node, const xmlChar *name, const xmlChar *nameSpace) {
     doc =  node->doc;
     if (doc != NULL) {
         if (doc->intSubset != NULL) {
-        xmlAttributePtr attrDecl;
+            xmlAttributePtr attrDecl;
 
-        attrDecl = xmlGetDtdAttrDesc(doc->intSubset, node->name, name);
-        if ((attrDecl == NULL) && (doc->extSubset != NULL))
-        attrDecl = xmlGetDtdAttrDesc(doc->extSubset, node->name, name);
+            attrDecl = xmlGetDtdAttrDesc(doc->intSubset, node->name, name);
+            if ((attrDecl == NULL) && (doc->extSubset != NULL))
+                attrDecl = xmlGetDtdAttrDesc(doc->extSubset, node->name, name);
 
-        if ((attrDecl != NULL) && (attrDecl->prefix != NULL)) {
-            /*
-         * The DTD declaration only allows a prefix search
-         */
-        ns = xmlSearchNs(doc, node, attrDecl->prefix);
-        if ((ns != NULL) && (xmlStrEqual(ns->href, nameSpace)))
-            return(xmlStrdup(attrDecl->defaultValue));
+            if ((attrDecl != NULL) && (attrDecl->prefix != NULL)) {
+                /*
+                 * The DTD declaration only allows a prefix search
+                 */
+                ns = xmlSearchNs(doc, node, attrDecl->prefix);
+                if ((ns != NULL) && (xmlStrEqual(ns->href, nameSpace)))
+                    return(xmlStrdup(attrDecl->defaultValue));
+            }
         }
-    }
     }
     return(NULL);
 }
@@ -252,56 +252,56 @@ xsltGetUTF8Char(const unsigned char *utf, int *len) {
     unsigned int c;
 
     if (utf == NULL)
-    goto error;
+        goto error;
     if (len == NULL)
-    goto error;
+        goto error;
     if (*len < 1)
-    goto error;
+        goto error;
 
     c = utf[0];
     if (c & 0x80) {
-    if (*len < 2)
-        goto error;
-    if ((utf[1] & 0xc0) != 0x80)
-        goto error;
-    if ((c & 0xe0) == 0xe0) {
-        if (*len < 3)
-        goto error;
-        if ((utf[2] & 0xc0) != 0x80)
-        goto error;
-        if ((c & 0xf0) == 0xf0) {
-        if (*len < 4)
+        if (*len < 2)
             goto error;
-        if ((c & 0xf8) != 0xf0 || (utf[3] & 0xc0) != 0x80)
+        if ((utf[1] & 0xc0) != 0x80)
             goto error;
-        *len = 4;
-        /* 4-byte code */
-        c = (utf[0] & 0x7) << 18;
-        c |= (utf[1] & 0x3f) << 12;
-        c |= (utf[2] & 0x3f) << 6;
-        c |= utf[3] & 0x3f;
+        if ((c & 0xe0) == 0xe0) {
+            if (*len < 3)
+                goto error;
+            if ((utf[2] & 0xc0) != 0x80)
+                goto error;
+            if ((c & 0xf0) == 0xf0) {
+                if (*len < 4)
+                    goto error;
+                if ((c & 0xf8) != 0xf0 || (utf[3] & 0xc0) != 0x80)
+                    goto error;
+                *len = 4;
+                /* 4-byte code */
+                c = (utf[0] & 0x7) << 18;
+                c |= (utf[1] & 0x3f) << 12;
+                c |= (utf[2] & 0x3f) << 6;
+                c |= utf[3] & 0x3f;
+            } else {
+              /* 3-byte code */
+                *len = 3;
+                c = (utf[0] & 0xf) << 12;
+                c |= (utf[1] & 0x3f) << 6;
+                c |= utf[2] & 0x3f;
+            }
         } else {
-          /* 3-byte code */
-        *len = 3;
-        c = (utf[0] & 0xf) << 12;
-        c |= (utf[1] & 0x3f) << 6;
-        c |= utf[2] & 0x3f;
+          /* 2-byte code */
+            *len = 2;
+            c = (utf[0] & 0x1f) << 6;
+            c |= utf[1] & 0x3f;
         }
     } else {
-      /* 2-byte code */
-        *len = 2;
-        c = (utf[0] & 0x1f) << 6;
-        c |= utf[1] & 0x3f;
-    }
-    } else {
-    /* 1-byte code */
-    *len = 1;
+        /* 1-byte code */
+        *len = 1;
     }
     return(c);
 
 error:
     if (len != NULL)
-    *len = 0;
+        *len = 0;
     return(-1);
 }
 
@@ -320,31 +320,31 @@ error:
  */
 int
 xsltPointerListAddSize(xsltPointerListPtr list,
-               void *item,
-               int initialSize)
+                       void *item,
+                       int initialSize)
 {
     if (list->items == NULL) {
-    if (initialSize <= 0)
-        initialSize = 1;
-    list->items = (void **) xmlMalloc(
-        initialSize * sizeof(void *));
-    if (list->items == NULL) {
-        xsltGenericError(xsltGenericErrorContext,
-         "xsltPointerListAddSize: memory allocation failure.\n");
-        return(-1);
-    }
-    list->number = 0;
-    list->size = initialSize;
+        if (initialSize <= 0)
+            initialSize = 1;
+        list->items = (void **) xmlMalloc(
+            initialSize * sizeof(void *));
+        if (list->items == NULL) {
+            xsltGenericError(xsltGenericErrorContext,
+             "xsltPointerListAddSize: memory allocation failure.\n");
+            return(-1);
+        }
+        list->number = 0;
+        list->size = initialSize;
     } else if (list->size <= list->number) {
-    list->size *= 2;
-    list->items = (void **) xmlRealloc(list->items,
-        list->size * sizeof(void *));
-    if (list->items == NULL) {
-        xsltGenericError(xsltGenericErrorContext,
-         "xsltPointerListAddSize: memory re-allocation failure.\n");
-        list->size = 0;
-        return(-1);
-    }
+        list->size *= 2;
+        list->items = (void **) xmlRealloc(list->items,
+            list->size * sizeof(void *));
+        if (list->items == NULL) {
+            xsltGenericError(xsltGenericErrorContext,
+             "xsltPointerListAddSize: memory re-allocation failure.\n");
+            list->size = 0;
+            return(-1);
+        }
     }
     list->items[list->number++] = item;
     return(0);
@@ -365,14 +365,14 @@ xsltPointerListCreate(int initialSize)
 
     ret = xmlMalloc(sizeof(xsltPointerList));
     if (ret == NULL) {
-    xsltGenericError(xsltGenericErrorContext,
-         "xsltPointerListCreate: memory allocation failure.\n");
-    return (NULL);
+        xsltGenericError(xsltGenericErrorContext,
+             "xsltPointerListCreate: memory allocation failure.\n");
+        return (NULL);
     }
     memset(ret, 0, sizeof(xsltPointerList));
     if (initialSize > 0) {
-    xsltPointerListAddSize(ret, NULL, initialSize);
-    ret->number = 0;
+        xsltPointerListAddSize(ret, NULL, initialSize);
+        ret->number = 0;
     }
     return (ret);
 }
@@ -388,9 +388,9 @@ void
 xsltPointerListFree(xsltPointerListPtr list)
 {
     if (list == NULL)
-    return;
+        return;
     if (list->items != NULL)
-    xmlFree(list->items);
+        xmlFree(list->items);
     xmlFree(list);
 }
 
@@ -405,8 +405,8 @@ void
 xsltPointerListClear(xsltPointerListPtr list)
 {
     if (list->items != NULL) {
-    xmlFree(list->items);
-    list->items = NULL;
+        xmlFree(list->items);
+        list->items = NULL;
     }
     list->number = 0;
     list->size = 0;
@@ -415,9 +415,9 @@ xsltPointerListClear(xsltPointerListPtr list)
 #endif /* XSLT_REFACTORED */
 
 /************************************************************************
- *                                  *
- *      Handling of XSLT stylesheets messages           *
- *                                  *
+ *                                                                      *
+ *              Handling of XSLT stylesheets messages                   *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -436,72 +436,72 @@ xsltMessage(xsltTransformContextPtr ctxt, xmlNodePtr node, xmlNodePtr inst) {
     int terminate = 0;
 
     if ((ctxt == NULL) || (inst == NULL))
-    return;
+        return;
 
     if (ctxt->error != NULL) {
-    error = ctxt->error;
-    errctx = ctxt->errctx;
+        error = ctxt->error;
+        errctx = ctxt->errctx;
     }
 
     prop = xmlGetNsProp(inst, (const xmlChar *)"terminate", NULL);
     if (prop != NULL) {
-    if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
-        terminate = 1;
-    } else if (xmlStrEqual(prop, (const xmlChar *)"no")) {
-        terminate = 0;
-    } else {
-        xsltTransformError(ctxt, NULL, inst,
-        "xsl:message : terminate expecting 'yes' or 'no'\n");
-    }
-    xmlFree(prop);
+        if (xmlStrEqual(prop, (const xmlChar *)"yes")) {
+            terminate = 1;
+        } else if (xmlStrEqual(prop, (const xmlChar *)"no")) {
+            terminate = 0;
+        } else {
+            xsltTransformError(ctxt, NULL, inst,
+                "xsl:message : terminate expecting 'yes' or 'no'\n");
+        }
+        xmlFree(prop);
     }
     message = xsltEvalTemplateString(ctxt, node, inst);
     if (message != NULL) {
-    int len = xmlStrlen(message);
+        int len = xmlStrlen(message);
 
-    error(errctx, "%s", (const char *)message);
-    if ((len > 0) && (message[len - 1] != '\n'))
-        error(errctx, "\n");
-    xmlFree(message);
+        error(errctx, "%s", (const char *)message);
+        if ((len > 0) && (message[len - 1] != '\n'))
+            error(errctx, "\n");
+        xmlFree(message);
     }
     if (terminate)
-    ctxt->state = XSLT_STATE_STOPPED;
+        ctxt->state = XSLT_STATE_STOPPED;
 }
 
 /************************************************************************
- *                                  *
- *      Handling of out of context errors           *
- *                                  *
+ *                                                                      *
+ *              Handling of out of context errors                       *
+ *                                                                      *
  ************************************************************************/
 
-#define XSLT_GET_VAR_STR(msg, str) {                \
-    int       size;                     \
-    int       chars;                        \
-    char      *larger;                      \
-    va_list   ap;                       \
-                                \
-    str = (char *) xmlMalloc(150);              \
-    if (str == NULL)                        \
-    return;                         \
-                                \
-    size = 150;                         \
-                                \
-    while (size < 64000) {                  \
-    va_start(ap, msg);                  \
-    chars = vsnprintf(str, size, msg, ap);          \
-    va_end(ap);                     \
-    if ((chars > -1) && (chars < size))         \
-        break;                      \
-    if (chars > -1)                     \
-        size += chars + 1;                  \
-    else                            \
-        size += 100;                    \
-    if ((larger = (char *) xmlRealloc(str, size)) == NULL) {\
-        xmlFree(str);                   \
-        return;                     \
-    }                           \
-    str = larger;                       \
-    }                               \
+#define XSLT_GET_VAR_STR(msg, str) {                            \
+    int       size;                                             \
+    int       chars;                                            \
+    char      *larger;                                          \
+    va_list   ap;                                               \
+                                                                \
+    str = (char *) xmlMalloc(150);                              \
+    if (str == NULL)                                            \
+        return;                                                 \
+                                                                \
+    size = 150;                                                 \
+                                                                \
+    while (size < 64000) {                                      \
+        va_start(ap, msg);                                      \
+        chars = vsnprintf(str, size, msg, ap);                  \
+        va_end(ap);                                             \
+        if ((chars > -1) && (chars < size))                     \
+            break;                                              \
+        if (chars > -1)                                         \
+            size += chars + 1;                                  \
+        else                                                    \
+            size += 100;                                        \
+        if ((larger = (char *) xmlRealloc(str, size)) == NULL) {\
+            xmlFree(str);                                       \
+            return;                                             \
+        }                                                       \
+        str = larger;                                           \
+    }                                                           \
 }
 /**
  * xsltGenericErrorDefaultFunc:
@@ -516,7 +516,7 @@ xsltGenericErrorDefaultFunc(void *ctx ATTRIBUTE_UNUSED, const char *msg, ...) {
     va_list args;
 
     if (xsltGenericErrorContext == NULL)
-    xsltGenericErrorContext = (void *) stderr;
+        xsltGenericErrorContext = (void *) stderr;
 
     va_start(args, msg);
     vfprintf((FILE *)xsltGenericErrorContext, msg, args);
@@ -544,9 +544,9 @@ void
 xsltSetGenericErrorFunc(void *ctx, xmlGenericErrorFunc handler) {
     xsltGenericErrorContext = ctx;
     if (handler != NULL)
-    xsltGenericError = handler;
+        xsltGenericError = handler;
     else
-    xsltGenericError = xsltGenericErrorDefaultFunc;
+        xsltGenericError = xsltGenericErrorDefaultFunc;
 }
 
 /**
@@ -562,7 +562,7 @@ xsltGenericDebugDefaultFunc(void *ctx ATTRIBUTE_UNUSED, const char *msg, ...) {
     va_list args;
 
     if (xsltGenericDebugContext == NULL)
-    return;
+        return;
 
     va_start(args, msg);
     vfprintf((FILE *)xsltGenericDebugContext, msg, args);
@@ -590,9 +590,9 @@ void
 xsltSetGenericDebugFunc(void *ctx, xmlGenericErrorFunc handler) {
     xsltGenericDebugContext = ctx;
     if (handler != NULL)
-    xsltGenericDebug = handler;
+        xsltGenericDebug = handler;
     else
-    xsltGenericDebug = xsltGenericDebugDefaultFunc;
+        xsltGenericDebug = xsltGenericDebugDefaultFunc;
 }
 
 /**
@@ -605,7 +605,7 @@ xsltSetGenericDebugFunc(void *ctx, xmlGenericErrorFunc handler) {
  */
 void
 xsltPrintErrorContext(xsltTransformContextPtr ctxt,
-                  xsltStylesheetPtr style, xmlNodePtr node) {
+                      xsltStylesheetPtr style, xmlNodePtr node) {
     int line = 0;
     const xmlChar *file = NULL;
     const xmlChar *name = NULL;
@@ -615,56 +615,56 @@ xsltPrintErrorContext(xsltTransformContextPtr ctxt,
 
     if (ctxt != NULL) {
         if (ctxt->state == XSLT_STATE_OK)
-        ctxt->state = XSLT_STATE_ERROR;
-    if (ctxt->error != NULL) {
-        error = ctxt->error;
-        errctx = ctxt->errctx;
-    }
+            ctxt->state = XSLT_STATE_ERROR;
+        if (ctxt->error != NULL) {
+            error = ctxt->error;
+            errctx = ctxt->errctx;
+        }
     }
     if ((node == NULL) && (ctxt != NULL))
-    node = ctxt->inst;
+        node = ctxt->inst;
 
     if (node != NULL)  {
-    if ((node->type == XML_DOCUMENT_NODE) ||
-        (node->type == XML_HTML_DOCUMENT_NODE)) {
-        xmlDocPtr doc = (xmlDocPtr) node;
+        if ((node->type == XML_DOCUMENT_NODE) ||
+            (node->type == XML_HTML_DOCUMENT_NODE)) {
+            xmlDocPtr doc = (xmlDocPtr) node;
 
-        file = doc->URL;
-    } else {
-        line = xmlGetLineNo(node);
-        if ((node->doc != NULL) && (node->doc->URL != NULL))
-        file = node->doc->URL;
-        if (node->name != NULL)
-        name = node->name;
-    }
+            file = doc->URL;
+        } else {
+            line = xmlGetLineNo(node);
+            if ((node->doc != NULL) && (node->doc->URL != NULL))
+                file = node->doc->URL;
+            if (node->name != NULL)
+                name = node->name;
+        }
     }
 
     if (ctxt != NULL)
-    type = "runtime error";
+        type = "runtime error";
     else if (style != NULL) {
 #ifdef XSLT_REFACTORED
-    if (XSLT_CCTXT(style)->errSeverity == XSLT_ERROR_SEVERITY_WARNING)
-        type = "compilation warning";
-    else
-        type = "compilation error";
+        if (XSLT_CCTXT(style)->errSeverity == XSLT_ERROR_SEVERITY_WARNING)
+            type = "compilation warning";
+        else
+            type = "compilation error";
 #else
-    type = "compilation error";
+        type = "compilation error";
 #endif
     }
 
     if ((file != NULL) && (line != 0) && (name != NULL))
-    error(errctx, "%s: file %s line %d element %s\n",
-          type, file, line, name);
+        error(errctx, "%s: file %s line %d element %s\n",
+              type, file, line, name);
     else if ((file != NULL) && (name != NULL))
-    error(errctx, "%s: file %s element %s\n", type, file, name);
+        error(errctx, "%s: file %s element %s\n", type, file, name);
     else if ((file != NULL) && (line != 0))
-    error(errctx, "%s: file %s line %d\n", type, file, line);
+        error(errctx, "%s: file %s line %d\n", type, file, line);
     else if (file != NULL)
-    error(errctx, "%s: file %s\n", type, file);
+        error(errctx, "%s: file %s\n", type, file);
     else if (name != NULL)
-    error(errctx, "%s: element %s\n", type, name);
+        error(errctx, "%s: element %s\n", type, name);
     else
-    error(errctx, "%s\n", type);
+        error(errctx, "%s\n", type);
 }
 
 /**
@@ -700,34 +700,34 @@ xsltSetTransformErrorFunc(xsltTransformContextPtr ctxt,
  */
 void
 xsltTransformError(xsltTransformContextPtr ctxt,
-           xsltStylesheetPtr style,
-           xmlNodePtr node,
-           const char *msg, ...) {
+                   xsltStylesheetPtr style,
+                   xmlNodePtr node,
+                   const char *msg, ...) {
     xmlGenericErrorFunc error = xsltGenericError;
     void *errctx = xsltGenericErrorContext;
     char * str;
 
     if (ctxt != NULL) {
         if (ctxt->state == XSLT_STATE_OK)
-        ctxt->state = XSLT_STATE_ERROR;
-    if (ctxt->error != NULL) {
-        error = ctxt->error;
-        errctx = ctxt->errctx;
-    }
+            ctxt->state = XSLT_STATE_ERROR;
+        if (ctxt->error != NULL) {
+            error = ctxt->error;
+            errctx = ctxt->errctx;
+        }
     }
     if ((node == NULL) && (ctxt != NULL))
-    node = ctxt->inst;
+        node = ctxt->inst;
     xsltPrintErrorContext(ctxt, style, node);
     XSLT_GET_VAR_STR(msg, str);
     error(errctx, "%s", str);
     if (str != NULL)
-    xmlFree(str);
+        xmlFree(str);
 }
 
 /************************************************************************
- *                                  *
- *              QNames                  *
- *                                  *
+ *                                                                      *
+ *                              QNames                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -781,54 +781,54 @@ xsltGetQNameURI(xmlNodePtr node, xmlChar ** name)
     xmlNsPtr ns;
 
     if (name == NULL)
-    return(NULL);
+        return(NULL);
     qname = *name;
     if ((qname == NULL) || (*qname == 0))
-    return(NULL);
+        return(NULL);
     if (node == NULL) {
-    xsltGenericError(xsltGenericErrorContext,
-                 "QName: no element for namespace lookup %s\n",
-             qname);
-    xmlFree(qname);
-    *name = NULL;
-    return(NULL);
+        xsltGenericError(xsltGenericErrorContext,
+                         "QName: no element for namespace lookup %s\n",
+                         qname);
+        xmlFree(qname);
+        *name = NULL;
+        return(NULL);
     }
 
     /* nasty but valid */
     if (qname[0] == ':')
-    return(NULL);
+        return(NULL);
 
     /*
      * we are not trying to validate but just to cut, and yes it will
      * work even if this is a set of UTF-8 encoded chars
      */
     while ((qname[len] != 0) && (qname[len] != ':'))
-    len++;
+        len++;
 
     if (qname[len] == 0)
-    return(NULL);
+        return(NULL);
 
     /*
      * handle xml: separately, this one is magical
      */
     if ((qname[0] == 'x') && (qname[1] == 'm') &&
         (qname[2] == 'l') && (qname[3] == ':')) {
-    if (qname[4] == 0)
-        return(NULL);
+        if (qname[4] == 0)
+            return(NULL);
         *name = xmlStrdup(&qname[4]);
-    xmlFree(qname);
-    return(XML_XML_NAMESPACE);
+        xmlFree(qname);
+        return(XML_XML_NAMESPACE);
     }
 
     qname[len] = 0;
     ns = xmlSearchNs(node->doc, node, qname);
     if (ns == NULL) {
-    xsltGenericError(xsltGenericErrorContext,
-        "%s:%s : no namespace bound to prefix %s\n",
-                 qname, &qname[len + 1], qname);
-    *name = NULL;
-    xmlFree(qname);
-    return(NULL);
+        xsltGenericError(xsltGenericErrorContext,
+                "%s:%s : no namespace bound to prefix %s\n",
+                         qname, &qname[len + 1], qname);
+        *name = NULL;
+        xmlFree(qname);
+        return(NULL);
     }
     *name = xmlStrdup(&qname[len + 1]);
     xmlFree(qname);
@@ -849,7 +849,7 @@ xsltGetQNameURI(xmlNodePtr node, xmlChar ** name)
  */
 const xmlChar *
 xsltGetQNameURI2(xsltStylesheetPtr style, xmlNodePtr node,
-         const xmlChar **name) {
+                 const xmlChar **name) {
     int len = 0;
     xmlChar *qname;
     xmlNsPtr ns;
@@ -863,8 +863,8 @@ xsltGetQNameURI2(xsltStylesheetPtr style, xmlNodePtr node,
         xsltGenericError(xsltGenericErrorContext,
                          "QName: no element for namespace lookup %s\n",
                           qname);
-    *name = NULL;
-    return(NULL);
+        *name = NULL;
+        return(NULL);
     }
 
     /*
@@ -891,16 +891,16 @@ xsltGetQNameURI2(xsltStylesheetPtr style, xmlNodePtr node,
     qname = xmlStrndup(*name, len);
     ns = xmlSearchNs(node->doc, node, qname);
     if (ns == NULL) {
-    if (style) {
-        xsltTransformError(NULL, style, node,
-        "No namespace bound to prefix '%s'.\n",
-        qname);
-        style->errors++;
-    } else {
-        xsltGenericError(xsltGenericErrorContext,
+        if (style) {
+            xsltTransformError(NULL, style, node,
+                "No namespace bound to prefix '%s'.\n",
+                qname);
+            style->errors++;
+        } else {
+            xsltGenericError(xsltGenericErrorContext,
                 "%s : no namespace bound to prefix %s\n",
-        *name, qname);
-    }
+                *name, qname);
+        }
         *name = NULL;
         xmlFree(qname);
         return(NULL);
@@ -911,9 +911,9 @@ xsltGetQNameURI2(xsltStylesheetPtr style, xmlNodePtr node,
 }
 
 /************************************************************************
- *                                  *
- *              Sorting                 *
- *                                  *
+ *                                                                      *
+ *                              Sorting                                 *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -930,35 +930,37 @@ xsltDocumentSortFunction(xmlNodeSetPtr list) {
     xmlNodePtr node;
 
     if (list == NULL)
-    return;
+        return;
     len = list->nodeNr;
     if (len <= 1)
-    return;
+        return;
     /* TODO: sort is really not optimized, does it needs to ? */
     for (i = 0;i < len -1;i++) {
-    for (j = i + 1; j < len; j++) {
-        tst = xmlXPathCmpNodes(list->nodeTab[i], list->nodeTab[j]);
-        if (tst == -1) {
-        node = list->nodeTab[i];
-        list->nodeTab[i] = list->nodeTab[j];
-        list->nodeTab[j] = node;
+        for (j = i + 1; j < len; j++) {
+            tst = xmlXPathCmpNodes(list->nodeTab[i], list->nodeTab[j]);
+            if (tst == -1) {
+                node = list->nodeTab[i];
+                list->nodeTab[i] = list->nodeTab[j];
+                list->nodeTab[j] = node;
+            }
         }
-    }
     }
 }
 
 /**
- * xsltComputeSortResult:
+ * xsltComputeSortResultiInternal:
  * @ctxt:  a XSLT process context
  * @sort:  node list
+ * @xfrm:  Transform strings according to locale
  *
  * reorder the current node list accordingly to the set of sorting
  * requirement provided by the array of nodes.
  *
  * Returns a ordered XPath nodeset or NULL in case of error.
  */
-xmlXPathObjectPtr *
-xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
+static xmlXPathObjectPtr *
+xsltComputeSortResultInternal(xsltTransformContextPtr ctxt, xmlNodePtr sort,
+                              int xfrm) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemSortPtr comp;
 #else
@@ -977,17 +979,17 @@ xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
 
     comp = sort->psvi;
     if (comp == NULL) {
-    xsltGenericError(xsltGenericErrorContext,
-         "xsl:sort : compilation failed\n");
-    return(NULL);
+        xsltGenericError(xsltGenericErrorContext,
+             "xsl:sort : compilation failed\n");
+        return(NULL);
     }
 
     if ((comp->select == NULL) || (comp->comp == NULL))
-    return(NULL);
+        return(NULL);
 
     list = ctxt->nodeList;
     if ((list == NULL) || (list->nodeNr <= 1))
-    return(NULL);
+        return(NULL);
 
     len = list->nodeNr;
 
@@ -997,9 +999,9 @@ xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
 
     results = xmlMalloc(len * sizeof(xmlXPathObjectPtr));
     if (results == NULL) {
-    xsltGenericError(xsltGenericErrorContext,
-         "xsltComputeSortResult: memory allocation failure\n");
-    return(NULL);
+        xsltGenericError(xsltGenericErrorContext,
+             "xsltComputeSortResult: memory allocation failure\n");
+        return(NULL);
     }
 
     oldNode = ctxt->node;
@@ -1009,61 +1011,61 @@ xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
     oldNsNr = ctxt->xpathCtxt->nsNr;
     oldNamespaces = ctxt->xpathCtxt->namespaces;
     for (i = 0;i < len;i++) {
-    ctxt->inst = sort;
-    ctxt->xpathCtxt->contextSize = len;
-    ctxt->xpathCtxt->proximityPosition = i + 1;
-    ctxt->node = list->nodeTab[i];
-    ctxt->xpathCtxt->node = ctxt->node;
+        ctxt->inst = sort;
+        ctxt->xpathCtxt->contextSize = len;
+        ctxt->xpathCtxt->proximityPosition = i + 1;
+        ctxt->node = list->nodeTab[i];
+        ctxt->xpathCtxt->node = ctxt->node;
 #ifdef XSLT_REFACTORED
-    if (comp->inScopeNs != NULL) {
-        ctxt->xpathCtxt->namespaces = comp->inScopeNs->list;
-        ctxt->xpathCtxt->nsNr = comp->inScopeNs->xpathNumber;
-    } else {
-        ctxt->xpathCtxt->namespaces = NULL;
-        ctxt->xpathCtxt->nsNr = 0;
-    }
+        if (comp->inScopeNs != NULL) {
+            ctxt->xpathCtxt->namespaces = comp->inScopeNs->list;
+            ctxt->xpathCtxt->nsNr = comp->inScopeNs->xpathNumber;
+        } else {
+            ctxt->xpathCtxt->namespaces = NULL;
+            ctxt->xpathCtxt->nsNr = 0;
+        }
 #else
-    ctxt->xpathCtxt->namespaces = comp->nsList;
-    ctxt->xpathCtxt->nsNr = comp->nsNr;
+        ctxt->xpathCtxt->namespaces = comp->nsList;
+        ctxt->xpathCtxt->nsNr = comp->nsNr;
 #endif
-    res = xmlXPathCompiledEval(comp->comp, ctxt->xpathCtxt);
-    if (res != NULL) {
-        if (res->type != XPATH_STRING)
-        res = xmlXPathConvertString(res);
-        if (comp->number)
-        res = xmlXPathConvertNumber(res);
-        res->index = i; /* Save original pos for dupl resolv */
-        if (comp->number) {
-        if (res->type == XPATH_NUMBER) {
-            results[i] = res;
-        } else {
+        res = xmlXPathCompiledEval(comp->comp, ctxt->xpathCtxt);
+        if (res != NULL) {
+            if (res->type != XPATH_STRING)
+                res = xmlXPathConvertString(res);
+            if (comp->number)
+                res = xmlXPathConvertNumber(res);
+            res->index = i;     /* Save original pos for dupl resolv */
+            if (comp->number) {
+                if (res->type == XPATH_NUMBER) {
+                    results[i] = res;
+                } else {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltComputeSortResult: select didn't evaluate to a number\n");
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltComputeSortResult: select didn't evaluate to a number\n");
 #endif
-            results[i] = NULL;
-        }
-        } else {
-        if (res->type == XPATH_STRING) {
-            if (comp->locale != (xsltLocale)0) {
-            xmlChar *str = res->stringval;
-            res->stringval = (xmlChar *) xsltStrxfrm(comp->locale, str);
-            xmlFree(str);
-            }
+                    results[i] = NULL;
+                }
+            } else {
+                if (res->type == XPATH_STRING) {
+                    if ((xfrm) && (comp->locale != (xsltLocale)0)) {
+                        xmlChar *str = res->stringval;
+                        res->stringval = (xmlChar *) xsltStrxfrm(comp->locale, str);
+                        xmlFree(str);
+                    }
 
-            results[i] = res;
-        } else {
+                    results[i] = res;
+                } else {
 #ifdef WITH_XSLT_DEBUG_PROCESS
-            xsltGenericDebug(xsltGenericDebugContext,
-            "xsltComputeSortResult: select didn't evaluate to a string\n");
+                    xsltGenericDebug(xsltGenericDebugContext,
+                        "xsltComputeSortResult: select didn't evaluate to a string\n");
 #endif
+                    results[i] = NULL;
+                }
+            }
+        } else {
+            ctxt->state = XSLT_STATE_STOPPED;
             results[i] = NULL;
         }
-        }
-    } else {
-        ctxt->state = XSLT_STATE_STOPPED;
-        results[i] = NULL;
-    }
     }
     ctxt->node = oldNode;
     ctxt->inst = oldInst;
@@ -1073,6 +1075,21 @@ xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
     ctxt->xpathCtxt->namespaces = oldNamespaces;
 
     return(results);
+}
+
+/**
+ * xsltComputeSortResult:
+ * @ctxt:  a XSLT process context
+ * @sort:  node list
+ *
+ * reorder the current node list accordingly to the set of sorting
+ * requirement provided by the array of nodes.
+ *
+ * Returns a ordered XPath nodeset or NULL in case of error.
+ */
+xmlXPathObjectPtr *
+xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
+    return xsltComputeSortResultInternal(ctxt, sort, /* xfrm */ 0);
 }
 
 /**
@@ -1086,7 +1103,7 @@ xsltComputeSortResult(xsltTransformContextPtr ctxt, xmlNodePtr sort) {
  */
 void
 xsltDefaultSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts,
-               int nbsorts) {
+                   int nbsorts) {
 #ifdef XSLT_REFACTORED
     xsltStyleItemSortPtr comp;
 #else
@@ -1102,70 +1119,83 @@ xsltDefaultSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts,
     int depth;
     xmlNodePtr node;
     xmlXPathObjectPtr tmp;
-    int tempstype[XSLT_MAX_SORT], temporder[XSLT_MAX_SORT];
+    int tempstype[XSLT_MAX_SORT], temporder[XSLT_MAX_SORT],
+        templang[XSLT_MAX_SORT];
 
     if ((ctxt == NULL) || (sorts == NULL) || (nbsorts <= 0) ||
-    (nbsorts >= XSLT_MAX_SORT))
-    return;
+        (nbsorts >= XSLT_MAX_SORT))
+        return;
     if (sorts[0] == NULL)
-    return;
+        return;
     comp = sorts[0]->psvi;
     if (comp == NULL)
-    return;
+        return;
 
     list = ctxt->nodeList;
     if ((list == NULL) || (list->nodeNr <= 1))
-    return; /* nothing to do */
+        return; /* nothing to do */
 
     for (j = 0; j < nbsorts; j++) {
-    comp = sorts[j]->psvi;
-    tempstype[j] = 0;
-    if ((comp->stype == NULL) && (comp->has_stype != 0)) {
-        comp->stype =
-        xsltEvalAttrValueTemplate(ctxt, sorts[j],
-                      (const xmlChar *) "data-type",
-                      XSLT_NAMESPACE);
-        if (comp->stype != NULL) {
-        tempstype[j] = 1;
-        if (xmlStrEqual(comp->stype, (const xmlChar *) "text"))
-            comp->number = 0;
-        else if (xmlStrEqual(comp->stype, (const xmlChar *) "number"))
-            comp->number = 1;
-        else {
-            xsltTransformError(ctxt, NULL, sorts[j],
-              "xsltDoSortFunction: no support for data-type = %s\n",
-                     comp->stype);
-            comp->number = 0; /* use default */
+        comp = sorts[j]->psvi;
+        tempstype[j] = 0;
+        if ((comp->stype == NULL) && (comp->has_stype != 0)) {
+            comp->stype =
+                xsltEvalAttrValueTemplate(ctxt, sorts[j],
+                                          (const xmlChar *) "data-type",
+                                          NULL);
+            if (comp->stype != NULL) {
+                tempstype[j] = 1;
+                if (xmlStrEqual(comp->stype, (const xmlChar *) "text"))
+                    comp->number = 0;
+                else if (xmlStrEqual(comp->stype, (const xmlChar *) "number"))
+                    comp->number = 1;
+                else {
+                    xsltTransformError(ctxt, NULL, sorts[j],
+                          "xsltDoSortFunction: no support for data-type = %s\n",
+                                     comp->stype);
+                    comp->number = 0; /* use default */
+                }
+            }
         }
+        temporder[j] = 0;
+        if ((comp->order == NULL) && (comp->has_order != 0)) {
+            comp->order = xsltEvalAttrValueTemplate(ctxt, sorts[j],
+                                                    (const xmlChar *) "order",
+                                                    NULL);
+            if (comp->order != NULL) {
+                temporder[j] = 1;
+                if (xmlStrEqual(comp->order, (const xmlChar *) "ascending"))
+                    comp->descending = 0;
+                else if (xmlStrEqual(comp->order,
+                                     (const xmlChar *) "descending"))
+                    comp->descending = 1;
+                else {
+                    xsltTransformError(ctxt, NULL, sorts[j],
+                             "xsltDoSortFunction: invalid value %s for order\n",
+                                     comp->order);
+                    comp->descending = 0; /* use default */
+                }
+            }
         }
-    }
-    temporder[j] = 0;
-    if ((comp->order == NULL) && (comp->has_order != 0)) {
-        comp->order = xsltEvalAttrValueTemplate(ctxt, sorts[j],
-                            (const xmlChar *) "order",
-                            XSLT_NAMESPACE);
-        if (comp->order != NULL) {
-        temporder[j] = 1;
-        if (xmlStrEqual(comp->order, (const xmlChar *) "ascending"))
-            comp->descending = 0;
-        else if (xmlStrEqual(comp->order,
-                     (const xmlChar *) "descending"))
-            comp->descending = 1;
-        else {
-            xsltTransformError(ctxt, NULL, sorts[j],
-                 "xsltDoSortFunction: invalid value %s for order\n",
-                     comp->order);
-            comp->descending = 0; /* use default */
+        templang[j] = 0;
+        if ((comp->lang == NULL) && (comp->has_lang != 0)) {
+            xmlChar *lang = xsltEvalAttrValueTemplate(ctxt, sorts[j],
+                                                      (xmlChar *) "lang",
+                                                      NULL);
+            if (lang != NULL) {
+                templang[j] = 1;
+                comp->locale = xsltNewLocale(lang);
+                xmlFree(lang);
+            }
         }
-        }
-    }
     }
 
     len = list->nodeNr;
 
-    resultsTab[0] = xsltComputeSortResult(ctxt, sorts[0]);
+    resultsTab[0] = xsltComputeSortResultInternal(ctxt, sorts[0],
+                                                  /* xfrm */ 1);
     for (i = 1;i < XSLT_MAX_SORT;i++)
-    resultsTab[i] = NULL;
+        resultsTab[i] = NULL;
 
     results = resultsTab[0];
 
@@ -1173,165 +1203,172 @@ xsltDefaultSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr *sorts,
     descending = comp->descending;
     number = comp->number;
     if (results == NULL)
-    return;
+        goto cleanup;
 
     /* Shell's sort of node-set */
     for (incr = len / 2; incr > 0; incr /= 2) {
-    for (i = incr; i < len; i++) {
-        j = i - incr;
-        if (results[i] == NULL)
-        continue;
+        for (i = incr; i < len; i++) {
+            j = i - incr;
+            if (results[i] == NULL)
+                continue;
 
-        while (j >= 0) {
-        if (results[j] == NULL)
-            tst = 1;
-        else {
-            if (number) {
-            /* We make NaN smaller than number in accordance
-               with XSLT spec */
-            if (xmlXPathIsNaN(results[j]->floatval)) {
-                if (xmlXPathIsNaN(results[j + incr]->floatval))
-                tst = 0;
-                else
-                tst = -1;
-            } else if (xmlXPathIsNaN(results[j + incr]->floatval))
-                tst = 1;
-            else if (results[j]->floatval ==
-                results[j + incr]->floatval)
-                tst = 0;
-            else if (results[j]->floatval >
-                results[j + incr]->floatval)
-                tst = 1;
-            else tst = -1;
-            } else if(comp->locale != (xsltLocale)0) {
-            tst = xsltLocaleStrcmp(
-                comp->locale,
-                (xsltLocaleChar *) results[j]->stringval,
-                (xsltLocaleChar *) results[j + incr]->stringval);
-            } else {
-            tst = xmlStrcmp(results[j]->stringval,
-                     results[j + incr]->stringval);
-            }
-            if (descending)
-            tst = -tst;
-        }
-        if (tst == 0) {
-            /*
-             * Okay we need to use multi level sorts
-             */
-            depth = 1;
-            while (depth < nbsorts) {
-            if (sorts[depth] == NULL)
-                break;
-            comp = sorts[depth]->psvi;
-            if (comp == NULL)
-                break;
-            desc = comp->descending;
-            numb = comp->number;
-
-            /*
-             * Compute the result of the next level for the
-             * full set, this might be optimized ... or not
-             */
-            if (resultsTab[depth] == NULL)
-                resultsTab[depth] = xsltComputeSortResult(ctxt,
-                                        sorts[depth]);
-            res = resultsTab[depth];
-            if (res == NULL)
-                break;
-            if (res[j] == NULL) {
-                if (res[j+incr] != NULL)
-                tst = 1;
-            } else if (res[j+incr] == NULL) {
-                tst = -1;
-            } else {
-                if (numb) {
-                /* We make NaN smaller than number in
-                   accordance with XSLT spec */
-                if (xmlXPathIsNaN(res[j]->floatval)) {
-                    if (xmlXPathIsNaN(res[j +
-                        incr]->floatval))
-                    tst = 0;
-                    else
-                        tst = -1;
-                } else if (xmlXPathIsNaN(res[j + incr]->
-                        floatval))
+            while (j >= 0) {
+                if (results[j] == NULL)
                     tst = 1;
-                else if (res[j]->floatval == res[j + incr]->
-                        floatval)
-                    tst = 0;
-                else if (res[j]->floatval >
-                    res[j + incr]->floatval)
-                    tst = 1;
-                else tst = -1;
-                } else if(comp->locale != (xsltLocale)0) {
-                tst = xsltLocaleStrcmp(
-                    comp->locale,
-                    (xsltLocaleChar *) res[j]->stringval,
-                    (xsltLocaleChar *) res[j + incr]->stringval);
-                } else {
-                tst = xmlStrcmp(res[j]->stringval,
-                         res[j + incr]->stringval);
+                else {
+                    if (number) {
+                        /* We make NaN smaller than number in accordance
+                           with XSLT spec */
+                        if (xmlXPathIsNaN(results[j]->floatval)) {
+                            if (xmlXPathIsNaN(results[j + incr]->floatval))
+                                tst = 0;
+                            else
+                                tst = -1;
+                        } else if (xmlXPathIsNaN(results[j + incr]->floatval))
+                            tst = 1;
+                        else if (results[j]->floatval ==
+                                results[j + incr]->floatval)
+                            tst = 0;
+                        else if (results[j]->floatval >
+                                results[j + incr]->floatval)
+                            tst = 1;
+                        else tst = -1;
+                    } else if(comp->locale != (xsltLocale)0) {
+                        tst = xsltLocaleStrcmp(
+                            comp->locale,
+                            (xsltLocaleChar *) results[j]->stringval,
+                            (xsltLocaleChar *) results[j + incr]->stringval);
+                    } else {
+                        tst = xmlStrcmp(results[j]->stringval,
+                                     results[j + incr]->stringval);
+                    }
+                    if (descending)
+                        tst = -tst;
                 }
-                if (desc)
-                tst = -tst;
-            }
+                if (tst == 0) {
+                    /*
+                     * Okay we need to use multi level sorts
+                     */
+                    depth = 1;
+                    while (depth < nbsorts) {
+                        if (sorts[depth] == NULL)
+                            break;
+                        comp = sorts[depth]->psvi;
+                        if (comp == NULL)
+                            break;
+                        desc = comp->descending;
+                        numb = comp->number;
 
-            /*
-             * if we still can't differenciate at this level
-             * try one level deeper.
-             */
-            if (tst != 0)
-                break;
-            depth++;
+                        /*
+                         * Compute the result of the next level for the
+                         * full set, this might be optimized ... or not
+                         */
+                        if (resultsTab[depth] == NULL)
+                            resultsTab[depth] =
+                                xsltComputeSortResultInternal(ctxt,
+                                                              sorts[depth],
+                                                              /* xfrm */ 1);
+                        res = resultsTab[depth];
+                        if (res == NULL)
+                            break;
+                        if (res[j] == NULL) {
+                            if (res[j+incr] != NULL)
+                                tst = 1;
+                        } else if (res[j+incr] == NULL) {
+                            tst = -1;
+                        } else {
+                            if (numb) {
+                                /* We make NaN smaller than number in
+                                   accordance with XSLT spec */
+                                if (xmlXPathIsNaN(res[j]->floatval)) {
+                                    if (xmlXPathIsNaN(res[j +
+                                                incr]->floatval))
+                                        tst = 0;
+                                    else
+                                        tst = -1;
+                                } else if (xmlXPathIsNaN(res[j + incr]->
+                                                floatval))
+                                    tst = 1;
+                                else if (res[j]->floatval == res[j + incr]->
+                                                floatval)
+                                    tst = 0;
+                                else if (res[j]->floatval >
+                                        res[j + incr]->floatval)
+                                    tst = 1;
+                                else tst = -1;
+                            } else if(comp->locale != (xsltLocale)0) {
+                                tst = xsltLocaleStrcmp(
+                                    comp->locale,
+                                    (xsltLocaleChar *) res[j]->stringval,
+                                    (xsltLocaleChar *) res[j + incr]->stringval);
+                            } else {
+                                tst = xmlStrcmp(res[j]->stringval,
+                                             res[j + incr]->stringval);
+                            }
+                            if (desc)
+                                tst = -tst;
+                        }
+
+                        /*
+                         * if we still can't differenciate at this level
+                         * try one level deeper.
+                         */
+                        if (tst != 0)
+                            break;
+                        depth++;
+                    }
+                }
+                if (tst == 0) {
+                    tst = results[j]->index > results[j + incr]->index;
+                }
+                if (tst > 0) {
+                    tmp = results[j];
+                    results[j] = results[j + incr];
+                    results[j + incr] = tmp;
+                    node = list->nodeTab[j];
+                    list->nodeTab[j] = list->nodeTab[j + incr];
+                    list->nodeTab[j + incr] = node;
+                    depth = 1;
+                    while (depth < nbsorts) {
+                        if (sorts[depth] == NULL)
+                            break;
+                        if (resultsTab[depth] == NULL)
+                            break;
+                        res = resultsTab[depth];
+                        tmp = res[j];
+                        res[j] = res[j + incr];
+                        res[j + incr] = tmp;
+                        depth++;
+                    }
+                    j -= incr;
+                } else
+                    break;
             }
-        }
-        if (tst == 0) {
-            tst = results[j]->index > results[j + incr]->index;
-        }
-        if (tst > 0) {
-            tmp = results[j];
-            results[j] = results[j + incr];
-            results[j + incr] = tmp;
-            node = list->nodeTab[j];
-            list->nodeTab[j] = list->nodeTab[j + incr];
-            list->nodeTab[j + incr] = node;
-            depth = 1;
-            while (depth < nbsorts) {
-            if (sorts[depth] == NULL)
-                break;
-            if (resultsTab[depth] == NULL)
-                break;
-            res = resultsTab[depth];
-            tmp = res[j];
-            res[j] = res[j + incr];
-            res[j + incr] = tmp;
-            depth++;
-            }
-            j -= incr;
-        } else
-            break;
         }
     }
-    }
 
+cleanup:
     for (j = 0; j < nbsorts; j++) {
-    comp = sorts[j]->psvi;
-    if (tempstype[j] == 1) {
-        /* The data-type needs to be recomputed each time */
-        xmlFree((void *)(comp->stype));
-        comp->stype = NULL;
-    }
-    if (temporder[j] == 1) {
-        /* The order needs to be recomputed each time */
-        xmlFree((void *)(comp->order));
-        comp->order = NULL;
-    }
-    if (resultsTab[j] != NULL) {
-        for (i = 0;i < len;i++)
-        xmlXPathFreeObject(resultsTab[j][i]);
-        xmlFree(resultsTab[j]);
-    }
+        comp = sorts[j]->psvi;
+        if (tempstype[j] == 1) {
+            /* The data-type needs to be recomputed each time */
+            xmlFree((void *)(comp->stype));
+            comp->stype = NULL;
+        }
+        if (temporder[j] == 1) {
+            /* The order needs to be recomputed each time */
+            xmlFree((void *)(comp->order));
+            comp->order = NULL;
+        }
+        if (templang[j] == 1) {
+            xsltFreeLocale(comp->locale);
+            comp->locale = (xsltLocale)0;
+        }
+        if (resultsTab[j] != NULL) {
+            for (i = 0;i < len;i++)
+                xmlXPathFreeObject(resultsTab[j][i]);
+            xmlFree(resultsTab[j]);
+        }
     }
 }
 
@@ -1357,7 +1394,7 @@ xsltDoSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr * sorts,
                    int nbsorts)
 {
     if (ctxt->sortfunc != NULL)
-    (ctxt->sortfunc)(ctxt, sorts, nbsorts);
+        (ctxt->sortfunc)(ctxt, sorts, nbsorts);
     else if (xsltSortFunction != NULL)
         xsltSortFunction(ctxt, sorts, nbsorts);
 }
@@ -1372,9 +1409,9 @@ xsltDoSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr * sorts,
 void
 xsltSetSortFunc(xsltSortFunc handler) {
     if (handler != NULL)
-    xsltSortFunction = handler;
+        xsltSortFunction = handler;
     else
-    xsltSortFunction = xsltDefaultSortFunction;
+        xsltSortFunction = xsltDefaultSortFunction;
 }
 
 /**
@@ -1393,9 +1430,9 @@ xsltSetCtxtSortFunc(xsltTransformContextPtr ctxt, xsltSortFunc handler) {
 }
 
 /************************************************************************
- *                                  *
- *              Parsing options             *
- *                                  *
+ *                                                                      *
+ *                              Parsing options                         *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1427,9 +1464,9 @@ xsltSetCtxtParseOptions(xsltTransformContextPtr ctxt, int options)
 }
 
 /************************************************************************
- *                                  *
- *              Output                  *
- *                                  *
+ *                                                                      *
+ *                              Output                                  *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -1445,24 +1482,24 @@ xsltSetCtxtParseOptions(xsltTransformContextPtr ctxt, int options)
  */
 int
 xsltSaveResultTo(xmlOutputBufferPtr buf, xmlDocPtr result,
-           xsltStylesheetPtr style) {
+               xsltStylesheetPtr style) {
     const xmlChar *encoding;
     int base;
     const xmlChar *method;
     int indent;
 
     if ((buf == NULL) || (result == NULL) || (style == NULL))
-    return(-1);
+        return(-1);
     if ((result->children == NULL) ||
-    ((result->children->type == XML_DTD_NODE) &&
-     (result->children->next == NULL)))
-    return(0);
+        ((result->children->type == XML_DTD_NODE) &&
+         (result->children->next == NULL)))
+        return(0);
 
     if ((style->methodURI != NULL) &&
-    ((style->method == NULL) ||
-     (!xmlStrEqual(style->method, (const xmlChar *) "xhtml")))) {
+        ((style->method == NULL) ||
+         (!xmlStrEqual(style->method, (const xmlChar *) "xhtml")))) {
         xsltGenericError(xsltGenericErrorContext,
-        "xsltSaveResultTo : unknown output method\n");
+                "xsltSaveResultTo : unknown output method\n");
         return(-1);
     }
 
@@ -1473,113 +1510,113 @@ xsltSaveResultTo(xmlOutputBufferPtr buf, xmlDocPtr result,
     XSLT_GET_IMPORT_INT(indent, style, indent);
 
     if ((method == NULL) && (result->type == XML_HTML_DOCUMENT_NODE))
-    method = (const xmlChar *) "html";
+        method = (const xmlChar *) "html";
 
     if ((method != NULL) &&
-    (xmlStrEqual(method, (const xmlChar *) "html"))) {
-    if (encoding != NULL) {
-        htmlSetMetaEncoding(result, (const xmlChar *) encoding);
-    } else {
-        htmlSetMetaEncoding(result, (const xmlChar *) "UTF-8");
-    }
-    if (indent == -1)
-        indent = 1;
-    htmlDocContentDumpFormatOutput(buf, result, (const char *) encoding,
-                               indent);
-    xmlOutputBufferFlush(buf);
-    } else if ((method != NULL) &&
-    (xmlStrEqual(method, (const xmlChar *) "xhtml"))) {
-    if (encoding != NULL) {
-        htmlSetMetaEncoding(result, (const xmlChar *) encoding);
-    } else {
-        htmlSetMetaEncoding(result, (const xmlChar *) "UTF-8");
-    }
-    htmlDocContentDumpOutput(buf, result, (const char *) encoding);
-    xmlOutputBufferFlush(buf);
-    } else if ((method != NULL) &&
-           (xmlStrEqual(method, (const xmlChar *) "text"))) {
-    xmlNodePtr cur;
-
-    cur = result->children;
-    while (cur != NULL) {
-        if (cur->type == XML_TEXT_NODE)
-        xmlOutputBufferWriteString(buf, (const char *) cur->content);
-
-        /*
-         * Skip to next node
-         */
-        if (cur->children != NULL) {
-        if ((cur->children->type != XML_ENTITY_DECL) &&
-            (cur->children->type != XML_ENTITY_REF_NODE) &&
-            (cur->children->type != XML_ENTITY_NODE)) {
-            cur = cur->children;
-            continue;
-        }
-        }
-        if (cur->next != NULL) {
-        cur = cur->next;
-        continue;
-        }
-
-        do {
-        cur = cur->parent;
-        if (cur == NULL)
-            break;
-        if (cur == (xmlNodePtr) style->doc) {
-            cur = NULL;
-            break;
-        }
-        if (cur->next != NULL) {
-            cur = cur->next;
-            break;
-        }
-        } while (cur != NULL);
-    }
-    xmlOutputBufferFlush(buf);
-    } else {
-    int omitXmlDecl;
-    int standalone;
-
-    XSLT_GET_IMPORT_INT(omitXmlDecl, style, omitXmlDeclaration);
-    XSLT_GET_IMPORT_INT(standalone, style, standalone);
-
-    if (omitXmlDecl != 1) {
-        xmlOutputBufferWriteString(buf, "<?xml version=");
-        if (result->version != NULL) {
-        xmlOutputBufferWriteString(buf, "\"");
-        xmlOutputBufferWriteString(buf, (const char *)result->version);
-        xmlOutputBufferWriteString(buf, "\"");
-        } else
-        xmlOutputBufferWriteString(buf, "\"1.0\"");
-        if (encoding == NULL) {
-        if (result->encoding != NULL)
-            encoding = result->encoding;
-        else if (result->charset != XML_CHAR_ENCODING_UTF8)
-            encoding = (const xmlChar *)
-                   xmlGetCharEncodingName((xmlCharEncoding)
-                                          result->charset);
-        }
+        (xmlStrEqual(method, (const xmlChar *) "html"))) {
         if (encoding != NULL) {
-        xmlOutputBufferWriteString(buf, " encoding=");
-        xmlOutputBufferWriteString(buf, "\"");
-        xmlOutputBufferWriteString(buf, (const char *) encoding);
-        xmlOutputBufferWriteString(buf, "\"");
+            htmlSetMetaEncoding(result, (const xmlChar *) encoding);
+        } else {
+            htmlSetMetaEncoding(result, (const xmlChar *) "UTF-8");
         }
-        switch (standalone) {
-        case 0:
-            xmlOutputBufferWriteString(buf, " standalone=\"no\"");
-            break;
-        case 1:
-            xmlOutputBufferWriteString(buf, " standalone=\"yes\"");
-            break;
-        default:
-            break;
+        if (indent == -1)
+            indent = 1;
+        htmlDocContentDumpFormatOutput(buf, result, (const char *) encoding,
+                                       indent);
+        xmlOutputBufferFlush(buf);
+    } else if ((method != NULL) &&
+        (xmlStrEqual(method, (const xmlChar *) "xhtml"))) {
+        if (encoding != NULL) {
+            htmlSetMetaEncoding(result, (const xmlChar *) encoding);
+        } else {
+            htmlSetMetaEncoding(result, (const xmlChar *) "UTF-8");
         }
-        xmlOutputBufferWriteString(buf, "?>\n");
-    }
-    if (result->children != NULL) {
+        htmlDocContentDumpOutput(buf, result, (const char *) encoding);
+        xmlOutputBufferFlush(buf);
+    } else if ((method != NULL) &&
+               (xmlStrEqual(method, (const xmlChar *) "text"))) {
+        xmlNodePtr cur;
+
+        cur = result->children;
+        while (cur != NULL) {
+            if (cur->type == XML_TEXT_NODE)
+                xmlOutputBufferWriteString(buf, (const char *) cur->content);
+
+            /*
+             * Skip to next node
+             */
+            if (cur->children != NULL) {
+                if ((cur->children->type != XML_ENTITY_DECL) &&
+                    (cur->children->type != XML_ENTITY_REF_NODE) &&
+                    (cur->children->type != XML_ENTITY_NODE)) {
+                    cur = cur->children;
+                    continue;
+                }
+            }
+            if (cur->next != NULL) {
+                cur = cur->next;
+                continue;
+            }
+
+            do {
+                cur = cur->parent;
+                if (cur == NULL)
+                    break;
+                if (cur == (xmlNodePtr) style->doc) {
+                    cur = NULL;
+                    break;
+                }
+                if (cur->next != NULL) {
+                    cur = cur->next;
+                    break;
+                }
+            } while (cur != NULL);
+        }
+        xmlOutputBufferFlush(buf);
+    } else {
+        int omitXmlDecl;
+        int standalone;
+
+        XSLT_GET_IMPORT_INT(omitXmlDecl, style, omitXmlDeclaration);
+        XSLT_GET_IMPORT_INT(standalone, style, standalone);
+
+        if (omitXmlDecl != 1) {
+            xmlOutputBufferWriteString(buf, "<?xml version=");
+            if (result->version != NULL) {
+                xmlOutputBufferWriteString(buf, "\"");
+                xmlOutputBufferWriteString(buf, (const char *)result->version);
+                xmlOutputBufferWriteString(buf, "\"");
+            } else
+                xmlOutputBufferWriteString(buf, "\"1.0\"");
+            if (encoding == NULL) {
+                if (result->encoding != NULL)
+                    encoding = result->encoding;
+                else if (result->charset != XML_CHAR_ENCODING_UTF8)
+                    encoding = (const xmlChar *)
+                               xmlGetCharEncodingName((xmlCharEncoding)
+                                                      result->charset);
+            }
+            if (encoding != NULL) {
+                xmlOutputBufferWriteString(buf, " encoding=");
+                xmlOutputBufferWriteString(buf, "\"");
+                xmlOutputBufferWriteString(buf, (const char *) encoding);
+                xmlOutputBufferWriteString(buf, "\"");
+            }
+            switch (standalone) {
+                case 0:
+                    xmlOutputBufferWriteString(buf, " standalone=\"no\"");
+                    break;
+                case 1:
+                    xmlOutputBufferWriteString(buf, " standalone=\"yes\"");
+                    break;
+                default:
+                    break;
+            }
+            xmlOutputBufferWriteString(buf, "?>\n");
+        }
+        if (result->children != NULL) {
             xmlNodePtr children = result->children;
-        xmlNodePtr child = children;
+            xmlNodePtr child = children;
 
             /*
              * Hack to avoid quadratic behavior when scanning
@@ -1588,21 +1625,21 @@ xsltSaveResultTo(xmlOutputBufferPtr buf, xmlDocPtr result,
              */
             result->children = NULL;
 
-        while (child != NULL) {
-        xmlNodeDumpOutput(buf, result, child, 0, (indent == 1),
-                      (const char *) encoding);
-        if (indent && ((child->type == XML_DTD_NODE) ||
-            ((child->type == XML_COMMENT_NODE) &&
-             (child->next != NULL))))
-            xmlOutputBufferWriteString(buf, "\n");
-        child = child->next;
-        }
-        if (indent)
-            xmlOutputBufferWriteString(buf, "\n");
+            while (child != NULL) {
+                xmlNodeDumpOutput(buf, result, child, 0, (indent == 1),
+                                  (const char *) encoding);
+                if (indent && ((child->type == XML_DTD_NODE) ||
+                    ((child->type == XML_COMMENT_NODE) &&
+                     (child->next != NULL))))
+                    xmlOutputBufferWriteString(buf, "\n");
+                child = child->next;
+            }
+            if (indent)
+                        xmlOutputBufferWriteString(buf, "\n");
 
             result->children = children;
-    }
-    xmlOutputBufferFlush(buf);
+        }
+        xmlOutputBufferFlush(buf);
     }
     return(buf->written - base);
 }
@@ -1621,31 +1658,31 @@ xsltSaveResultTo(xmlOutputBufferPtr buf, xmlDocPtr result,
  */
 int
 xsltSaveResultToFilename(const char *URL, xmlDocPtr result,
-             xsltStylesheetPtr style, int compression) {
+                         xsltStylesheetPtr style, int compression) {
     xmlOutputBufferPtr buf;
     const xmlChar *encoding;
     int ret;
 
     if ((URL == NULL) || (result == NULL) || (style == NULL))
-    return(-1);
+        return(-1);
     if (result->children == NULL)
-    return(0);
+        return(0);
 
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
     if (encoding != NULL) {
-    xmlCharEncodingHandlerPtr encoder;
+        xmlCharEncodingHandlerPtr encoder;
 
-    encoder = xmlFindCharEncodingHandler((char *)encoding);
-    if ((encoder != NULL) &&
-        (xmlStrEqual((const xmlChar *)encoder->name,
-             (const xmlChar *) "UTF-8")))
-        encoder = NULL;
-    buf = xmlOutputBufferCreateFilename(URL, encoder, compression);
+        encoder = xmlFindCharEncodingHandler((char *)encoding);
+        if ((encoder != NULL) &&
+            (xmlStrEqual((const xmlChar *)encoder->name,
+                         (const xmlChar *) "UTF-8")))
+            encoder = NULL;
+        buf = xmlOutputBufferCreateFilename(URL, encoder, compression);
     } else {
-    buf = xmlOutputBufferCreateFilename(URL, NULL, compression);
+        buf = xmlOutputBufferCreateFilename(URL, NULL, compression);
     }
     if (buf == NULL)
-    return(-1);
+        return(-1);
     xsltSaveResultTo(buf, result, style);
     ret = xmlOutputBufferClose(buf);
     return(ret);
@@ -1670,26 +1707,26 @@ xsltSaveResultToFile(FILE *file, xmlDocPtr result, xsltStylesheetPtr style) {
     int ret;
 
     if ((file == NULL) || (result == NULL) || (style == NULL))
-    return(-1);
+        return(-1);
     if (result->children == NULL)
-    return(0);
+        return(0);
 
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
     if (encoding != NULL) {
-    xmlCharEncodingHandlerPtr encoder;
+        xmlCharEncodingHandlerPtr encoder;
 
-    encoder = xmlFindCharEncodingHandler((char *)encoding);
-    if ((encoder != NULL) &&
-        (xmlStrEqual((const xmlChar *)encoder->name,
-             (const xmlChar *) "UTF-8")))
-        encoder = NULL;
-    buf = xmlOutputBufferCreateFile(file, encoder);
+        encoder = xmlFindCharEncodingHandler((char *)encoding);
+        if ((encoder != NULL) &&
+            (xmlStrEqual((const xmlChar *)encoder->name,
+                         (const xmlChar *) "UTF-8")))
+            encoder = NULL;
+        buf = xmlOutputBufferCreateFile(file, encoder);
     } else {
-    buf = xmlOutputBufferCreateFile(file, NULL);
+        buf = xmlOutputBufferCreateFile(file, NULL);
     }
 
     if (buf == NULL)
-    return(-1);
+        return(-1);
     xsltSaveResultTo(buf, result, style);
     ret = xmlOutputBufferClose(buf);
     return(ret);
@@ -1714,25 +1751,25 @@ xsltSaveResultToFd(int fd, xmlDocPtr result, xsltStylesheetPtr style) {
     int ret;
 
     if ((fd < 0) || (result == NULL) || (style == NULL))
-    return(-1);
+        return(-1);
     if (result->children == NULL)
-    return(0);
+        return(0);
 
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
     if (encoding != NULL) {
-    xmlCharEncodingHandlerPtr encoder;
+        xmlCharEncodingHandlerPtr encoder;
 
-    encoder = xmlFindCharEncodingHandler((char *)encoding);
-    if ((encoder != NULL) &&
-        (xmlStrEqual((const xmlChar *)encoder->name,
-             (const xmlChar *) "UTF-8")))
-        encoder = NULL;
-    buf = xmlOutputBufferCreateFd(fd, encoder);
+        encoder = xmlFindCharEncodingHandler((char *)encoding);
+        if ((encoder != NULL) &&
+            (xmlStrEqual((const xmlChar *)encoder->name,
+                         (const xmlChar *) "UTF-8")))
+            encoder = NULL;
+        buf = xmlOutputBufferCreateFd(fd, encoder);
     } else {
-    buf = xmlOutputBufferCreateFd(fd, NULL);
+        buf = xmlOutputBufferCreateFd(fd, NULL);
     }
     if (buf == NULL)
-    return(-1);
+        return(-1);
     xsltSaveResultTo(buf, result, style);
     ret = xmlOutputBufferClose(buf);
     return(ret);
@@ -1752,46 +1789,46 @@ xsltSaveResultToFd(int fd, xmlDocPtr result, xsltStylesheetPtr style) {
  */
 int
 xsltSaveResultToString(xmlChar **doc_txt_ptr, int * doc_txt_len,
-               xmlDocPtr result, xsltStylesheetPtr style) {
+                       xmlDocPtr result, xsltStylesheetPtr style) {
     xmlOutputBufferPtr buf;
     const xmlChar *encoding;
 
     *doc_txt_ptr = NULL;
     *doc_txt_len = 0;
     if (result->children == NULL)
-    return(0);
+        return(0);
 
     XSLT_GET_IMPORT_PTR(encoding, style, encoding)
     if (encoding != NULL) {
-    xmlCharEncodingHandlerPtr encoder;
+        xmlCharEncodingHandlerPtr encoder;
 
-    encoder = xmlFindCharEncodingHandler((char *)encoding);
-    if ((encoder != NULL) &&
-        (xmlStrEqual((const xmlChar *)encoder->name,
-             (const xmlChar *) "UTF-8")))
-        encoder = NULL;
-    buf = xmlAllocOutputBuffer(encoder);
+        encoder = xmlFindCharEncodingHandler((char *)encoding);
+        if ((encoder != NULL) &&
+            (xmlStrEqual((const xmlChar *)encoder->name,
+                         (const xmlChar *) "UTF-8")))
+            encoder = NULL;
+        buf = xmlAllocOutputBuffer(encoder);
     } else {
-    buf = xmlAllocOutputBuffer(NULL);
+        buf = xmlAllocOutputBuffer(NULL);
     }
     if (buf == NULL)
-    return(-1);
+        return(-1);
     xsltSaveResultTo(buf, result, style);
 #ifdef LIBXML2_NEW_BUFFER
     if (buf->conv != NULL) {
-    *doc_txt_len = xmlBufUse(buf->conv);
-    *doc_txt_ptr = xmlStrndup(xmlBufContent(buf->conv), *doc_txt_len);
+        *doc_txt_len = xmlBufUse(buf->conv);
+        *doc_txt_ptr = xmlStrndup(xmlBufContent(buf->conv), *doc_txt_len);
     } else {
-    *doc_txt_len = xmlBufUse(buf->buffer);
-    *doc_txt_ptr = xmlStrndup(xmlBufContent(buf->buffer), *doc_txt_len);
+        *doc_txt_len = xmlBufUse(buf->buffer);
+        *doc_txt_ptr = xmlStrndup(xmlBufContent(buf->buffer), *doc_txt_len);
     }
 #else
     if (buf->conv != NULL) {
-    *doc_txt_len = buf->conv->use;
-    *doc_txt_ptr = xmlStrndup(buf->conv->content, *doc_txt_len);
+        *doc_txt_len = buf->conv->use;
+        *doc_txt_ptr = xmlStrndup(buf->conv->content, *doc_txt_len);
     } else {
-    *doc_txt_len = buf->buffer->use;
-    *doc_txt_ptr = xmlStrndup(buf->buffer->content, *doc_txt_len);
+        *doc_txt_len = buf->buffer->use;
+        *doc_txt_ptr = xmlStrndup(buf->buffer->content, *doc_txt_len);
     }
 #endif
     (void)xmlOutputBufferClose(buf);
@@ -1801,9 +1838,9 @@ xsltSaveResultToString(xmlChar **doc_txt_ptr, int * doc_txt_len,
 #ifdef WITH_PROFILER
 
 /************************************************************************
- *                                  *
- *      Generating profiling information            *
- *                                  *
+ *                                                                      *
+ *              Generating profiling information                        *
+ *                                                                      *
  ************************************************************************/
 
 static long calibration = -1;
@@ -1823,7 +1860,7 @@ xsltCalibrateTimestamps(void) {
     register int i;
 
     for (i = 0;i < 999;i++)
-    xsltTimestamp();
+        xsltTimestamp();
     return(xsltTimestamp() / 1000);
 }
 #endif
@@ -1981,82 +2018,82 @@ xsltSaveProfiling(xsltTransformContextPtr ctxt, FILE *output) {
     int *childt;
 
     if ((output == NULL) || (ctxt == NULL))
-    return;
+        return;
     if (ctxt->profile == 0)
-    return;
+        return;
 
     nb = 0;
     max = MAX_TEMPLATES;
     templates = xmlMalloc(max * sizeof(xsltTemplatePtr));
     if (templates == NULL)
-    return;
+        return;
 
     style = ctxt->style;
     while (style != NULL) {
-    templ1 = style->templates;
-    while (templ1 != NULL) {
-        if (nb >= max)
-        break;
+        templ1 = style->templates;
+        while (templ1 != NULL) {
+            if (nb >= max)
+                break;
 
-        if (templ1->nbCalls > 0)
-        templates[nb++] = templ1;
-        templ1 = templ1->next;
-    }
+            if (templ1->nbCalls > 0)
+                templates[nb++] = templ1;
+            templ1 = templ1->next;
+        }
 
-    style = xsltNextImport(style);
+        style = xsltNextImport(style);
     }
 
     for (i = 0;i < nb -1;i++) {
-    for (j = i + 1; j < nb; j++) {
-        if ((templates[i]->time <= templates[j]->time) ||
-        ((templates[i]->time == templates[j]->time) &&
-             (templates[i]->nbCalls <= templates[j]->nbCalls))) {
-        templ1 = templates[j];
-        templates[j] = templates[i];
-        templates[i] = templ1;
+        for (j = i + 1; j < nb; j++) {
+            if ((templates[i]->time <= templates[j]->time) ||
+                ((templates[i]->time == templates[j]->time) &&
+                 (templates[i]->nbCalls <= templates[j]->nbCalls))) {
+                templ1 = templates[j];
+                templates[j] = templates[i];
+                templates[i] = templ1;
+            }
         }
-    }
     }
 
 
     /* print flat profile */
 
     fprintf(output, "%6s%20s%20s%10s  Calls Tot 100us Avg\n\n",
-        "number", "match", "name", "mode");
+            "number", "match", "name", "mode");
     total = 0;
     totalt = 0;
     for (i = 0;i < nb;i++) {
          templ1 = templates[i];
-    fprintf(output, "%5d ", i);
-    if (templ1->match != NULL) {
-        if (xmlStrlen(templ1->match) > 20)
-        fprintf(output, "%s\n%26s", templ1->match, "");
-        else
-        fprintf(output, "%20s", templ1->match);
-    } else {
-        fprintf(output, "%20s", "");
-    }
-    if (templ1->name != NULL) {
-        if (xmlStrlen(templ1->name) > 20)
-        fprintf(output, "%s\n%46s", templ1->name, "");
-        else
-        fprintf(output, "%20s", templ1->name);
-    } else {
-        fprintf(output, "%20s", "");
-    }
-    if (templ1->mode != NULL) {
-        if (xmlStrlen(templ1->mode) > 10)
-        fprintf(output, "%s\n%56s", templ1->mode, "");
-        else
-        fprintf(output, "%10s", templ1->mode);
-    } else {
-        fprintf(output, "%10s", "");
-    }
-    fprintf(output, " %6d", templ1->nbCalls);
-    fprintf(output, " %6ld %6ld\n", templ1->time,
-        templ1->time / templ1->nbCalls);
-    total += templ1->nbCalls;
-    totalt += templ1->time;
+        fprintf(output, "%5d ", i);
+        if (templ1->match != NULL) {
+            if (xmlStrlen(templ1->match) > 20)
+                fprintf(output, "%s\n%26s", templ1->match, "");
+            else
+                fprintf(output, "%20s", templ1->match);
+        } else {
+            fprintf(output, "%20s", "");
+        }
+        if (templ1->name != NULL) {
+            if (xmlStrlen(templ1->name) > 20)
+                fprintf(output, "%s\n%46s", templ1->name, "");
+            else
+                fprintf(output, "%20s", templ1->name);
+        } else {
+            fprintf(output, "%20s", "");
+        }
+        if (templ1->mode != NULL) {
+            if (xmlStrlen(templ1->mode) > 10)
+                fprintf(output, "%s\n%56s", templ1->mode, "");
+            else
+                fprintf(output, "%10s", templ1->mode);
+        } else {
+            fprintf(output, "%10s", "");
+        }
+        fprintf(output, " %6d", templ1->nbCalls);
+        fprintf(output, " %6ld %6ld\n", templ1->time,
+                templ1->time / templ1->nbCalls);
+        total += templ1->nbCalls;
+        totalt += templ1->time;
     }
     fprintf(output, "\n%30s%26s %6d %6ld\n", "Total", "", total, totalt);
 
@@ -2065,7 +2102,7 @@ xsltSaveProfiling(xsltTransformContextPtr ctxt, FILE *output) {
 
     childt = xmlMalloc((nb + 1) * sizeof(int));
     if (childt == NULL)
-    return;
+        return;
 
     /* precalculate children times */
     for (i = 0; i < nb; i++) {
@@ -2163,9 +2200,9 @@ xsltSaveProfiling(xsltTransformContextPtr ctxt, FILE *output) {
 }
 
 /************************************************************************
- *                                  *
- *      Fetching profiling information              *
- *                                  *
+ *                                                                      *
+ *              Fetching profiling information                          *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -2280,9 +2317,9 @@ xsltGetProfileInformation(xsltTransformContextPtr ctxt)
 #endif /* WITH_PROFILER */
 
 /************************************************************************
- *                                  *
- *      Hooks for libxml2 XPath                 *
- *                                  *
+ *                                                                      *
+ *              Hooks for libxml2 XPath                                 *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -2303,13 +2340,13 @@ xsltXPathCompileFlags(xsltStylesheetPtr style, const xmlChar *str, int flags) {
 
     if (style != NULL) {
         xpathCtxt = style->principal->xpathCtxt;
-    if (xpathCtxt == NULL)
-        return NULL;
-    xpathCtxt->dict = style->dict;
+        if (xpathCtxt == NULL)
+            return NULL;
+        xpathCtxt->dict = style->dict;
     } else {
-    xpathCtxt = xmlXPathNewContext(NULL);
-    if (xpathCtxt == NULL)
-        return NULL;
+        xpathCtxt = xmlXPathNewContext(NULL);
+        if (xpathCtxt == NULL)
+            return NULL;
     }
     xpathCtxt->flags = flags;
 
@@ -2319,7 +2356,7 @@ xsltXPathCompileFlags(xsltStylesheetPtr style, const xmlChar *str, int flags) {
     ret = xmlXPathCtxtCompile(xpathCtxt, str);
 
     if (style == NULL) {
-    xmlXPathFreeContext(xpathCtxt);
+        xmlXPathFreeContext(xpathCtxt);
     }
     /*
      * TODO: there is a lot of optimizations which should be possible
@@ -2345,9 +2382,9 @@ xsltXPathCompile(xsltStylesheetPtr style, const xmlChar *str) {
 }
 
 /************************************************************************
- *                                  *
- *      Hooks for the debugger                  *
- *                                  *
+ *                                                                      *
+ *              Hooks for the debugger                                  *
+ *                                                                      *
  ************************************************************************/
 
 int xslDebugStatus;
@@ -2416,7 +2453,7 @@ xsltSetDebuggerCallbacks(int no, void *block)
     xsltDebuggerCallbacksPtr callbacks;
 
     if ((block == NULL) || (no != XSLT_CALLBACK_NUMBER))
-    return(-1);
+        return(-1);
 
     callbacks = (xsltDebuggerCallbacksPtr) block;
     xsltDebuggerCurrentCallbacks.handler = callbacks->handler;
@@ -2438,10 +2475,10 @@ xsltSetDebuggerCallbacks(int no, void *block)
  */
 void
 xslHandleDebugger(xmlNodePtr cur, xmlNodePtr node, xsltTemplatePtr templ,
-              xsltTransformContextPtr ctxt)
+                  xsltTransformContextPtr ctxt)
 {
     if (xsltDebuggerCurrentCallbacks.handler != NULL)
-    xsltDebuggerCurrentCallbacks.handler(cur, node, templ, ctxt);
+        xsltDebuggerCurrentCallbacks.handler(cur, node, templ, ctxt);
 }
 
 /**
@@ -2457,7 +2494,7 @@ int
 xslAddCall(xsltTemplatePtr templ, xmlNodePtr source)
 {
     if (xsltDebuggerCurrentCallbacks.add != NULL)
-    return(xsltDebuggerCurrentCallbacks.add(templ, source));
+        return(xsltDebuggerCurrentCallbacks.add(templ, source));
     return(0);
 }
 
@@ -2470,7 +2507,7 @@ void
 xslDropCall(void)
 {
     if (xsltDebuggerCurrentCallbacks.drop != NULL)
-    xsltDebuggerCurrentCallbacks.drop();
+        xsltDebuggerCurrentCallbacks.drop();
 }
 
 #endif /* WITH_DEBUGGER */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltutils.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/libxslt/xsltutils.h
@@ -31,9 +31,9 @@ extern "C" {
  *
  * Macro to flag unimplemented blocks.
  */
-#define XSLT_TODO                           \
-    xsltGenericError(xsltGenericErrorContext,               \
-        "Unimplemented block at %s:%d\n",               \
+#define XSLT_TODO                                                       \
+    xsltGenericError(xsltGenericErrorContext,                           \
+            "Unimplemented block at %s:%d\n",                           \
             __FILE__, __LINE__);
 
 /**
@@ -41,9 +41,9 @@ extern "C" {
  *
  * Macro to flag that a problem was detected internally.
  */
-#define XSLT_STRANGE                            \
-    xsltGenericError(xsltGenericErrorContext,               \
-        "Internal error at %s:%d\n",                \
+#define XSLT_STRANGE                                                    \
+    xsltGenericError(xsltGenericErrorContext,                           \
+            "Internal error at %s:%d\n",                                \
             __FILE__, __LINE__);
 
 /**
@@ -51,7 +51,7 @@ extern "C" {
  *
  * Checks that the element pertains to XSLT namespace.
  */
-#define IS_XSLT_ELEM(n)                         \
+#define IS_XSLT_ELEM(n)                                                 \
     (((n) != NULL) && ((n)->type == XML_ELEMENT_NODE) &&                \
      ((n)->ns != NULL) && (xmlStrEqual((n)->ns->href, XSLT_NAMESPACE)))
 
@@ -60,7 +60,7 @@ extern "C" {
  *
  * Checks the value of an element in XSLT namespace.
  */
-#define IS_XSLT_NAME(n, val)                        \
+#define IS_XSLT_NAME(n, val)                                            \
     (xmlStrEqual((n)->name, (const xmlChar *) (val)))
 
 /**
@@ -68,56 +68,56 @@ extern "C" {
  *
  * Check that a node is a 'real' one: document, element, text or attribute.
  */
-#define IS_XSLT_REAL_NODE(n)                        \
-    (((n) != NULL) &&                           \
-     (((n)->type == XML_ELEMENT_NODE) ||                \
-      ((n)->type == XML_TEXT_NODE) ||                   \
-      ((n)->type == XML_CDATA_SECTION_NODE) ||              \
-      ((n)->type == XML_ATTRIBUTE_NODE) ||              \
-      ((n)->type == XML_DOCUMENT_NODE) ||               \
-      ((n)->type == XML_HTML_DOCUMENT_NODE) ||              \
-      ((n)->type == XML_COMMENT_NODE) ||                \
+#define IS_XSLT_REAL_NODE(n)                                            \
+    (((n) != NULL) &&                                                   \
+     (((n)->type == XML_ELEMENT_NODE) ||                                \
+      ((n)->type == XML_TEXT_NODE) ||                                   \
+      ((n)->type == XML_CDATA_SECTION_NODE) ||                          \
+      ((n)->type == XML_ATTRIBUTE_NODE) ||                              \
+      ((n)->type == XML_DOCUMENT_NODE) ||                               \
+      ((n)->type == XML_HTML_DOCUMENT_NODE) ||                          \
+      ((n)->type == XML_COMMENT_NODE) ||                                \
       ((n)->type == XML_PI_NODE)))
 
 /*
  * Our own version of namespaced attributes lookup.
  */
 XSLTPUBFUN xmlChar * XSLTCALL
-        xsltGetNsProp   (xmlNodePtr node,
-                 const xmlChar *name,
-                 const xmlChar *nameSpace);
+                xsltGetNsProp   (xmlNodePtr node,
+                                 const xmlChar *name,
+                                 const xmlChar *nameSpace);
 XSLTPUBFUN const xmlChar * XSLTCALL
-        xsltGetCNsProp  (xsltStylesheetPtr style,
-                 xmlNodePtr node,
-                 const xmlChar *name,
-                 const xmlChar *nameSpace);
+                xsltGetCNsProp  (xsltStylesheetPtr style,
+                                 xmlNodePtr node,
+                                 const xmlChar *name,
+                                 const xmlChar *nameSpace);
 XSLTPUBFUN int XSLTCALL
-        xsltGetUTF8Char (const unsigned char *utf,
-                 int *len);
+                xsltGetUTF8Char (const unsigned char *utf,
+                                 int *len);
 
 /*
  * XSLT Debug Tracing Tracing Types
  */
 typedef enum {
-    XSLT_TRACE_ALL =        -1,
-    XSLT_TRACE_NONE =       0,
-    XSLT_TRACE_COPY_TEXT =      1<<0,
-    XSLT_TRACE_PROCESS_NODE =   1<<1,
-    XSLT_TRACE_APPLY_TEMPLATE = 1<<2,
-    XSLT_TRACE_COPY =       1<<3,
-    XSLT_TRACE_COMMENT =        1<<4,
-    XSLT_TRACE_PI =         1<<5,
-    XSLT_TRACE_COPY_OF =        1<<6,
-    XSLT_TRACE_VALUE_OF =       1<<7,
-    XSLT_TRACE_CALL_TEMPLATE =  1<<8,
-    XSLT_TRACE_APPLY_TEMPLATES =    1<<9,
-    XSLT_TRACE_CHOOSE =     1<<10,
-    XSLT_TRACE_IF =         1<<11,
-    XSLT_TRACE_FOR_EACH =       1<<12,
-    XSLT_TRACE_STRIP_SPACES =   1<<13,
-    XSLT_TRACE_TEMPLATES =      1<<14,
-    XSLT_TRACE_KEYS =       1<<15,
-    XSLT_TRACE_VARIABLES =      1<<16
+        XSLT_TRACE_ALL =                -1,
+        XSLT_TRACE_NONE =               0,
+        XSLT_TRACE_COPY_TEXT =          1<<0,
+        XSLT_TRACE_PROCESS_NODE =       1<<1,
+        XSLT_TRACE_APPLY_TEMPLATE =     1<<2,
+        XSLT_TRACE_COPY =               1<<3,
+        XSLT_TRACE_COMMENT =            1<<4,
+        XSLT_TRACE_PI =                 1<<5,
+        XSLT_TRACE_COPY_OF =            1<<6,
+        XSLT_TRACE_VALUE_OF =           1<<7,
+        XSLT_TRACE_CALL_TEMPLATE =      1<<8,
+        XSLT_TRACE_APPLY_TEMPLATES =    1<<9,
+        XSLT_TRACE_CHOOSE =             1<<10,
+        XSLT_TRACE_IF =                 1<<11,
+        XSLT_TRACE_FOR_EACH =           1<<12,
+        XSLT_TRACE_STRIP_SPACES =       1<<13,
+        XSLT_TRACE_TEMPLATES =          1<<14,
+        XSLT_TRACE_KEYS =               1<<15,
+        XSLT_TRACE_VARIABLES =          1<<16
 } xsltDebugTraceCodes;
 
 /**
@@ -125,14 +125,14 @@ typedef enum {
  *
  * Control the type of xsl debugtrace messages emitted.
  */
-#define XSLT_TRACE(ctxt,code,call)  \
-    if (ctxt->traceCode && (*(ctxt->traceCode) & code)) \
-        call
+#define XSLT_TRACE(ctxt,code,call)      \
+        if (ctxt->traceCode && (*(ctxt->traceCode) & code)) \
+            call
 
 XSLTPUBFUN void XSLTCALL
-        xsltDebugSetDefaultTrace(xsltDebugTraceCodes val);
+                xsltDebugSetDefaultTrace(xsltDebugTraceCodes val);
 XSLTPUBFUN xsltDebugTraceCodes XSLTCALL
-        xsltDebugGetDefaultTrace(void);
+                xsltDebugGetDefaultTrace(void);
 
 /*
  * XSLT specific error and debug reporting functions.
@@ -143,95 +143,95 @@ XSLTPUBVAR xmlGenericErrorFunc xsltGenericDebug;
 XSLTPUBVAR void *xsltGenericDebugContext;
 
 XSLTPUBFUN void XSLTCALL
-        xsltPrintErrorContext       (xsltTransformContextPtr ctxt,
-                                             xsltStylesheetPtr style,
-                         xmlNodePtr node);
+                xsltPrintErrorContext           (xsltTransformContextPtr ctxt,
+                                                 xsltStylesheetPtr style,
+                                                 xmlNodePtr node);
 XSLTPUBFUN void XSLTCALL
-        xsltMessage         (xsltTransformContextPtr ctxt,
-                         xmlNodePtr node,
-                         xmlNodePtr inst);
+                xsltMessage                     (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr node,
+                                                 xmlNodePtr inst);
 XSLTPUBFUN void XSLTCALL
-        xsltSetGenericErrorFunc     (void *ctx,
-                         xmlGenericErrorFunc handler);
+                xsltSetGenericErrorFunc         (void *ctx,
+                                                 xmlGenericErrorFunc handler);
 XSLTPUBFUN void XSLTCALL
-        xsltSetGenericDebugFunc     (void *ctx,
-                         xmlGenericErrorFunc handler);
+                xsltSetGenericDebugFunc         (void *ctx,
+                                                 xmlGenericErrorFunc handler);
 XSLTPUBFUN void XSLTCALL
-        xsltSetTransformErrorFunc   (xsltTransformContextPtr ctxt,
-                         void *ctx,
-                         xmlGenericErrorFunc handler);
+                xsltSetTransformErrorFunc       (xsltTransformContextPtr ctxt,
+                                                 void *ctx,
+                                                 xmlGenericErrorFunc handler);
 XSLTPUBFUN void XSLTCALL
-        xsltTransformError      (xsltTransformContextPtr ctxt,
-                         xsltStylesheetPtr style,
-                         xmlNodePtr node,
-                         const char *msg,
-                         ...) LIBXSLT_ATTR_FORMAT(4,5);
+                xsltTransformError              (xsltTransformContextPtr ctxt,
+                                                 xsltStylesheetPtr style,
+                                                 xmlNodePtr node,
+                                                 const char *msg,
+                                                 ...) LIBXSLT_ATTR_FORMAT(4,5);
 
 XSLTPUBFUN int XSLTCALL
-        xsltSetCtxtParseOptions     (xsltTransformContextPtr ctxt,
-                         int options);
+                xsltSetCtxtParseOptions         (xsltTransformContextPtr ctxt,
+                                                 int options);
 /*
  * Sorting.
  */
 
 XSLTPUBFUN void XSLTCALL
-        xsltDocumentSortFunction    (xmlNodeSetPtr list);
+                xsltDocumentSortFunction        (xmlNodeSetPtr list);
 XSLTPUBFUN void XSLTCALL
-        xsltSetSortFunc         (xsltSortFunc handler);
+                xsltSetSortFunc                 (xsltSortFunc handler);
 XSLTPUBFUN void XSLTCALL
-        xsltSetCtxtSortFunc     (xsltTransformContextPtr ctxt,
-                         xsltSortFunc handler);
+                xsltSetCtxtSortFunc             (xsltTransformContextPtr ctxt,
+                                                 xsltSortFunc handler);
 XSLTPUBFUN void XSLTCALL
-        xsltDefaultSortFunction     (xsltTransformContextPtr ctxt,
-                         xmlNodePtr *sorts,
-                         int nbsorts);
+                xsltDefaultSortFunction         (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr *sorts,
+                                                 int nbsorts);
 XSLTPUBFUN void XSLTCALL
-        xsltDoSortFunction      (xsltTransformContextPtr ctxt,
-                         xmlNodePtr * sorts,
-                         int nbsorts);
+                xsltDoSortFunction              (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr * sorts,
+                                                 int nbsorts);
 XSLTPUBFUN xmlXPathObjectPtr * XSLTCALL
-        xsltComputeSortResult       (xsltTransformContextPtr ctxt,
-                         xmlNodePtr sort);
+                xsltComputeSortResult           (xsltTransformContextPtr ctxt,
+                                                 xmlNodePtr sort);
 
 /*
  * QNames handling.
  */
 
 XSLTPUBFUN const xmlChar * XSLTCALL
-        xsltSplitQName          (xmlDictPtr dict,
-                         const xmlChar *name,
-                         const xmlChar **prefix);
+                xsltSplitQName                  (xmlDictPtr dict,
+                                                 const xmlChar *name,
+                                                 const xmlChar **prefix);
 XSLTPUBFUN const xmlChar * XSLTCALL
-        xsltGetQNameURI         (xmlNodePtr node,
-                         xmlChar **name);
+                xsltGetQNameURI                 (xmlNodePtr node,
+                                                 xmlChar **name);
 
 XSLTPUBFUN const xmlChar * XSLTCALL
-        xsltGetQNameURI2        (xsltStylesheetPtr style,
-                         xmlNodePtr node,
-                         const xmlChar **name);
+                xsltGetQNameURI2                (xsltStylesheetPtr style,
+                                                 xmlNodePtr node,
+                                                 const xmlChar **name);
 
 /*
  * Output, reuse libxml I/O buffers.
  */
 XSLTPUBFUN int XSLTCALL
-        xsltSaveResultTo        (xmlOutputBufferPtr buf,
-                         xmlDocPtr result,
-                         xsltStylesheetPtr style);
+                xsltSaveResultTo                (xmlOutputBufferPtr buf,
+                                                 xmlDocPtr result,
+                                                 xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-        xsltSaveResultToFilename    (const char *URI,
-                         xmlDocPtr result,
-                         xsltStylesheetPtr style,
-                         int compression);
+                xsltSaveResultToFilename        (const char *URI,
+                                                 xmlDocPtr result,
+                                                 xsltStylesheetPtr style,
+                                                 int compression);
 XSLTPUBFUN int XSLTCALL
-        xsltSaveResultToFile        (FILE *file,
-                         xmlDocPtr result,
-                         xsltStylesheetPtr style);
+                xsltSaveResultToFile            (FILE *file,
+                                                 xmlDocPtr result,
+                                                 xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-        xsltSaveResultToFd      (int fd,
-                         xmlDocPtr result,
-                         xsltStylesheetPtr style);
+                xsltSaveResultToFd              (int fd,
+                                                 xmlDocPtr result,
+                                                 xsltStylesheetPtr style);
 XSLTPUBFUN int XSLTCALL
-        xsltSaveResultToString          (xmlChar **doc_txt_ptr,
+                xsltSaveResultToString          (xmlChar **doc_txt_ptr,
                                                  int * doc_txt_len,
                                                  xmlDocPtr result,
                                                  xsltStylesheetPtr style);
@@ -240,26 +240,26 @@ XSLTPUBFUN int XSLTCALL
  * XPath interface
  */
 XSLTPUBFUN xmlXPathCompExprPtr XSLTCALL
-        xsltXPathCompile        (xsltStylesheetPtr style,
-                         const xmlChar *str);
+                xsltXPathCompile                (xsltStylesheetPtr style,
+                                                 const xmlChar *str);
 XSLTPUBFUN xmlXPathCompExprPtr XSLTCALL
-        xsltXPathCompileFlags       (xsltStylesheetPtr style,
-                         const xmlChar *str,
-                         int flags);
+                xsltXPathCompileFlags           (xsltStylesheetPtr style,
+                                                 const xmlChar *str,
+                                                 int flags);
 
 /*
  * Profiling.
  */
 XSLTPUBFUN void XSLTCALL
-        xsltSaveProfiling       (xsltTransformContextPtr ctxt,
-                         FILE *output);
+                xsltSaveProfiling               (xsltTransformContextPtr ctxt,
+                                                 FILE *output);
 XSLTPUBFUN xmlDocPtr XSLTCALL
-        xsltGetProfileInformation   (xsltTransformContextPtr ctxt);
+                xsltGetProfileInformation       (xsltTransformContextPtr ctxt);
 
 XSLTPUBFUN long XSLTCALL
-        xsltTimestamp           (void);
+                xsltTimestamp                   (void);
 XSLTPUBFUN void XSLTCALL
-        xsltCalibrateAdjust     (long delta);
+                xsltCalibrateAdjust             (long delta);
 
 /**
  * XSLT_TIMESTAMP_TICS_PER_SEC:
@@ -288,21 +288,21 @@ typedef enum {
 XSLTPUBVAR int xslDebugStatus;
 
 typedef void (*xsltHandleDebuggerCallback) (xmlNodePtr cur, xmlNodePtr node,
-            xsltTemplatePtr templ, xsltTransformContextPtr ctxt);
+                        xsltTemplatePtr templ, xsltTransformContextPtr ctxt);
 typedef int (*xsltAddCallCallback) (xsltTemplatePtr templ, xmlNodePtr source);
 typedef void (*xsltDropCallCallback) (void);
 
 XSLTPUBFUN void XSLTCALL
-        xsltSetDebuggerStatus       (int value);
+                xsltSetDebuggerStatus           (int value);
 XSLTPUBFUN int XSLTCALL
-        xsltGetDebuggerStatus       (void);
+                xsltGetDebuggerStatus           (void);
 XSLTPUBFUN int XSLTCALL
-        xsltSetDebuggerCallbacks    (int no, void *block);
+                xsltSetDebuggerCallbacks        (int no, void *block);
 XSLTPUBFUN int XSLTCALL
-        xslAddCall          (xsltTemplatePtr templ,
-                         xmlNodePtr source);
+                xslAddCall                      (xsltTemplatePtr templ,
+                                                 xmlNodePtr source);
 XSLTPUBFUN void XSLTCALL
-        xslDropCall         (void);
+                xslDropCall                     (void);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/win32/Makefile.msvc
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/win32/Makefile.msvc
@@ -73,6 +73,11 @@ LDFLAGS = $(LDFLAGS) /DEBUG
 CFLAGS = $(CFLAGS) /D "NDEBUG" /O2 
 !endif
 
+# append CFLAGS etc. passed on command line
+CPPFLAGS = $(CPPFLAGS) $(EXTRA_CPPFLAGS)
+CFLAGS = $(CFLAGS) $(EXTRA_CFLAGS)
+LDFLAGS = $(LDFLAGS) $(EXTRA_LDFLAGS)
+
 # Libxslt object files.
 XSLT_OBJS = $(XSLT_INTDIR)\attributes.obj\
 	$(XSLT_INTDIR)\documents.obj\

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/win32/configure.js
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxslt/src/win32/configure.js
@@ -47,6 +47,7 @@ var withIconv = true;
 var withZlib = false;
 var withCrypto = true;
 var withModules = false;
+var withProfiler = true;
 /* Win32 build options. */
 var dirSep = "\\";
 var compiler = "msvc";
@@ -106,6 +107,7 @@ function usage()
 	txt += "  zlib:       Use zlib library (" + (withZlib? "yes" : "no") + ")\n";
 	txt += "  crypto:     Enable Crypto support (" + (withCrypto? "yes" : "no") + ")\n";
 	txt += "  modules:    Enable Module support (" + (withModules? "yes" : "no") + ")\n";
+	txt += "  profiler:   Enable Profiler support (" + (withProfiler? "yes" : "no") + ")\n";
 	txt += "\nWin32 build options, default value given in parentheses:\n\n";
 	txt += "  compiler:   Compiler to be used [msvc|mingw] (" + compiler + ")\n";
 	txt += "  cruntime:   C-runtime compiler option (only msvc) (" + cruntime + ")\n";
@@ -134,7 +136,7 @@ function usage()
    file included by our makefile. */
 function discoverVersion()
 {
-	var fso, cf, vf, ln, s;
+	var fso, cf, vf, ln, s, m;
 	fso = new ActiveXObject("Scripting.FileSystemObject");
 	verCvs = "";
 	if (useCvsVer && fso.FileExists("..\\CVS\\Entries")) {
@@ -143,8 +145,8 @@ function discoverVersion()
 			ln = cf.ReadLine();
 			s = new String(ln);
 			if (s.search(/^\/ChangeLog\//) != -1) {
-				iDot = s.indexOf(".");
-				iSlash = s.indexOf("/", iDot);
+				var iDot = s.indexOf(".");
+				var iSlash = s.indexOf("/", iDot);
 				verCvs = "CVS" + s.substring(iDot + 1, iSlash);
 				break;
 			}
@@ -174,13 +176,13 @@ function discoverVersion()
 			verMicroXslt = m[1];
 		} else if (s.search(/^LIBEXSLT_MAJOR_VERSION=/) != -1) {
 			vf.WriteLine(s);
-			verMajorExslt = s.substring(s.indexOf("=") + 1, s.length)
+			verMajorExslt = s.substring(s.indexOf("=") + 1, s.length);
 		} else if(s.search(/^LIBEXSLT_MINOR_VERSION=/) != -1) {
 			vf.WriteLine(s);
-			verMinorExslt = s.substring(s.indexOf("=") + 1, s.length)
+			verMinorExslt = s.substring(s.indexOf("=") + 1, s.length);
 		} else if(s.search(/^LIBEXSLT_MICRO_VERSION=/) != -1) {
 			vf.WriteLine(s);
-			verMicroExslt = s.substring(s.indexOf("=") + 1, s.length)
+			verMicroExslt = s.substring(s.indexOf("=") + 1, s.length);
 		}
 	}
 	cf.Close();
@@ -192,6 +194,7 @@ function discoverVersion()
 	vf.WriteLine("WITH_ZLIB=" + (withZlib? "1" : "0"));
 	vf.WriteLine("WITH_CRYPTO=" + (withCrypto? "1" : "0"));
 	vf.WriteLine("WITH_MODULES=" + (withModules? "1" : "0"));
+	vf.WriteLine("WITH_PROFILER=" + (withProfiler? "1" : "0"));
 	vf.WriteLine("DEBUG=" + (buildDebug? "1" : "0"));
 	vf.WriteLine("STATIC=" + (buildStatic? "1" : "0"));
 	vf.WriteLine("PREFIX=" + buildPrefix);
@@ -240,6 +243,8 @@ function configureXslt()
 			of.WriteLine(s.replace(/\@WITH_DEBUGGER\@/, withDebugger? "1" : "0"));
 		} else if (s.search(/\@WITH_MODULES\@/) != -1) {
 			of.WriteLine(s.replace(/\@WITH_MODULES\@/, withModules? "1" : "0"));
+		} else if (s.search(/\@WITH_PROFILER\@/) != -1) {
+			of.WriteLine(s.replace(/\@WITH_PROFILER\@/, withProfiler? "1" : "0"));
 		} else if (s.search(/\@LIBXSLT_DEFAULT_PLUGINS_PATH\@/) != -1) {
 			of.WriteLine(s.replace(/\@LIBXSLT_DEFAULT_PLUGINS_PATH\@/, "NULL"));
 		} else
@@ -343,6 +348,8 @@ for (i = 0; (i < WScript.Arguments.length) && (error == 0); i++) {
 			withCrypto = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "modules")
 			withModules = strToBool(arg.substring(opt.length + 1, arg.length));
+		else if (opt == "profiler")
+			withProfiler = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "compiler")
 			compiler = arg.substring(opt.length + 1, arg.length);
  		else if (opt == "cruntime")
@@ -353,8 +360,6 @@ for (i = 0; (i < WScript.Arguments.length) && (error == 0); i++) {
 			buildStatic = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "prefix")
 			buildPrefix = arg.substring(opt.length + 1, arg.length);
-		else if (opt == "incdir")
-			buildIncPrefix = arg.substring(opt.length + 1, arg.length);
 		else if (opt == "bindir")
 			buildBinPrefix = arg.substring(opt.length + 1, arg.length);
 		else if (opt == "libdir")
@@ -477,13 +482,14 @@ txtOut += "         Use iconv: " + boolToStr(withIconv) + "\n";
 txtOut += "         With zlib: " + boolToStr(withZlib) + "\n";
 txtOut += "            Crypto: " + boolToStr(withCrypto) + "\n";
 txtOut += "           Modules: " + boolToStr(withModules) + "\n";
+txtOut += "          Profiler: " + boolToStr(withProfiler) + "\n";
 txtOut += "\n";
 txtOut += "Win32 build configuration\n";
 txtOut += "-------------------------\n";
 txtOut += "          Compiler: " + compiler + "\n";
 if (compiler == "msvc")
 	txtOut += "  C-Runtime option: " + cruntime + "\n";
-	txtOut += "    Embed Manifest: " + boolToStr(vcmanifest) + "\n";
+txtOut += "    Embed Manifest: " + boolToStr(vcmanifest) + "\n";
 txtOut += "     Debug symbols: " + boolToStr(buildDebug) + "\n";
 txtOut += "   Static xsltproc: " + boolToStr(buildStatic) + "\n";
 txtOut += "    Install prefix: " + buildPrefix + "\n";


### PR DESCRIPTION
Clean backport to `jfx11u`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8286256](https://bugs.openjdk.java.net/browse/JDK-8286256): Update libxml2 to 2.9.14
 * [JDK-8286257](https://bugs.openjdk.java.net/browse/JDK-8286257): Update libxslt to 1.1.35


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx11u pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/jfx11u pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx11u/pull/101.diff">https://git.openjdk.java.net/jfx11u/pull/101.diff</a>

</details>
