### PR TITLE
8089986: Menu beeps when mnemonics is used

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -538,6 +538,9 @@ LRESULT GlassWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_CAPTURECHANGED:
             ViewContainer::NotifyCaptureChanged(GetHWND(), (HWND)lParam);
             break;
+        case WM_MENUCHAR:
+            // Stop the beep when missing mnemonic or accelerator key JDK-8089986
+            return MNC_CLOSE << 16;
         case WM_SYSKEYDOWN:
         case WM_SYSKEYUP:
         case WM_KEYDOWN:


### PR DESCRIPTION
Almost clean backport, with a difference in copyright year. Otherwise clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8089986](https://bugs.openjdk.org/browse/JDK-8089986): Menu beeps when mnemonics is used


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx11u pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jfx11u pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx11u/pull/127.diff">https://git.openjdk.org/jfx11u/pull/127.diff</a>

</details>
