### PR TITLE
8298167: Opacity in WebView not working anymore

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.cpp
@@ -610,8 +610,10 @@ bool GraphicsContextJava::supportsTransparencyLayers() const
     return true;
 }
 
-void GraphicsContextJava::beginPlatformTransparencyLayer(float opacity)
+void GraphicsContextJava::beginTransparencyLayer(float opacity)
 {
+    GraphicsContext::beginTransparencyLayer(opacity);
+
     if (paintingDisabled())
       return;
 
@@ -620,13 +622,15 @@ void GraphicsContextJava::beginPlatformTransparencyLayer(float opacity)
     << opacity;
 }
 
-void GraphicsContextJava::endPlatformTransparencyLayer()
+void GraphicsContextJava::endTransparencyLayer()
 {
     if (paintingDisabled())
       return;
 
     platformContext()->rq().freeSpace(4)
     << (jint)com_sun_webkit_graphics_GraphicsDecoder_ENDTRANSPARENCYLAYER;
+
+    GraphicsContext::endTransparencyLayer();
 }
 
 void GraphicsContextJava::clearRect(const FloatRect& rect)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/GraphicsContextJava.h
@@ -118,8 +118,8 @@ public:
     FloatRect roundToDevicePixels(const FloatRect& frect, RoundingMode) override;
 
     bool supportsTransparencyLayers() const override;
-    void beginPlatformTransparencyLayer(float opacity);
-    void endPlatformTransparencyLayer();
+    void beginTransparencyLayer(float opacity) override;
+    void endTransparencyLayer() override;
 
     void translate(float x, float y) override;
     void rotate(float radians) override;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/OpacityTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/OpacityTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import javafx.scene.web.WebEngineShim;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class OpacityTest extends TestBase {
+    /**
+     * @test
+     * @bug 8298167
+     * summary
+     * Loads black-background areas with different opacity values: 1.0, 0.5, and 0.0.
+     * Checks if the areas are rendered with black, gray, and white colors accordigly.
+     * Colors are taken from the center of each area.
+     */
+    @Test public void testOpacity() {
+        loadContent("<html>\n" +
+                    "<body style='margin: 0px;'>\n" +
+                    "<p style='opacity: 1.0; height: 100px; margin: 0px; background-color:#000; color: #fff;'>text</p>\n" +
+                    "<p style='opacity: 0.5; height: 100px; margin: 0px; background-color:#000; color: #fff;'>text</p>\n" +
+                    "<p style='opacity: 0.0; height: 100px; margin: 0px; background-color:#000; color: #fff;'>text</p>\n" +
+                    "</body>\n" +
+                    "</html>");
+        submit(() -> {
+                final WebPage webPage = WebEngineShim.getPage(getEngine());
+                assertNotNull(webPage);
+                final BufferedImage img = WebPageShim.paint(webPage, 0, 0, 800, 600);
+                assertNotNull(img);
+
+                final Color pixelAt400x50 = new Color(img.getRGB(400, 50), true);
+                assertTrue("Color should be black:" + pixelAt400x50, isColorsSimilar(Color.BLACK, pixelAt400x50, 1));
+                final Color pixelAt400x150 = new Color(img.getRGB(400, 150), true);
+                assertTrue("Color should be gray:" + pixelAt400x150, isColorsSimilar(Color.GRAY, pixelAt400x150, 1));
+                final Color pixelAt400x250 = new Color(img.getRGB(400, 250), true);
+                assertTrue("Color should be white:" + pixelAt400x250, isColorsSimilar(Color.WHITE, pixelAt400x250, 1));
+        });
+    }
+}


### PR DESCRIPTION
Clean backport. Tested in connection with 4 other WebKit fixes in the `test-kcr-11.0.19` branch, including a successful CI build. I also verfied that the native WebKit code is identical to mainline jfx after applying all patches (excluding a couple of copyright years).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298167](https://bugs.openjdk.org/browse/JDK-8298167): Opacity in WebView not working anymore


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx11u pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/jfx11u pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx11u/pull/131.diff">https://git.openjdk.org/jfx11u/pull/131.diff</a>

</details>
