### PR TITLE
8283402: Update to gcc 11.2 on Linux

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -88,7 +88,7 @@ jfx.gradle.version=7.3
 jfx.gradle.version.min=6.3
 
 # Toolchains
-jfx.build.linux.gcc.version=gcc10.3.0-OL6.4+1.0
+jfx.build.linux.gcc.version=gcc11.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2022-17.1.0+1.0
 jfx.build.macosx.xcode.version=Xcode12.4+1.0
 


### PR DESCRIPTION
Not a clean backport. The one line change to `build.properties` applied cleanly. The other two files, `gradle/verification.metadata` and the GitHub actions script, don't exist in jfx11u.

CI build run on Linux.
