### PR TITLE
8291087: Wrong position of focus of screen reader on Windows with screen scale > 1

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -40,7 +40,11 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyCombination;
 import com.sun.glass.ui.Accessible;
+import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
+import com.sun.javafx.stage.WindowHelper;
+import com.sun.javafx.tk.TKStage;
+import com.sun.javafx.tk.quantum.WindowStage;
 import static javafx.scene.AccessibleAttribute.*;
 
 /*
@@ -877,6 +881,27 @@ final class WinAccessible extends Accessible {
         return variant;
     }
 
+    private Screen getScreen() {
+        Scene scene = (Scene) getAttribute(SCENE);
+        if (scene == null || scene.getWindow() == null) return null;
+        TKStage tkStage = WindowHelper.getPeer(scene.getWindow());
+        if (!(tkStage instanceof WindowStage)) return null;
+        WindowStage windowStage = (WindowStage) tkStage;
+        if (windowStage.getPlatformWindow() == null) return null;
+        return windowStage.getPlatformWindow().getScreen();
+    }
+
+    float[] getPlatformBounds(float x, float y, float w, float h) {
+        float[] platformBounds = new float[] { x, y, w, h };
+        Screen screen = getScreen();
+        if (screen == null) return platformBounds;
+        platformBounds[0] = screen.toPlatformX(x);
+        platformBounds[1] = screen.toPlatformY(y);
+        platformBounds[2] = (float) Math.ceil(w * screen.getPlatformScaleX());
+        platformBounds[3] = (float) Math.ceil(h * screen.getPlatformScaleY());
+        return platformBounds;
+    }
+
     /***********************************************/
     /*       IRawElementProviderFragment           */
     /***********************************************/
@@ -887,8 +912,10 @@ final class WinAccessible extends Accessible {
 
         Bounds bounds = (Bounds)getAttribute(BOUNDS);
         if (bounds != null) {
-            return new float[] {(float)bounds.getMinX(), (float)bounds.getMinY(),
-                                (float)bounds.getWidth(), (float)bounds.getHeight()};
+            return getPlatformBounds((float) bounds.getMinX(),
+                                     (float) bounds.getMinY(),
+                                     (float) bounds.getWidth(),
+                                     (float) bounds.getHeight());
         }
         return null;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -326,10 +326,16 @@ class WinTextRangeProvider {
             int index = 0;
             for (int i = 0; i < bounds.length; i++) {
                 Bounds b = bounds[i];
-                result[index++] = b.getMinX();
-                result[index++] = b.getMinY();
-                result[index++] = b.getWidth();
-                result[index++] = b.getHeight();
+                float[] platformBounds = accessible.getPlatformBounds(
+                        (float) b.getMinX(),
+                        (float) b.getMinY(),
+                        (float) b.getWidth(),
+                        (float) b.getHeight());
+
+                result[index++] = platformBounds[0];
+                result[index++] = platformBounds[1];
+                result[index++] = platformBounds[2];
+                result[index++] = platformBounds[3];
             }
             return result;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -55,7 +55,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import static com.sun.javafx.FXPermissions.*;
 
-class WindowStage extends GlassStage {
+public class WindowStage extends GlassStage {
 
     protected Window platformWindow;
 
@@ -236,7 +236,7 @@ class WindowStage extends GlassStage {
         }
     }
 
-    final Window getPlatformWindow() {
+    public final Window getPlatformWindow() {
         return platformWindow;
     }
 


### PR DESCRIPTION
Clean backport. CI build run on all three platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291087](https://bugs.openjdk.org/browse/JDK-8291087): Wrong position of focus of screen reader on Windows with screen scale > 1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx11u pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jfx11u pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx11u/pull/121.diff">https://git.openjdk.org/jfx11u/pull/121.diff</a>

</details>
