### PR TITLE
8302470: Change JBS version in .jcheck/conf to jfxNN[.0.MM]

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx11.0.19
+version=jfx11.0.19
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -11,7 +11,7 @@ Here are the steps to increment the JavaFX release version number to a new
 feature version (for example, from 13 to 14).
 
 * In `.jcheck/conf`, modify the `version` property in the `[general]`
-section to increment the version number from `openjfx$N` to `openjfx$N+1`.
+section to increment the JBS version number from `jfx$N` to `jfx$N+1`.
 
 * In `build.properties`, modify the following properties to increment the
 feature version number from `N` to `N+1`:
@@ -33,8 +33,8 @@ Here are the steps to increment the JavaFX release version number to a new
 security version (for example, from 13 to 13.0.1).
 
 * In `.jcheck/conf`, modify the `version` property in the `[general]`
-section to increment the version number from `openjfx$N` to `openjfx$N.0.1`
-or from `openjfx$N.0.M` to `openjfx$N.0.$M+1`.
+section to increment the JBS version number from `jfx$N` to `jfx$N.0.1`
+or from `jfx$N.0.M` to `jfx$N.0.$M+1`.
 
 * In `build.properties`, modify the `jfx.release.security.version` property
 to increment the security version number from `M` to `M+1`.


### PR DESCRIPTION
In support of the JBS version change from "openjfxNN[.0.MM]" to "jfxNN[.0.MM]", we need to update the JBS version in .jcheck/conf in each active code line.

The planned cut-over date is Tuesday, Feb 28. I will integrate this PR immediately after the JBS version renaming is done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302470](https://bugs.openjdk.org/browse/JDK-8302470): Change JBS version in .jcheck/conf to jfxNN[.0.MM]


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx11u pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jfx11u pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx11u/pull/134.diff">https://git.openjdk.org/jfx11u/pull/134.diff</a>

</details>
