### PR TITLE
8283786: Update to Visual Studio 2022 version 17.1.0 on Windows

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=6.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.3.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2019-16.9.3+1.0
+jfx.build.windows.msvc.version=VS2022-17.1.0+1.0
 jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools


### PR DESCRIPTION
Not a clean backport.
Following two files are not present in jfx11.

1. .github/workflows/submit.yml
2. gradle/verification-metadata.xml

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283786](https://bugs.openjdk.org/browse/JDK-8283786): Update to Visual Studio 2022 version 17.1.0 on Windows


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx11u pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jfx11u pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx11u/pull/104.diff">https://git.openjdk.org/jfx11u/pull/104.diff</a>

</details>
